### PR TITLE
Add VM usage guide and Orange Pi 5 Plus installation manual

### DIFF
--- a/docs/OPI5PLUS_INSTALL.md
+++ b/docs/OPI5PLUS_INSTALL.md
@@ -1,0 +1,754 @@
+# BCM v7 — Orange Pi 5 Plus Installation Manual
+
+Complete guide to deploying the BCM v7 headunit system on Orange Pi 5 Plus (RK3588) for the Alfa Romeo 156.
+
+---
+
+## 1. Hardware Requirements
+
+### SBC
+
+| Item | Specification |
+|------|---------------|
+| **Board** | Orange Pi 5 Plus |
+| **SoC** | RK3588 (4× A76 + 4× A55) |
+| **RAM** | 16 GB recommended (8 GB minimum) |
+| **Storage** | 64 GB eMMC + 128 GB microSD (dashcam) |
+| **Power** | 5.1V / 4A via USB-C |
+
+### Peripherals
+
+| Item | Model / Spec | Connection |
+|------|-------------|------------|
+| Display 1 (dashboard) | 4.3" TFT 800x480 | HDMI0 or DSI |
+| Display 2 (multimedia) | 7" IPS 1024x600 | HDMI1 or DSI |
+| USB DAC | ES9038Q2M module | USB 2.0 port |
+| Amplifier (4ch) | TDA7388 board | RCA from DAC |
+| Amplifier (sub) | TDA2050 board | RCA from DAC |
+| K-Line transceiver | L9637D on perfboard | UART3 (pins 8, 10) |
+| Parking sensors | 4× HC-SR04 | GPIO (see pin table) |
+| Temperature sensor | DS18B20 waterproof probe | 1-Wire (pin 7) |
+| Input controller | Arduino Pro Micro + rotary encoder | USB |
+| Cameras | 2× AHD 720P | USB3.0 grabber |
+| Microphone | USB condenser | USB |
+| BT remote | Steering wheel remote | Bluetooth |
+| Power supply | LM2596 12V→5.1V | USB-C PD trigger |
+
+### Wiring & Electronics
+
+See `schematics/README.md` for full assembly instructions, GPIO pinout, and circuit diagrams.
+
+---
+
+## 2. OS Installation
+
+### 2.1 Download Armbian
+
+Download Armbian for Orange Pi 5 Plus (bookworm/noble, CLI server image — no desktop needed):
+
+```bash
+# On your PC
+wget https://redirect.armbian.com/orangepi5plus/Bookworm_current_minimal
+# Or use Armbian's download page for the latest stable image
+```
+
+### 2.2 Flash to eMMC
+
+Option A — Flash via SD card first, then transfer to eMMC:
+
+```bash
+# Flash SD card (on your PC)
+sudo dd if=Armbian_*.img of=/dev/sdX bs=1M status=progress
+
+# Boot from SD, then copy to eMMC
+sudo armbian-install
+# Select: Boot from eMMC, ext4 filesystem
+```
+
+Option B — Flash eMMC directly via USB-C (maskrom mode):
+
+```bash
+# Hold BOOT button, connect USB-C to PC
+sudo rkdeveloptool db rk3588_spl_loader.bin
+sudo rkdeveloptool wl 0 Armbian_*.img
+sudo rkdeveloptool rd
+```
+
+### 2.3 First boot
+
+```bash
+# Connect via serial console (UART debug) or SSH
+# Default: root / 1234, will prompt to create user
+
+# Set hostname
+sudo hostnamectl set-hostname bcm-v7
+
+# Set timezone
+sudo timedatectl set-timezone Europe/Warsaw
+
+# Disable desktop environment (if accidentally installed)
+sudo systemctl set-default multi-user.target
+```
+
+---
+
+## 3. System Configuration
+
+### 3.1 System packages
+
+```bash
+sudo apt update && sudo apt upgrade -y
+
+# Core
+sudo apt install -y \
+    python3 python3-venv python3-pip \
+    git build-essential pkg-config
+
+# Audio (PipeWire)
+sudo apt install -y \
+    pipewire pipewire-pulse pipewire-alsa wireplumber \
+    alsa-utils
+
+# Bluetooth
+sudo apt install -y \
+    bluez bluez-tools
+
+# Display / framebuffer
+sudo apt install -y \
+    python3-pygame libsdl2-dev libsdl2-image-dev \
+    libdrm-dev
+
+# Serial / UART
+sudo apt install -y \
+    python3-serial
+
+# GPIO
+sudo apt install -y \
+    gpiod libgpiod-dev python3-libgpiod
+
+# GStreamer (dashcam)
+sudo apt install -y \
+    gstreamer1.0-tools gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-ugly
+
+# V4L2 (cameras)
+sudo apt install -y \
+    v4l-utils
+
+# Optional: voice control
+sudo apt install -y \
+    python3-sounddevice portaudio19-dev
+```
+
+### 3.2 Enable hardware interfaces
+
+```bash
+# Enable UART3 (K-Line), SPI, I2C, 1-Wire via device tree overlays
+# Edit /boot/armbianEnv.txt:
+sudo nano /boot/armbianEnv.txt
+```
+
+Add/modify:
+
+```
+overlays=uart3 i2c3 spi1 w1-gpio
+param_w1_pin=GPIO4_C1
+param_w1_pin_int_pullup=1
+```
+
+```bash
+# Reboot to apply
+sudo reboot
+
+# Verify UART3
+ls -la /dev/ttyS3
+# Should exist
+
+# Verify 1-Wire
+ls /sys/bus/w1/devices/
+# Should show DS18B20 sensor ID (28-xxxx)
+
+# Verify GPIO access
+gpioinfo | head -20
+```
+
+### 3.3 User permissions
+
+```bash
+# Create bcm user (or use existing)
+sudo useradd -m -s /bin/bash bcm
+sudo usermod -aG gpio,i2c,spi,video,render,bluetooth,audio,dialout bcm
+
+# Allow GPIO without root
+sudo cp /opt/bcm/config/99-gpio.rules /etc/udev/rules.d/
+# Content of 99-gpio.rules:
+# SUBSYSTEM=="gpio", KERNEL=="gpiochip*", MODE="0660", GROUP="gpio"
+sudo udevadm control --reload-rules
+```
+
+---
+
+## 4. Application Deployment
+
+### 4.1 Clone and install
+
+```bash
+sudo mkdir -p /opt/bcm
+sudo chown bcm:bcm /opt/bcm
+
+sudo -u bcm bash
+cd /opt/bcm
+
+git clone https://github.com/geek95dg/Alfa156-headunit.git .
+
+# Create virtual environment
+python3 -m venv venv
+source venv/bin/activate
+
+# Install dependencies
+pip install -r requirements.txt
+pip install -r requirements-opi.txt
+
+# Verify
+python -m pytest tests/ -v
+```
+
+### 4.2 Vosk speech models
+
+```bash
+cd /opt/bcm/src/voice/models
+
+# Polish model (~40MB)
+wget https://alphacephei.com/vosk/models/vosk-model-small-pl-0.22.zip
+unzip vosk-model-small-pl-0.22.zip
+mv vosk-model-small-pl-0.22 vosk-model-small-pl
+
+# English model (~40MB)
+wget https://alphacephei.com/vosk/models/vosk-model-small-en-us-0.15.zip
+unzip vosk-model-small-en-us-0.15.zip
+mv vosk-model-small-en-us-0.15 vosk-model-small-en-us
+```
+
+### 4.3 PipeWire configuration
+
+```bash
+# User-level PipeWire config for USB DAC
+sudo -u bcm mkdir -p /home/bcm/.config/pipewire/pipewire.conf.d
+sudo -u bcm cp /opt/bcm/config/pipewire/pipewire.conf \
+    /home/bcm/.config/pipewire/pipewire.conf.d/bcm-v7.conf
+
+# Copy EQ profile
+sudo -u bcm cp /opt/bcm/config/pipewire/eq-profile.json \
+    /home/bcm/.config/pipewire/
+
+# Restart PipeWire (as bcm user)
+sudo -u bcm systemctl --user restart pipewire wireplumber
+
+# Verify USB DAC is detected
+sudo -u bcm wpctl status
+# Should show ES9038Q2M as an audio sink
+```
+
+### 4.4 Arduino firmware
+
+```bash
+# On a PC with Arduino IDE:
+# 1. Open arduino/rotary_encoder/rotary_encoder.ino
+# 2. Select Board: Arduino Micro
+# 3. Install HID-Project library
+# 4. Upload to Arduino Pro Micro
+# 5. Connect Arduino to OPi USB port
+
+# Verify on OPi
+sudo dmesg | tail -20
+# Should show: "input: Arduino Micro as /devices/..."
+cat /proc/bus/input/devices | grep -A5 Arduino
+```
+
+---
+
+## 5. Systemd Services
+
+### 5.1 Install services
+
+```bash
+sudo cp /opt/bcm/config/systemd/*.service /etc/systemd/system/
+sudo systemctl daemon-reload
+```
+
+### 5.2 Service architecture
+
+```
+bcm-power.service          ← starts first (ignition, shutdown, backlight)
+    ├── bcm-dashboard.service  ← depends on power (4.3" TFT renderer)
+    ├── bcm-obd.service        ← depends on power (K-Line ECU comms)
+    ├── bcm-dashcam.service    ← depends on power (GStreamer recording)
+    ├── bcm-voice.service      ← depends on power (Vosk recognition)
+    └── bcm-multimedia.service ← depends on power (OpenAuto + BT)
+```
+
+### 5.3 Enable auto-start
+
+```bash
+# Enable all services
+sudo systemctl enable bcm-power bcm-dashboard bcm-obd \
+    bcm-dashcam bcm-voice bcm-multimedia
+
+# Start manually (for testing)
+sudo systemctl start bcm-power
+
+# Check status
+sudo systemctl status bcm-power bcm-dashboard bcm-obd
+```
+
+### 5.4 Service paths
+
+All services expect the application at `/opt/bcm` with a virtualenv at `/opt/bcm/venv`.
+
+Key environment variables set by services:
+- `PYTHONPATH=/opt/bcm`
+- `BCM_PLATFORM=opi`
+- `SDL_VIDEODRIVER=kmsdrm` (dashboard service)
+
+### 5.5 Logs
+
+```bash
+# View service logs
+journalctl -u bcm-power -f
+journalctl -u bcm-dashboard -f
+
+# Application logs
+tail -f /opt/bcm/logs/bcm.log
+```
+
+---
+
+## 6. Display Configuration
+
+### 6.1 Dual display setup
+
+The OPi 5 Plus has 2 HDMI outputs. Configure them:
+
+```bash
+# List connected displays
+cat /sys/class/drm/card*/status
+
+# Typical setup:
+# HDMI-A-1 → 4.3" TFT (800x480, dashboard)
+# HDMI-A-2 → 7" IPS (1024x600, multimedia / Android Auto)
+```
+
+### 6.2 Framebuffer for dashboard
+
+The dashboard renders directly to framebuffer (no Xorg/Wayland needed):
+
+```bash
+# Check framebuffer
+fbset -fb /dev/fb0
+
+# Test pattern
+cat /dev/urandom > /dev/fb0
+
+# Dashboard uses SDL_VIDEODRIVER=kmsdrm for direct rendering
+# This is set in bcm-dashboard.service
+```
+
+### 6.3 Backlight control
+
+PWM backlight is managed by the power module:
+- Pin 32 (PWM2) → 4.3" dashboard
+- Pin 33 (PWM3) → 7" multimedia
+
+Brightness is configurable in `config/bcm_config.yaml` (0-100%).
+
+---
+
+## 7. Audio Setup
+
+### 7.1 USB DAC verification
+
+```bash
+# Check DAC is detected
+aplay -l
+# Should list ES9038Q2M as a USB audio device
+
+# PipeWire status
+wpctl status
+# Look for: ES9038Q2M [vol: X.XX]
+
+# Set as default sink
+wpctl set-default <node-id>
+
+# Test playback
+speaker-test -t wav -c 2 -D plughw:CARD=ES9038Q2M
+```
+
+### 7.2 Audio chain
+
+```
+PipeWire (software mixer + EQ)
+    ↓ USB
+ES9038Q2M DAC (32-bit, 129dB SNR)
+    ↓ RCA L/R
+TDA7388 (4× 41W Class AB)  →  4 speakers (front L/R, rear L/R)
+TDA2050 (32W Class AB mono) →  subwoofer
+    ↑ 12V direct (25A fused)
+```
+
+### 7.3 EQ presets
+
+EQ is managed via PipeWire filter chain. Presets defined in `config/pipewire/eq-profile.json`:
+- **Flat** — no processing
+- **Rock** — boosted lows + highs
+- **Jazz** — warm mids emphasis
+- **Bass Boost** — +6dB below 120Hz
+- **Custom** — user-defined 10-band parametric
+
+Switch presets via settings menu (press H on dashboard) or voice: "zmien styl" / "change theme".
+
+---
+
+## 8. K-Line / OBD-II Setup
+
+### 8.1 Hardware verification
+
+```bash
+# Check UART3 is available
+ls -la /dev/ttyS3
+
+# Test serial loopback (short TX to RX)
+stty -F /dev/ttyS3 10400 raw
+echo "test" > /dev/ttyS3 &
+cat /dev/ttyS3
+```
+
+### 8.2 ECU communication
+
+The OBD module communicates with the Bosch EDC15C7 ECU at 10400 baud using KWP2000:
+
+1. **5-baud init** to address 0x01
+2. **KWP2000 fast init** handshake
+3. **PID requests** for RPM, speed, coolant temp, fuel rate, etc.
+
+Config in `bcm_config.yaml`:
+```yaml
+serial:
+  kline:
+    port_opi: /dev/ttyS3
+    baudrate: 10400
+    ecu_address: 0x01
+```
+
+### 8.3 Troubleshooting K-Line
+
+```bash
+# Check L9637D wiring
+# Pin 6 (K-Line) should show ~12V idle (pulled up by 510Ω)
+
+# Monitor raw serial traffic
+picocom /dev/ttyS3 -b 10400 --imap lfcrlf
+
+# Check user has dialout group
+groups bcm | grep dialout
+```
+
+---
+
+## 9. Parking Sensors
+
+### 9.1 Verify GPIO
+
+```bash
+# Check pin access
+gpioget gpiochip4 16  # TRIG pin — should read 0
+gpioget gpiochip4 18  # ECHO pin 1
+
+# Quick test (trigger + measure echo)
+gpioset gpiochip4 16=1
+sleep 0.00001
+gpioset gpiochip4 16=0
+# ECHO pin should pulse high for distance measurement
+```
+
+### 9.2 Sensor calibration
+
+HC-SR04 measures distance by timing the ECHO pulse:
+- Distance (cm) = pulse_duration × 17150
+- Zones: safe (>100cm), caution (50-100cm), warning (30-50cm), danger (<30cm)
+- Buzzer frequency increases as distance decreases
+
+---
+
+## 10. Camera & Dashcam
+
+### 10.1 Verify cameras
+
+```bash
+# List V4L2 devices
+v4l2-ctl --list-devices
+
+# Test camera feed
+ffplay /dev/video0 -video_size 1280x720
+
+# Check AHD grabber channels
+v4l2-ctl --device=/dev/video0 --get-input
+v4l2-ctl --device=/dev/video0 --set-input=0   # Front cam
+v4l2-ctl --device=/dev/video0 --set-input=1   # Rear cam
+```
+
+### 10.2 Dashcam storage
+
+```bash
+# Mount dedicated SD card for recordings
+sudo mkdir -p /media/dashcam
+sudo mount /dev/mmcblk1p1 /media/dashcam
+
+# Add to fstab for auto-mount
+echo "/dev/mmcblk1p1 /media/dashcam ext4 defaults,noatime 0 2" | sudo tee -a /etc/fstab
+
+# Config
+# camera.recording_path: /media/dashcam
+# camera.segment_minutes: 5
+# camera.max_storage_gb: 128
+```
+
+Dashcam records in H.264, 5-minute segments, auto-deletes oldest when storage exceeds 128 GB.
+
+---
+
+## 11. Bluetooth
+
+### 11.1 Enable BT
+
+```bash
+# Check BT adapter (OPi 5 Plus has built-in BT 5.0)
+bluetoothctl show
+
+# Enable
+bluetoothctl power on
+bluetoothctl discoverable on
+bluetoothctl pairable on
+
+# Pair phone
+bluetoothctl scan on
+# Wait for phone to appear
+bluetoothctl pair XX:XX:XX:XX:XX:XX
+bluetoothctl trust XX:XX:XX:XX:XX:XX
+bluetoothctl connect XX:XX:XX:XX:XX:XX
+```
+
+### 11.2 A2DP audio streaming
+
+PipeWire handles A2DP sink automatically. Once paired, the phone can stream audio:
+
+```bash
+# Verify A2DP sink
+wpctl status | grep -i bluetooth
+```
+
+### 11.3 HFP hands-free
+
+Phone calls route through PipeWire with automatic audio ducking (music volume reduced during calls).
+
+---
+
+## 12. Voice Control
+
+### 12.1 Microphone setup
+
+```bash
+# List input devices
+arecord -l
+
+# Test recording
+arecord -f S16_LE -r 16000 -c 1 -d 5 /tmp/test.wav
+aplay /tmp/test.wav
+
+# Set USB mic as default source
+wpctl set-default <source-node-id>
+```
+
+### 12.2 Wake word
+
+- Polish: **"Hej komputer"**
+- English: **"Hey computer"**
+
+After wake word detection, speak a command within 5 seconds.
+
+### 12.3 Available commands
+
+| Polish | English | Action |
+|--------|---------|--------|
+| pokaz temperature | show temperature | Display exterior temp |
+| wlacz radio | turn on radio | Switch audio source |
+| nastepny utwor | next track | Next track |
+| poprzedni utwor | previous track | Previous track |
+| glosniej | volume up | Volume +10% |
+| ciszej | volume down | Volume -10% |
+| pokaz zuzycie | show consumption | Show fuel consumption |
+| status samochodu | car status | Show vehicle status |
+| nagrywaj | start recording | Start dashcam |
+| zatrzymaj nagrywanie | stop recording | Stop dashcam |
+| zmien styl | change theme | Cycle dashboard theme |
+| zmien jezyk | change language | Switch PL/EN |
+
+---
+
+## 13. Power Management
+
+### 13.1 Boot sequence
+
+```
+Ignition ON (12V signal via PC817 optoisolator)
+    ↓
+bcm-power.service starts (STANDBY → WAKE → ACTIVE)
+    ↓
+bcm-dashboard.service starts (gauges render in ~2s)
+    ↓
+bcm-obd.service starts (K-Line init, ECU handshake)
+    ↓
+bcm-dashcam.service, bcm-voice.service, bcm-multimedia.service
+```
+
+**Target boot time:** < 3 seconds from ignition to dashboard visible.
+
+### 13.2 Shutdown sequence
+
+```
+Ignition OFF detected
+    ↓
+30-second delay (configurable: power.shutdown_delay_seconds)
+    ↓
+bcm-power publishes "power.shutdown" event
+    ↓
+All modules save state & stop gracefully
+    ↓
+Backlight fades out (1 second)
+    ↓
+OPi shuts down (sudo poweroff)
+```
+
+### 13.3 Fast boot optimization
+
+```bash
+# Disable unnecessary services
+sudo systemctl disable NetworkManager-wait-online
+sudo systemctl disable apt-daily.timer
+sudo systemctl disable apt-daily-upgrade.timer
+sudo systemctl disable man-db.timer
+
+# Reduce kernel boot time
+# Add to /boot/armbianEnv.txt:
+# extraargs=quiet loglevel=0 fastboot
+
+# Pre-load Python bytecache
+cd /opt/bcm && python -m compileall src/
+```
+
+---
+
+## 14. Maintenance
+
+### 14.1 Update application
+
+```bash
+sudo -u bcm bash
+cd /opt/bcm
+source venv/bin/activate
+
+git pull origin main
+pip install -r requirements.txt -r requirements-opi.txt
+
+# Run tests
+python -m pytest tests/ -v
+
+# Restart services
+sudo systemctl restart bcm-power
+```
+
+### 14.2 Backup config
+
+```bash
+# Backup current settings
+cp /opt/bcm/config/bcm_config.yaml /opt/bcm/config/bcm_config.yaml.bak
+
+# Backup dashcam footage (optional)
+rsync -av /media/dashcam/ /media/usb-backup/dashcam/
+```
+
+### 14.3 Monitoring
+
+```bash
+# System health
+htop                           # CPU/RAM usage
+sensors                        # SoC temperature
+df -h                          # Disk usage
+journalctl -u bcm-* --since today  # Today's logs
+
+# BCM status
+sudo systemctl status bcm-power bcm-dashboard bcm-obd bcm-dashcam bcm-voice bcm-multimedia
+```
+
+### 14.4 Common issues
+
+| Problem | Solution |
+|---------|----------|
+| No display output | Check HDMI cable, verify `fbset -fb /dev/fb0` |
+| No audio from DAC | `wpctl status`, check USB DAC is default sink |
+| K-Line timeout | Check L9637D wiring, verify 510Ω pull-up, test with picocom |
+| Parking sensors stuck | Check HC-SR04 VCC (5V), verify ECHO voltage dividers |
+| High CPU temp | Check heatsink on RK3588, add small fan if >75C |
+| Dashboard freezes | Check `journalctl -u bcm-dashboard`, restart service |
+| Bluetooth won't pair | `bluetoothctl power off && bluetoothctl power on`, re-scan |
+| Vosk not loading | Verify model paths in config, check RAM usage (needs ~200MB) |
+| Boot too slow | Apply fast boot optimizations (section 13.3) |
+
+---
+
+## 15. Pin Reference (Quick Card)
+
+```
+Orange Pi 5 Plus — 40-pin GPIO Header
+┌──────────────────────────────────────┐
+│  Pin 7  — DS18B20 1-Wire (temp)      │
+│  Pin 8  — UART3 TX (K-Line)          │
+│  Pin 10 — UART3 RX (K-Line)          │
+│  Pin 12 — Buzzer (parking)           │
+│  Pin 16 — HC-SR04 TRIG (shared)      │
+│  Pin 18 — HC-SR04 ECHO #1 (rear-L)  │
+│  Pin 22 — HC-SR04 ECHO #2 (rear-CL) │
+│  Pin 24 — HC-SR04 ECHO #3 (rear-CR) │
+│  Pin 26 — HC-SR04 ECHO #4 (rear-R)  │
+│  Pin 29 — Ignition (optoisolator)    │
+│  Pin 31 — Door open (optoisolator)   │
+│  Pin 32 — PWM2 (4.3" backlight)      │
+│  Pin 33 — PWM3 (7" backlight)        │
+│  Pin 35 — Washer sprayer (opto)      │
+│  Pin 37 — Central lock (opto)        │
+└──────────────────────────────────────┘
+```
+
+---
+
+## 16. First Run Checklist
+
+After full installation, verify each subsystem:
+
+- [ ] OPi boots from eMMC, SSH accessible
+- [ ] UART3 visible: `ls /dev/ttyS3`
+- [ ] 1-Wire sensor visible: `ls /sys/bus/w1/devices/28-*`
+- [ ] GPIO accessible: `gpioinfo | grep -c "unnamed"`
+- [ ] PipeWire running: `systemctl --user status pipewire`
+- [ ] USB DAC detected: `aplay -l | grep ES9038`
+- [ ] Speakers output: `speaker-test -t wav -c 2`
+- [ ] Dashboard renders on 4.3" TFT (check `/dev/fb0`)
+- [ ] Arduino encoder works: `evtest /dev/input/eventX`
+- [ ] Cameras visible: `v4l2-ctl --list-devices`
+- [ ] Bluetooth adapter up: `bluetoothctl show`
+- [ ] K-Line responds: ECU handshake via `bcm-obd.service`
+- [ ] Parking sensors trigger: reverse gear → overlay appears
+- [ ] Voice responds: "Hej komputer" → "Slucham"
+- [ ] Dashcam records: check `/media/dashcam/*.mp4`
+- [ ] `python -m pytest tests/ -v` — all tests pass
+- [ ] All 6 systemd services: `sudo systemctl status bcm-*`

