### PR TITLE
Fix VMware setup: add missing pytest dependency and correct install i…

### DIFF
--- a/docs/VMWARE_SETUP.md
+++ b/docs/VMWARE_SETUP.md
@@ -138,8 +138,10 @@ cd Alfa156-headunit
 python3.12 -m venv .venv
 source .venv/bin/activate
 
-# Install dependencies
+# Install dependencies (common + x86 simulation + dev/test tools)
 pip install -r requirements.txt
+pip install -r requirements-x86.txt
+pip install -r requirements-dev.txt
 
 # Verify installation
 python -m pytest tests/ -v
@@ -368,10 +370,20 @@ sudo apt install -y python3-pygame libsdl2-dev
 export SDL_VIDEODRIVER=dummy
 ```
 
+### `No module named pytest`
+```bash
+# pytest is in the dev requirements — install it
+pip install -r requirements-dev.txt
+```
+
 ### Tests fail with import errors
 ```bash
 # Ensure you're in the venv
 source .venv/bin/activate
+# Ensure all requirement files are installed
+pip install -r requirements.txt
+pip install -r requirements-x86.txt
+pip install -r requirements-dev.txt
 # Ensure project root is in PYTHONPATH
 export PYTHONPATH=/home/$USER/Alfa156-headunit:$PYTHONPATH
 # Or run with: python -m pytest tests/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+# BCM v7 — Development/testing dependencies
+pytest>=8.0
+pytest-cov>=4.0


### PR DESCRIPTION
…nstructions

pytest was not included in any requirements file, causing `python -m pytest tests/` to fail with "No module named pytest" after following the setup guide.

- Add requirements-dev.txt with pytest and pytest-cov
- Fix VMWARE_SETUP.md section 4.2 to install all three requirement files (requirements.txt, requirements-x86.txt, requirements-dev.txt)
- Add troubleshooting entry for the "No module named pytest" error

https://claude.ai/code/session_01JCUMQY6GW9QNqmfYduGqWD