--- a/docs/VM_USAGE_GUIDE.md
+++ b/docs/VM_USAGE_GUIDE.md
@@ -1,0 +1,340 @@
+# BCM v7 — VM Usage Guide
+
+How to run, navigate, and test the BCM headunit system inside a VM (VMware or similar).
+
+> **Prerequisites:** VM already set up per [VMWARE_SETUP.md](VMWARE_SETUP.md).
+
+---
+
+## 1. Starting the System
+
+```bash
+cd ~/Alfa156-headunit
+source .venv/bin/activate
+
+# Start all modules in x86 simulation mode
+python main.py --platform x86
+```
+
+This opens the **dashboard window** (800x480) with live-simulated gauges, and starts all backend modules (OBD, parking, audio, voice, etc.) in simulation mode.
+
+### Selective startup
+
+```bash
+# Dashboard + OBD only (lightweight)
+python main.py --platform x86 --modules obd,dashboard
+
+# Audio + multimedia only (BT/DAC testing)
+python main.py --platform x86 --modules audio,multimedia
+
+# Dry run — list all modules, start nothing
+python main.py --platform x86 --dry-run
+```
+
+### Module list
+
+| Module | Part | What it does |
+|--------|------|-------------|
+| `dashboard` | 2 | PyGame GUI — gauges, trip, overlays, settings |
+| `obd` | 3 | Simulated ECU data (RPM, speed, coolant temp) |
+| `parking` | 4 | Simulated ultrasonic sensors + buzzer |
+| `environment` | 5 | Simulated exterior temperature |
+| `audio` | 6 | PipeWire volume/EQ (or stub if PipeWire unavailable) |
+| `voice` | 7 | Vosk speech recognition (or keyboard fallback) |
+| `input` | 8 | Keyboard input (simulates rotary encoder) |
+| `camera` | 9 | Simulated dashcam frames |
+| `power` | 10 | Simulated ignition/shutdown state machine |
+| `multimedia` | 11 | Bluetooth manager + OpenAuto stub |
+
+---
+
+## 2. Dashboard Keyboard Controls
+
+Once the dashboard window is open, these keys work:
+
+### Main Dashboard View
+
+| Key | Action |
+|-----|--------|
+| `UP` | Increase RPM (demo mode, +200) |
+| `DOWN` | Decrease RPM (demo mode, -200) |
+| `R` | Toggle reverse gear (shows parking overlay) |
+| `T` | Cycle exterior temperature down (-3 C per press, for icing test) |
+| `I` | Trigger icing alert overlay manually |
+| `H` or `HOME` | Open/close Settings menu |
+| `ESC` | Close settings (if open) / Quit application |
+
+### Settings Menu (press H to open)
+
+| Key | Action |
+|-----|--------|
+| `UP` | Move selection up |
+| `DOWN` | Move selection down |
+| `LEFT` | Cycle setting value backward |
+| `RIGHT` or `ENTER` | Cycle setting value forward |
+| `H` / `HOME` | Save & close settings |
+| `ESC` | Save & close settings |
+
+### Settings Available
+
+| Setting | Options |
+|---------|---------|
+| **Theme** | Classic Alfa Racing / Modern Dark / OEM Digital |
+| **Language** | Polski / English |
+| **Speed Units** | km/h / mph |
+| **Temp Units** | C / F |
+| **Brightness** | 0% — 100% (step 10%) |
+| **EQ Preset** | Flat / Rock / Jazz / Bass Boost / Custom |
+| **Wake Sensitivity** | Low / Medium / High |
+
+Settings are saved to `config/bcm_config.yaml` when you close the menu.
+
+---
+
+## 3. Testing Demo Scenarios
+
+### 3.1 Gauge operation
+
+1. Start: `python main.py --platform x86 --modules obd,dashboard`
+2. The demo data generator auto-produces sinusoidal RPM/speed/temp patterns
+3. Watch gauges animate — RPM swings 750-5000, speed follows, coolant slowly rises to ~90 C
+4. Press `UP`/`DOWN` to manually override RPM
+
+### 3.2 Parking overlay
+
+1. Press `R` to engage reverse gear
+2. Full-screen parking overlay appears with 4 colored distance bars:
+   - Green: > 1m (safe)
+   - Yellow: 0.5-1m (caution)
+   - Orange: 0.3-0.5m (warning)
+   - Red: < 0.3m (danger)
+3. Simulated sensors cycle through distances automatically
+4. Press `R` again to disengage
+
+### 3.3 Icing alert
+
+1. Press `T` repeatedly to drop the temperature
+2. At < 3 C: status bar shows snowflake icon + icing alert popup appears
+3. At <= 0 C: persistent icing warning state
+4. Or press `I` to trigger icing alert directly (5-second popup)
+
+### 3.4 Theme switching
+
+1. Press `H` to open Settings
+2. Navigate to "Theme" (first item)
+3. Press `RIGHT` to cycle: Classic Alfa Racing -> Modern Dark -> OEM Digital
+4. Press `H` or `ESC` to close — theme applies immediately
+
+### 3.5 K-Line OBD simulation (no hardware)
+
+```bash
+# Terminal 1: Create virtual serial pair
+socat -d -d pty,raw,echo=0,link=/tmp/kline_opi pty,raw,echo=0,link=/tmp/kline_sim
+
+# Terminal 2: Start BCM (edit config first: serial.kline.port_opi: /tmp/kline_opi)
+python main.py --platform x86 --modules obd,dashboard
+
+# Terminal 3: Feed simulated ECU responses
+python -c "
+import serial, time
+ser = serial.Serial('/tmp/kline_sim', 10400, timeout=1)
+while True:
+    data = ser.read(100)
+    if data:
+        print(f'Received: {data.hex()}')
+        # Fake RPM response (KWP2000 format)
+        ser.write(bytes([0x48, 0x6B, 0x11, 0x41, 0x0C, 0x1A, 0xF8, 0x00]))
+    time.sleep(0.1)
+"
+```
+
+### 3.6 Voice commands (keyboard fallback)
+
+When voice module is running in stub mode (no Vosk model), commands are dispatched via event bus. Available voice commands:
+
+**Polish (default):**
+- "hej komputer" — wake word
+- "pokaz temperature" — show temperature
+- "wlacz radio" — turn on radio
+- "nastepny utwor" / "poprzedni utwor" — next/prev track
+- "glosniej" / "ciszej" — volume up/down
+- "pokaz zuzycie" — show fuel consumption
+- "status samochodu" — car status
+- "nagrywaj" / "zatrzymaj nagrywanie" — start/stop dashcam
+- "zmien styl" — change theme
+- "zmien jezyk" — change language
+
+**English:**
+- "hey computer" — wake word
+- "show temperature", "turn on radio", "next track", "previous track"
+- "volume up", "volume down", "show consumption", "car status"
+- "start recording", "stop recording", "change theme", "change language"
+
+### 3.7 Audio system
+
+```bash
+# Check PipeWire status
+systemctl --user status pipewire wireplumber
+
+# List audio sinks
+pw-cli list-objects | grep -i node
+
+# Test audio output
+speaker-test -t wav -c 2
+
+# If USB DAC is passed through to VM
+wpctl set-default <node-id>
+```
+
+---
+
+## 4. Running Tests
+
+### All tests
+
+```bash
+cd ~/Alfa156-headunit
+source .venv/bin/activate
+python -m pytest tests/ -v
+```
+
+### Specific module tests
+
+```bash
+python -m pytest tests/test_dashboard.py -v    # Dashboard/GUI
+python -m pytest tests/test_obd.py -v          # K-Line / KWP2000
+python -m pytest tests/test_parking.py -v      # Parking sensors
+python -m pytest tests/test_environment.py -v  # Temperature / icing
+python -m pytest tests/test_audio.py -v        # PipeWire / volume
+python -m pytest tests/test_voice.py -v        # Voice recognition
+python -m pytest tests/test_input.py -v        # Rotary encoder / BT remote
+python -m pytest tests/test_camera.py -v       # Dashcam
+python -m pytest tests/test_power.py -v        # Power state machine
+python -m pytest tests/test_multimedia.py -v   # OpenAuto / Bluetooth
+python -m pytest tests/test_core.py -v         # Config / EventBus / HAL
+python -m pytest tests/test_integration.py -v  # Cross-module IPC
+```
+
+### With coverage report
+
+```bash
+python -m pytest tests/ --cov=src --cov-report=term-missing
+```
+
+### Run a single test function
+
+```bash
+python -m pytest tests/test_dashboard.py::test_settings_cycle_value -v
+```
+
+---
+
+## 5. Configuration Editing
+
+The master config lives at `config/bcm_config.yaml`. Key sections you may want to adjust for VM testing:
+
+```yaml
+# Force x86 platform (auto should work in VM)
+system:
+  platform: auto        # auto | x86 | opi
+
+# Enable/disable specific modules
+modules:
+  dashboard: true
+  obd: true
+  parking: true
+  # ... set false to skip modules you don't need
+
+# Dashboard display size
+display:
+  dashboard:
+    width: 800
+    height: 480
+    fps: 15
+    theme: classic_alfa  # classic_alfa | modern_dark | oem_digital
+
+# Audio config
+audio:
+  eq_preset: flat
+  master_volume: 70
+
+# K-Line serial port (for socat testing)
+serial:
+  kline:
+    port_opi: /dev/ttyS3      # real OPi
+    # Override for VM: /tmp/kline_opi
+```
+
+---
+
+## 6. Web Dashboard Viewer (x86 only)
+
+An alternative browser-based viewer is available for x86 development:
+
+```bash
+# Requires flask + flask-sock
+pip install flask flask-sock Pillow
+
+# Start web viewer (separate from PyGame)
+python -c "from src.dashboard.web_viewer import start_web_viewer; start_web_viewer()"
+```
+
+Opens at `http://localhost:5000` — shows dashboard frames via WebSocket.
+
+---
+
+## 7. Event Bus Debugging
+
+All modules communicate via the EventBus. To debug events:
+
+```python
+# In Python REPL or test script:
+from src.core.event_bus import EventBus
+
+bus = EventBus()
+bus.subscribe("*", lambda topic, value, ts: print(f"[{topic}] = {value}"))
+
+# Now start modules — you'll see all published events
+```
+
+Common event topics:
+- `obd.rpm`, `obd.speed`, `obd.coolant_temp`, `obd.fuel_level`, `obd.fuel_rate`
+- `obd.battery_voltage`
+- `env.temperature`
+- `parking.distances` (list of 4 floats)
+- `power.reverse_gear` (bool)
+- `input.volume_up`, `input.volume_down`
+- `voice.cmd.*` (voice command actions)
+
+---
+
+## 8. Logging
+
+Logs go to `logs/bcm.log` and stdout. Adjust verbosity:
+
+```yaml
+# config/bcm_config.yaml
+system:
+  log_level: DEBUG     # DEBUG | INFO | WARNING | ERROR
+```
+
+Or watch logs live:
+
+```bash
+tail -f logs/bcm.log
+```
+
+---
+
+## 9. Quick Test Checklist
+
+- [ ] `python main.py --platform x86 --dry-run` — all 11 modules listed
+- [ ] `python -m pytest tests/ -v` — all tests pass
+- [ ] Dashboard window opens, gauges animate
+- [ ] Press `H` — settings menu opens/closes
+- [ ] Cycle theme in settings — theme changes on close
+- [ ] Press `R` — parking overlay shows/hides
+- [ ] Press `T` 4-5 times — icing warning triggers
+- [ ] Press `I` — icing alert popup appears for 5s
+- [ ] PipeWire audio works: `speaker-test -t wav -c 2`
+- [ ] K-Line simulation works with socat (if testing OBD)


### PR DESCRIPTION
VM_USAGE_GUIDE.md: keyboard controls, menu navigation, demo scenarios, testing commands, event bus debugging, and configuration reference.

OPI5PLUS_INSTALL.md: complete deployment guide covering OS flash, system packages, device tree overlays, PipeWire/DAC setup, systemd services, K-Line/OBD, parking sensors, cameras, Bluetooth, voice control, power management, fast boot optimization, and maintenance procedures.

https://claude.ai/code/session_01BvBdi3XSeC8715Zm3NJFAd