### PR TITLE
Add Redmi Note 8 Pro (Ubuntu Touch) platform support

### DIFF
--- a/config/bcm_config_redmi.yaml
+++ b/config/bcm_config_redmi.yaml
@@ -1,0 +1,223 @@
+# BCM v8.5 — Configuration for Redmi Note 8 Pro (Ubuntu Touch)
+#
+# Key differences from OPi config:
+#   - Platform: redmi (auto-detected on UT/Halium)
+#   - Single built-in display (6.53" 1080x2340) acts as main 7" screen
+#   - Second display via USB-C HDMI adapter (cable only, no wireless)
+#   - GPIO offloaded to Arduino sensor hub via USB serial
+#   - Built-in GPS, Bluetooth, WiFi, microphone used natively
+#   - K-Line OBD via USB-UART adapter (CP2102/CH340)
+#   - Camera via USB AHD grabber through OTG hub
+
+system:
+  name: BCM v8.5
+  version: 0.1.0
+  platform: redmi
+  log_level: DEBUG
+  log_file: logs/bcm.log
+
+modules:
+  dashboard: true
+  obd: true
+  parking: true
+  environment: true
+  audio: true
+  voice: true
+  input: true
+  camera: true
+  power: true
+  multimedia: true
+  location: true
+  network: true
+  weather: true
+
+display:
+  # Main display: Redmi built-in screen (use in landscape)
+  # Phone screen resolution in landscape: 2340x1080 but web UI is adaptive
+  dashboard:
+    width: 1080
+    height: 2340
+    fps: 15
+    theme: heritage
+    brightness: 70
+  # Second display: 4.3" TFT via USB-C to HDMI adapter
+  multimedia:
+    width: 800
+    height: 480
+
+units:
+  speed: km/h
+  temperature: C
+
+language: pl
+
+# GPIO pins — mapped through Arduino sensor hub
+# Same logical pin numbers as OPi for code compatibility
+gpio:
+  parking_trig: 79
+  parking_echo:
+    - 80
+    - 81
+    - 82
+    - 83
+  buzzer: 84
+  backlight_dashboard: 32
+  backlight_multimedia: 33
+  onewire: 7
+  ignition: 85
+  door: 86
+  rain_sensor: 87
+  sprayer: 88
+  central_lock: 89
+
+# Serial ports — all via USB-C OTG hub
+serial:
+  kline:
+    # USB-UART adapter (CP2102 or CH340) for K-Line OBD-II
+    port_redmi: /dev/ttyUSB1
+    baudrate: 10400
+    ecu_address: 1
+  sensor_hub:
+    # Arduino sensor hub (parking, ignition, temp, relays)
+    port: /dev/ttyUSB0
+    baudrate: 115200
+
+hardware:
+  gps:
+    enabled: true
+    # On Redmi: use phone's built-in GPS via gpsd or UT location service
+    # Set to empty string to use built-in GPS
+    port: ""
+    baudrate: 9600
+    use_builtin: true
+  lte:
+    enabled: true
+    # Use phone's built-in cellular modem
+    device: ""
+    apn: ""
+    use_builtin: true
+
+audio:
+  eq_preset: jazz
+  master_volume: 70
+  # Phase 1 desk testing: use phone's built-in speaker
+  # Production: USB DAC via OTG hub
+  dac: builtin
+  amp_main: TDA7388
+  amp_sub: TDA2050
+  # Use phone's built-in microphone for voice control
+  mic_vosk: ""
+  mic_phone: ""
+
+voice:
+  wake_word_sensitivity: medium
+  model_pl: src/voice/models/vosk-model-small-pl
+  model_en: src/voice/models/vosk-model-small-en-us
+
+camera:
+  segment_minutes: 5
+  max_storage_gb: 128
+  recording_path: /media/dashcam
+
+swc:
+  enabled: true
+  buttons:
+    SWC_VOLUP: volume_up
+    SWC_VOLDN: volume_down
+    SWC_UP: menu_up
+    SWC_DOWN: menu_down
+    SWC_MUTE: mute
+    SWC_MODE: home
+    SWC_NEXT: next_track
+    SWC_PREV: prev_track
+    SWC_PICKUP: phone_pickup
+    SWC_HANGUP: phone_hangup
+    SWC_VOICE: voice_trigger
+    SWC_SRC: source_cycle
+
+brightness:
+  mode: auto
+  steps:
+    - 15
+    - 30
+    - 45
+    - 60
+    - 80
+    - 100
+
+music_panel:
+  enabled: true
+
+wifi:
+  enabled: true
+  ssid: ALFA
+  password: "87654321"
+  channel: 6
+  interface: ""
+  ip: 10.0.0.1
+  netmask: 255.255.255.0
+  dhcp_start: 10.0.0.10
+  dhcp_end: 10.0.0.50
+
+weather:
+  api_key: ""
+  poll_interval_min: 15
+  default_lat: 50.06
+  default_lon: 19.94
+
+power:
+  shutdown_delay_seconds: 30
+  backlight_fade_ms: 1000
+
+# v8.5 modules
+rain_sensor:
+  sensitivity: medium
+
+central_lock:
+  # Central lock Arduino — separate from sensor hub
+  port: /dev/ttyUSB2
+  baudrate: 9600
+
+lighting:
+  follow_me_home_seconds: 60
+  greeting_blinks: 2
+  leaving_home: true
+
+traffic:
+  api_key: ""
+  provider: tomtom
+  poll_interval_min: 5
+
+remote_status:
+  api_key: ""
+
+modules_v85:
+  rain_sensor: true
+  central_lock: true
+  lighting: true
+  performance: true
+  alarm: true
+  crash_detect: true
+  battery_backup: true
+
+alarm:
+  siren_duration: 60
+  arming_delay: 30
+  sensors:
+    door: true
+    motion: true
+    tilt: true
+    shock: true
+
+crash_detection:
+  speed_drop_threshold: 30
+  g_force_threshold: 3.0
+  post_crash_record_sec: 60
+
+tracking:
+  interval_sec: 30
+  lte_sync_min: 15
+  geofence_lat: 0
+  geofence_lon: 0
+  geofence_radius_km: 0
+  sms_number: ""

--- a/docs/REDMI_SETUP.md
+++ b/docs/REDMI_SETUP.md
@@ -1,0 +1,488 @@
+# BCM v8.5 — Redmi Note 8 Pro (Ubuntu Touch) — Setup & Testing Guide
+
+## Overview
+
+This guide covers running BCM v8.5 on a **Redmi Note 8 Pro** (codename `begonia`)
+with **Ubuntu Touch** instead of the Orange Pi 5 Plus. The phone's 6.53" screen
+replaces the 7/8" touchscreen, and all GPIO-dependent modules are offloaded to
+an Arduino sensor hub via USB-C OTG.
+
+**Testing is organized in 4 phases** — you can start with just the phone on your
+desk and progressively add hardware.
+
+---
+
+## Prerequisites
+
+### Hardware (minimum for Phase 1)
+- Redmi Note 8 Pro with **unlocked bootloader**
+- USB-C cable for flashing
+- PC with `fastboot` and `adb`
+
+### Software
+- Ubuntu Touch for `begonia` — https://devices.ubuntu-touch.io/device/begonia/
+- UBports Installer (recommended for flashing)
+
+---
+
+## Phase 1: Desk Testing — Phone Only (No External Hardware)
+
+**Goal:** Run BCM dashboard on the phone, verify web UI, demo data, themes.
+
+### 1.1 Install Ubuntu Touch
+
+```bash
+# Option A: UBports Installer (GUI — recommended)
+# Download from https://ubports.com/installer
+# Select device: Redmi Note 8 Pro (begonia)
+# Follow on-screen instructions (unlock bootloader, flash)
+
+# Option B: Manual fastboot
+fastboot flash boot boot.img
+fastboot flash system system.img
+fastboot flash userdata userdata.img
+fastboot reboot
+```
+
+### 1.2 Enable Developer Mode
+
+On the phone:
+1. Settings → About → tap Build Number 7 times
+2. Settings → Developer → enable Developer Mode
+3. Settings → Developer → enable SSH (note the password)
+
+### 1.3 Connect via SSH
+
+```bash
+# Find phone IP (usually via USB network 10.15.19.82)
+ssh phablet@10.15.19.82
+```
+
+### 1.4 Set Up Python Environment
+
+Ubuntu Touch uses a read-only root filesystem. Use Libertine containers or
+the writable home directory:
+
+```bash
+# Make the filesystem writable temporarily
+sudo mount -o remount,rw /
+
+# Install Python 3 and pip (if not already available)
+sudo apt update
+sudo apt install -y python3 python3-pip python3-venv git
+
+# Clone the project
+cd ~
+git clone https://github.com/geek95dg/Alfa156-headunit.git
+cd Alfa156-headunit
+
+# Create virtual environment
+python3 -m venv .venv
+source .venv/bin/activate
+
+# Install dependencies
+pip install -r requirements.txt -r requirements-redmi.txt
+```
+
+### 1.5 Run BCM in Desk Testing Mode
+
+```bash
+# Desk mode: all sensors simulated, demo data active
+./run_redmi.sh --desk
+```
+
+### 1.6 Access the Dashboard
+
+Open the phone's browser (Morph Browser on UT):
+- **Main display:** `http://localhost:5002`
+- **Small display:** `http://localhost:5003`
+
+Or from your PC on the same network:
+- `http://<phone-ip>:5002`
+- `http://<phone-ip>:5003`
+
+### 1.7 Phase 1 Test Checklist
+
+- [ ] `./run_redmi.sh --desk` starts without errors
+- [ ] `http://localhost:5002` loads in phone browser
+- [ ] Init screen → auto-transition to A1 Dashboard
+- [ ] All screens render: A1 (Dashboard), A2 (AA placeholder), A3 (Trip),
+      A4 (Weather), A5 (Service), A6 (DVR), A7 (Performance)
+- [ ] Theme switching works: Heritage / Modern / Autodelta
+- [ ] Language switching: PL ↔ EN
+- [ ] `http://localhost:5003` shows stats carousel (small display)
+- [ ] Press R key → reverse camera overlay appears
+- [ ] WebSocket data updates in real-time (gauges animate)
+- [ ] REST API responds: `curl http://localhost:5002/api/data`
+- [ ] Phone performance acceptable (no excessive lag)
+
+---
+
+## Phase 2: Audio Testing — Phone Speakers + Bluetooth
+
+**Goal:** Test audio routing through phone speakers, then Bluetooth.
+
+### 2.1 Audio via Phone Speakers
+
+BCM uses PipeWire/PulseAudio. On Ubuntu Touch, PulseAudio is the default
+audio server. Test with built-in speakers first:
+
+```bash
+# Verify PulseAudio is running
+pactl info
+
+# Test speaker output
+speaker-test -t wav -c 2 -l 1
+
+# Run BCM — audio should route to phone speaker
+./run_redmi.sh --desk
+```
+
+In the BCM web UI, test:
+- [ ] System notification sounds play
+- [ ] Volume control works (A1 dashboard)
+
+### 2.2 Bluetooth Audio (A2DP)
+
+Pair your phone with a Bluetooth speaker or car stereo (for desk testing):
+
+```bash
+# Scan for BT devices
+bluetoothctl scan on
+
+# Pair and connect
+bluetoothctl pair XX:XX:XX:XX:XX:XX
+bluetoothctl connect XX:XX:XX:XX:XX:XX
+```
+
+Test in BCM:
+- [ ] BT device appears in Settings screen
+- [ ] Music playback info shows on A1 (artist, title)
+- [ ] Audio streams to BT speaker
+
+### 2.3 Phase 2 Test Checklist
+
+- [ ] PulseAudio detected and working
+- [ ] Phone speaker outputs audio
+- [ ] Bluetooth pairing works from BCM Settings
+- [ ] A2DP streaming works
+- [ ] Volume control adjusts output level
+
+---
+
+## Phase 3: USB-C OTG Hub + External Hardware
+
+**Goal:** Connect USB accessories via OTG hub — USB-UART for OBD, cameras.
+
+### 3.1 USB-C OTG Hub Setup
+
+Connect a powered USB-C hub to the phone. See `docs/REDMI_USB_HUB.md` for
+recommended hubs and wiring.
+
+```bash
+# Verify USB devices are detected
+lsusb
+
+# Check serial devices
+ls -la /dev/ttyUSB*
+```
+
+### 3.2 OBD-II via USB-UART Adapter
+
+Connect a CP2102 or CH340 USB-UART adapter to the OTG hub:
+
+```bash
+# Verify adapter is detected
+dmesg | grep ttyUSB
+
+# The K-Line adapter should appear as /dev/ttyUSB1
+# (ttyUSB0 is reserved for sensor hub)
+```
+
+Update `config/bcm_config_redmi.yaml` if your port differs:
+```yaml
+serial:
+  kline:
+    port_redmi: /dev/ttyUSB1  # adjust to your adapter
+```
+
+Test OBD communication:
+```bash
+# Run with OBD module only
+./run_redmi.sh --modules obd,dashboard
+```
+
+- [ ] K-Line adapter detected as /dev/ttyUSBx
+- [ ] 5-baud initialization succeeds (in car only)
+- [ ] RPM, coolant temp, speed data appears on A1
+
+### 3.3 USB DAC (Audio Upgrade)
+
+Connect ES9038Q2M USB DAC to the OTG hub:
+
+```bash
+# Verify DAC is detected
+pactl list sinks short
+
+# Set as default sink
+pactl set-default-sink <dac-sink-name>
+```
+
+Update config:
+```yaml
+audio:
+  dac: ES9038Q2M  # change from 'builtin'
+```
+
+- [ ] USB DAC appears in PulseAudio sinks
+- [ ] Audio routes through DAC → amplifiers → speakers
+
+### 3.4 Camera / DVR
+
+Connect USB AHD grabber to the OTG hub:
+
+```bash
+# Check video devices
+v4l2-ctl --list-devices
+
+# Test capture
+ffmpeg -f v4l2 -i /dev/video0 -frames 1 test.jpg
+```
+
+- [ ] AHD grabber detected
+- [ ] Front camera captures frames
+- [ ] DVR recording starts (check recording path)
+
+### 3.5 Phase 3 Test Checklist
+
+- [ ] USB-C OTG hub recognized, all devices enumerated
+- [ ] At least 3 USB devices work simultaneously
+- [ ] USB-UART adapter works for OBD
+- [ ] USB DAC outputs audio (if connected)
+- [ ] Camera capture works (if connected)
+- [ ] No USB bandwidth issues or disconnects
+
+---
+
+## Phase 4: Arduino Sensor Hub + Full System
+
+**Goal:** Connect Arduino sensor hub for parking sensors, ignition detection,
+temperature, and relay control. Full system integration.
+
+### 4.1 Flash Arduino Sensor Hub Firmware
+
+The sensor hub Arduino handles all GPIO-dependent modules. Flash the firmware:
+
+```bash
+# From a PC with Arduino IDE
+# Open: arduino/sensor_hub/sensor_hub.ino
+# Board: Arduino Nano (or Pro Mini)
+# Upload
+```
+
+**Sensor hub Arduino wiring:**
+| Arduino Pin | Function | Connected To |
+|-------------|----------|--------------|
+| D2 | HC-SR04 TRIG (shared) | 4x sensor TRIG |
+| D3 | HC-SR04 ECHO 1 (LL) | Sensor 1 ECHO |
+| D4 | HC-SR04 ECHO 2 (CL) | Sensor 2 ECHO |
+| D5 | HC-SR04 ECHO 3 (CR) | Sensor 3 ECHO |
+| D6 | HC-SR04 ECHO 4 (RR) | Sensor 4 ECHO |
+| D7 | Buzzer | Piezo buzzer |
+| D8 | Ignition input | PC817 optoisolator |
+| D9 | Door input | PC817 optoisolator |
+| D10 | Rain sensor input | PC817 optoisolator |
+| D11 | Wiper relay output | Relay module |
+| D12 | Central lock input | PC817 optoisolator |
+| A0 | DS18B20 DATA | Temperature sensor |
+| USB | Serial 115200 baud | → USB-C OTG hub → Redmi |
+
+### 4.2 Connect and Test Sensor Hub
+
+```bash
+# Verify sensor hub appears
+ls -la /dev/ttyUSB0
+
+# Test communication
+python3 -c "
+import serial, json, time
+s = serial.Serial('/dev/ttyUSB0', 115200, timeout=1)
+time.sleep(2)
+while True:
+    line = s.readline().decode().strip()
+    if line:
+        print(json.loads(line))
+"
+```
+
+### 4.3 Run Full System
+
+```bash
+# Production mode (no --desk flag)
+./run_redmi.sh
+```
+
+### 4.4 Phase 4 Test Checklist
+
+- [ ] Sensor hub Arduino responds on /dev/ttyUSB0
+- [ ] Parking sensor distances update on small display
+- [ ] Buzzer sounds when distance < 0.5m
+- [ ] Temperature reading appears on A1
+- [ ] Ignition signal detected (in car)
+- [ ] Rain sensor triggers wiper relay (if connected)
+- [ ] Central lock Arduino on /dev/ttyUSB2 responds
+- [ ] Full system runs stable for 30+ minutes
+
+---
+
+## Phase 5: Car Installation
+
+**Goal:** Mount everything in the Alfa 156 and verify in-car operation.
+
+### 5.1 Mounting
+
+- Mount phone in DIN slot or custom bracket (landscape orientation)
+- Route USB-C OTG hub behind dashboard
+- Mount 4.3" second screen in instrument cluster area
+- Connect to car 12V via LM2596 (5.1V for USB hub power)
+
+### 5.2 Second Display Setup
+
+Connect 4.3" screen via USB-C to HDMI adapter (see `docs/REDMI_USB_HUB.md`):
+
+```bash
+# Open Chromium/Morph on second display
+# Point to small display server
+http://localhost:5003
+```
+
+### 5.3 In-Car Test Checklist
+
+- [ ] Phone powers on with ignition
+- [ ] BCM auto-starts (systemd service or UT app)
+- [ ] OBD reads real ECU data
+- [ ] Audio plays through car amplifiers
+- [ ] Parking sensors work during reverse
+- [ ] Camera switches on reverse gear
+- [ ] GPS acquires fix
+- [ ] Bluetooth pairs with driver's phone
+- [ ] Android Auto connects (wireless via WiFi AP)
+- [ ] System survives engine vibration
+- [ ] USB connections remain stable
+- [ ] Temperature doesn't cause throttling
+
+---
+
+## Auto-Start on Boot
+
+### Option A: Systemd User Service
+
+```bash
+mkdir -p ~/.config/systemd/user/
+
+cat > ~/.config/systemd/user/bcm.service << 'EOF'
+[Unit]
+Description=BCM v8.5 Alfa Romeo 156 Head Unit
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/Alfa156-headunit
+ExecStart=%h/Alfa156-headunit/run_redmi.sh
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+EOF
+
+systemctl --user enable bcm.service
+systemctl --user start bcm.service
+```
+
+### Option B: UT Autostart Script
+
+```bash
+mkdir -p ~/.config/autostart/
+cat > ~/.config/autostart/bcm.sh << 'EOF'
+#!/bin/bash
+sleep 10  # Wait for system to settle
+cd ~/Alfa156-headunit
+./run_redmi.sh &
+EOF
+chmod +x ~/.config/autostart/bcm.sh
+```
+
+---
+
+## Troubleshooting
+
+### USB OTG Not Working
+```bash
+# Check OTG mode
+cat /sys/class/typec/port0/data_role
+# Should show "host" — if "device", switch:
+echo host | sudo tee /sys/class/typec/port0/data_role
+```
+
+### Serial Devices Not Appearing
+```bash
+# Check kernel modules
+lsmod | grep -E "ch341|cp210x|ftdi"
+# If missing:
+sudo modprobe cp210x
+sudo modprobe ch341
+```
+
+### Audio Not Working
+```bash
+# Check PulseAudio
+pactl info
+pactl list sinks short
+
+# Restart PulseAudio
+pulseaudio --kill
+pulseaudio --start
+```
+
+### Phone Overheating
+The Helio G90T can throttle under sustained load. Mitigations:
+- Use a phone case with ventilation/heatsink
+- Reduce dashboard FPS in config (`display.dashboard.fps: 10`)
+- Disable modules you don't need
+- Ensure good airflow in the DIN slot
+
+### Permission Denied on /dev/ttyUSB*
+```bash
+# Add user to dialout group
+sudo usermod -aG dialout phablet
+# Or set permissions directly
+sudo chmod 666 /dev/ttyUSB*
+```
+
+### Web UI Slow / Laggy
+- Reduce animation complexity: use "Modern" theme (lightest)
+- Lower WebSocket update rate in config
+- Close other apps on the phone
+- Disable unused modules
+
+---
+
+## Performance Notes
+
+| Aspect | Redmi Note 8 Pro | Orange Pi 5 Plus |
+|--------|-----------------|------------------|
+| CPU | Helio G90T (2×A76 + 6×A55) | RK3588 (4×A76 + 4×A55) |
+| RAM | 6 GB | 8-16 GB |
+| GPU | Mali-G76 MC4 | Mali-G610 MP4 |
+| USB | 1× USB-C OTG | 1×USB3 + 2×USB2 + USB-C |
+| Display | 1× built-in 6.53" | 2× HDMI 2.1 |
+| GPIO | None (sensor hub) | 40-pin header |
+| Storage | 128 GB UFS 2.1 | 64 GB eMMC + NVMe |
+| WiFi | WiFi 5 (ac) | WiFi 6 (ax) |
+| BT | 5.0 | 5.0 |
+| GPS | Built-in | External USB module |
+| Cellular | Built-in 4G LTE | External USB modem |
+
+**Advantages of Redmi:** Built-in GPS, LTE, BT, mic, screen, battery.
+**Advantages of OPi:** Multiple USB ports, native GPIO, dual HDMI, more RAM.

--- a/docs/REDMI_SHOPPING_LIST.md
+++ b/docs/REDMI_SHOPPING_LIST.md
@@ -1,0 +1,175 @@
+# BCM v8.5 — Redmi Note 8 Pro — Shopping List & Prices
+
+## Overview
+
+This is the complete shopping list for building BCM v8.5 using a **Redmi Note 8 Pro**
+instead of the Orange Pi 5 Plus. The phone replaces the SBC, main display, GPS module,
+LTE modem, Bluetooth adapter, and one microphone — saving significant cost.
+
+**Prices are in PLN, estimated for Q1 2026.** Prices may vary by retailer.
+
+---
+
+## STAGE 1: Core System — Dashboard + Audio + OBD
+
+*Minimum viable system. Start here.*
+
+| # | Component | Model / Spec | Qty | Price (PLN) | Notes |
+|---|-----------|-------------|-----|-------------|-------|
+| 1 | Phone | **Redmi Note 8 Pro 6GB** (used, unlocked BL) | 1 | 300-500 | Codename: begonia. Must have unlocked bootloader |
+| 2 | USB-C OTG Hub | 7-in-1 with HDMI + PD charging | 1 | 80-150 | HDMI for 4.3" screen, PD for charging |
+| 3 | DC-DC Converter | LM2596 12V→5.1V 4A | 1 | 30-50 | Powers hub + phone via PD |
+| 4 | Fuses | 5A + 25A blade fuse | 2 | 10 | 5V line + 12V audio |
+| 5 | USB DAC | ES9038Q2M | 1 | 45-75 | 32-bit audio, RCA out |
+| 6 | Amplifier (main) | TDA7388 (4×45W) | 1 | 45-70 | 4-channel Class AB |
+| 7 | Heatsink | Aluminum (for TDA7388) | 1 | 10-15 | |
+| 8 | K-Line adapter | USB-UART CP2102 + L9637D + 510Ω | 1 | 25-40 | OBD-II communication |
+| 9 | Arduino (input) | Pro Micro ATmega32U4 | 1 | 40-60 | SWC buttons + LDR |
+| 10 | Optoisolators | PC817 | 3 | 6-9 | Ignition, door, reverse |
+| 11 | Resistors/transistors | BC547 + resistor kit | — | 15-20 | Pull-ups, dividers |
+| 12 | USB-C cable | Short (20-30cm) | 2 | 15-25 | Phone to hub, power to hub |
+| 13 | Cables + connectors | HDMI mini, USB-A, power | — | 40-60 | |
+| 14 | Phone mount | DIN bracket or 3D-printed | 1 | 20-50 | Landscape orientation |
+
+### Stage 1 Cost: **~680 — 1,125 PLN**
+
+**What you get:** Touchscreen dashboard with 8 screens (A1-A8), 3 themes,
+music via Bluetooth (built-in), OBD-II engine data, Android Auto via WiFi,
+built-in GPS, built-in LTE internet, voice control via built-in mic.
+
+> **Savings vs Orange Pi:** ~670-775 PLN less than OPi Stage 1 (1,350-1,900 PLN)
+> because the phone replaces: SBC (600-750), main display (400-600),
+> BT adapter (30-60), GPS module, LTE modem.
+
+---
+
+## STAGE 2: Cameras + Sensors + Second Screen
+
+*DVR, reverse camera, parking sensors, temperature, small display.*
+
+| # | Component | Model / Spec | Qty | Price (PLN) | Notes |
+|---|-----------|-------------|-----|-------------|-------|
+| 15 | Second screen | 4.3" TFT HDMI 800×480 | 1 | 150-250 | Stats carousel + reverse cam |
+| 16 | AHD Cameras | 720P front + rear | 2 | 200-400 | Waterproof, IR night vision |
+| 17 | Video grabber | USB3.0 4-ch AHD capture | 1 | 150-250 | Via OTG hub |
+| 18 | USB drive (DVR) | USB 3.0 128GB | 1 | 80-150 | Loop recording storage |
+| 19 | Sensor hub Arduino | Arduino Nano + CH340 | 1 | 20-35 | Handles all GPIO sensors |
+| 20 | Parking sensors | HC-SR04 ultrasonic | 4 | 60-80 | Connected to sensor hub |
+| 21 | Buzzer | Piezo 5V | 1 | 5-10 | Parking warning |
+| 22 | Temperature sensor | DS18B20 waterproof | 1 | 20-30 | Connected to sensor hub |
+| 23 | Optoisolators (extra) | PC817 | 3 | 6-9 | Rain, wiper, lock signals |
+| 24 | USB Microphone #2 | Mini/clip USB mic | 1 | 20-40 | Phone calls / AA (separate from built-in) |
+| 25 | Voltage dividers | 1kΩ + 2kΩ resistors | 4 sets | 8-12 | HC-SR04 echo 5V→3.3V |
+| 26 | Perfboard + headers | For sensor hub wiring | 1 | 10-15 | |
+
+### Stage 2 Cost: **~730 — 1,280 PLN**
+
+**What you get:** Dashcam (front + rear), reverse camera with parking overlay,
+4-zone parking sensors with buzzer, external temperature, small stats display,
+dedicated phone/AA microphone.
+
+---
+
+## STAGE 3: Connectivity + Subwoofer + Rain Sensor
+
+*Enhanced audio, weather, auto-wipers.*
+
+| # | Component | Model / Spec | Qty | Price (PLN) | Notes |
+|---|-----------|-------------|-----|-------------|-------|
+| 27 | Subwoofer amp | TDA2050 (40W mono) | 1 | 20-30 | Class AB, LP filter ~120Hz |
+| 28 | Heatsink (sub) | Aluminum | 1 | 5-10 | |
+| 29 | Rain sensor | Digital rain sensor module | 1 | 30-50 | Via optoisolator to sensor hub |
+| 30 | Wiper relay | 5V relay module | 1 | 8-12 | Wiper activation |
+
+### Stage 3 Cost: **~63 — 102 PLN**
+
+**What you get:** Subwoofer bass, auto-wipers on rain detection.
+
+> **Note:** GPS, LTE, and weather are **free** on Redmi — the phone has built-in
+> GPS and cellular data. No external modules needed (saves ~140-280 PLN vs OPi).
+
+---
+
+## STAGE 4: Central Lock + Alarm + Tracking
+
+*Smart lock, security system, battery backup.*
+
+| # | Component | Model / Spec | Qty | Price (PLN) | Notes |
+|---|-----------|-------------|-----|-------------|-------|
+| 31 | Arduino (lock) | Nano / Pro Mini | 1 | 20-30 | Central lock controller |
+| 32 | Relay module | 10-ch relay 5V | 1 | 40-60 | Lock, windows, trunk, lights |
+| 33 | RF receiver | RXB6 433MHz | 1 | 15-25 | Key fob receiver |
+| 34 | Siren | 12V piezo 120dB | 1 | 25-40 | Alarm output |
+| 35 | PIR sensor | HC-SR501 mini | 1 | 10-15 | Motion detection (cabin) |
+| 36 | Shock sensor | Piezo vibration sensor | 1 | 8-12 | Impact detection |
+| 37 | Accelerometer | MPU6050 6-axis | 1 | 15-30 | Tilt/tow detection |
+| 38 | Alarm LED | 5mm LED + resistor | 1 | 2-3 | Dashboard indicator |
+| 39 | Backup battery | Li-ion 18650 5000mAh | 1 | 20-30 | GPS tracking when off |
+| 40 | Charger + boost | TP4056 + MT3608 | 1 | 18-30 | 3.7V→5V conversion |
+| 41 | Power relay | Switching relay | 1 | 8-12 | Battery/car power switch |
+
+### Stage 4 Cost: **~180 — 285 PLN**
+
+**What you get:** Central lock with RF 433MHz key fob, window/trunk control,
+car alarm (motion + shock + tilt), follow-me-home lights, greeting blinks,
+GPS tracking for 30h on battery backup, crash detection with DVR protection.
+
+---
+
+## Cost Summary
+
+| Stage | What You Get | Min (PLN) | Max (PLN) | Cumulative |
+|-------|-------------|-----------|-----------|------------|
+| **1. Core** | Dashboard + Audio + OBD + AA + BT + GPS + LTE | 680 | 1,125 | 680 — 1,125 |
+| **2. Cameras** | DVR + Reverse + Parking + Temp + Small Screen | 730 | 1,280 | 1,410 — 2,405 |
+| **3. Audio+** | Subwoofer + Rain Sensor | 63 | 102 | 1,473 — 2,507 |
+| **4. Security** | Lock + Alarm + Tracking + Battery | 180 | 285 | 1,653 — 2,792 |
+
+### **TOTAL: ~1,650 — 2,800 PLN**
+
+---
+
+## Cost Comparison: Redmi vs Orange Pi
+
+| Component | Orange Pi Build | Redmi Build | Savings |
+|-----------|----------------|-------------|---------|
+| SBC / Phone | 600-750 (OPi 5+) | 300-500 (used Redmi) | 300-250 |
+| Main display (7") | 400-600 | 0 (built-in) | 400-600 |
+| BT adapter | 30-60 | 0 (built-in) | 30-60 |
+| GPS module | 40-80 | 0 (built-in) | 40-80 |
+| LTE modem | 100-200 | 0 (built-in) | 100-200 |
+| Microphone #1 | 30-50 | 0 (built-in) | 30-50 |
+| MOSFET backlight | 4-6 | 0 (phone handles) | 4-6 |
+| USB-C Hub w/HDMI | 0 (not needed) | 80-150 | -80 to -150 |
+| Sensor Hub Arduino | 0 (GPIO direct) | 20-35 | -20 to -35 |
+| **Total difference** | **2,480 — 3,840** | **1,650 — 2,800** | **~830 — 1,040 saved** |
+
+> **Bottom line:** The Redmi build saves approximately **830-1,040 PLN** compared
+> to the Orange Pi build, mainly because the phone integrates the display, GPS,
+> LTE, Bluetooth, and microphone.
+
+---
+
+## Where to Buy (Poland)
+
+| Retailer | Best For | URL |
+|----------|----------|-----|
+| Allegro | Used Redmi, sensors, Arduinos | allegro.pl |
+| Botland | Arduino, sensors, electronics | botland.com.pl |
+| Kamami | Electronic components, ICs | kamami.pl |
+| AliExpress | Bulk sensors, USB hubs, cameras | aliexpress.com |
+| Amazon.pl | USB-C hubs, displays, USB DAC | amazon.pl |
+| OLX | Used Redmi Note 8 Pro | olx.pl |
+| Nettigo | Arduino, breakout boards | nettigo.pl |
+
+---
+
+## Not Included in Prices
+
+- Car speakers (4× coaxial) — reuse existing or ~200-400 PLN
+- Subwoofer driver (1× 8") — ~100-200 PLN
+- Automotive wiring (12V cables, connectors) — ~50-100 PLN
+- DIN mounting bracket / 3D print — ~20-50 PLN
+- SIM card with data plan (for LTE) — use existing phone SIM
+- Key fob 433MHz transmitter — ~20-40 PLN each
+- Labor / installation time

--- a/docs/REDMI_USB_HUB.md
+++ b/docs/REDMI_USB_HUB.md
@@ -1,0 +1,302 @@
+# BCM v8.5 — USB-C Hub & Second Screen Guide (Redmi Note 8 Pro)
+
+## Overview
+
+The Redmi Note 8 Pro has a single USB-C port. To connect all BCM peripherals,
+you need a **powered USB-C OTG hub** with HDMI output for the second (4.3")
+display. Ubuntu Touch does **not support wireless display** (Miracast/WiDi),
+so the second screen **must be connected via cable** (USB-C to HDMI adapter
+or hub with HDMI port).
+
+---
+
+## Recommended USB-C Hub Configuration
+
+### Option A: All-in-One USB-C Hub (Recommended)
+
+A single hub that provides USB ports + HDMI + power delivery:
+
+```
+Redmi Note 8 Pro (USB-C)
+    │
+    └── USB-C Hub (powered)
+         ├── HDMI OUT ──────────→ 4.3" TFT Display (800×480)
+         ├── USB-A Port 1 ──────→ Arduino Sensor Hub (serial 115200)
+         ├── USB-A Port 2 ──────→ USB-UART CP2102 (K-Line OBD)
+         ├── USB-A Port 3 ──────→ ES9038Q2M USB DAC (audio)
+         ├── USB-A Port 4 ──────→ USB AHD Grabber (cameras)
+         ├── USB-A Port 5 ──────→ Arduino Central Lock (serial 9600)
+         ├── USB-A Port 6 ──────→ USB BT adapter (or use built-in)
+         ├── USB-A Port 7 ──────→ USB Microphone (Vosk voice)
+         └── USB-C PD IN ───────→ 5V/3A Power Supply (from LM2596)
+```
+
+**Recommended hubs:**
+
+| Hub Model | Ports | HDMI | PD | Price (PLN) |
+|-----------|-------|------|----|-------------|
+| Baseus 8-in-1 USB-C Hub | 3×USB3 + 1×USB2 | 4K@30Hz | 100W PD | 120-180 |
+| UGREEN 7-in-1 USB-C | 3×USB3 | 4K@30Hz | 100W PD | 100-150 |
+| MOKiN 9-in-1 USB-C | 2×USB3 + 2×USB2 | 4K@60Hz | 100W PD | 90-130 |
+| Generic 7-port USB-C Hub | 4×USB3 | 1080p | 60W PD | 60-100 |
+
+> **Important:** The hub MUST support **USB OTG mode** (host mode) and provide
+> external power to avoid draining the phone battery. PD (Power Delivery) input
+> on the hub keeps the phone charged while in use.
+
+### Option B: USB-C Hub + Separate HDMI Adapter
+
+If your hub doesn't have HDMI, use a separate USB-C to HDMI adapter:
+
+```
+Redmi Note 8 Pro (USB-C)
+    │
+    └── USB-C Splitter/Dock
+         ├── USB-C ──→ USB-C to HDMI Adapter ──→ 4.3" Display
+         └── USB-C ──→ Powered USB-A Hub (7+ ports)
+                        ├── Port 1: Sensor Hub Arduino
+                        ├── Port 2: USB-UART (K-Line)
+                        ├── Port 3: USB DAC
+                        ├── Port 4: AHD Grabber
+                        ├── Port 5: Central Lock Arduino
+                        ├── Port 6: Microphone
+                        └── Port 7: (spare)
+```
+
+### Option C: Minimum Desk Testing Setup
+
+For Phase 1-2 desk testing, you only need:
+
+```
+Redmi Note 8 Pro (USB-C)
+    │
+    └── Simple USB-C OTG Adapter (USB-C to USB-A female)
+         └── (optional) USB-UART for OBD testing
+```
+
+Cost: 15-30 PLN for a basic OTG adapter.
+
+---
+
+## Second Screen (4.3" Dashboard Display)
+
+### Why Cable Only?
+
+Ubuntu Touch on Redmi Note 8 Pro **does not support**:
+- Miracast / Wi-Fi Display
+- Chromecast protocol
+- Any wireless screen mirroring
+
+The only option is a **wired HDMI connection** through the USB-C hub.
+
+### Recommended 4.3" Displays
+
+| Display | Resolution | Input | Touch | Price (PLN) |
+|---------|-----------|-------|-------|-------------|
+| Waveshare 4.3" HDMI LCD | 800×480 | HDMI mini | No | 180-250 |
+| Elecrow 4.3" HDMI | 800×480 | HDMI | No | 150-200 |
+| Generic 4.3" TFT HDMI | 800×480 | HDMI | No | 100-150 |
+
+> The 4.3" display does NOT need touch — it's controlled by SWC and shows
+> only the stats carousel + reverse camera overlay.
+
+### HDMI Configuration
+
+The USB-C hub's HDMI output acts as an extended display. On Ubuntu Touch,
+configure it:
+
+```bash
+# Check connected displays
+xrandr --listmonitors
+
+# Set external display resolution
+xrandr --output HDMI-1 --mode 800x480 --right-of DSI-1
+
+# Or if using Wayland (default on UT):
+# The display should auto-configure
+```
+
+### Launching BCM on Both Screens
+
+```bash
+# Start BCM (serves both displays via web)
+./run_redmi.sh
+
+# Main display (phone screen): open in Morph Browser
+# URL: http://localhost:5002
+
+# Second display (4.3" HDMI): open Chromium in kiosk mode
+chromium-browser --kiosk --window-size=800,480 \
+    --app=http://localhost:5003
+```
+
+**Auto-launch on second screen:**
+
+```bash
+# Add to BCM startup script or systemd service
+# Wait for HDMI display to be detected, then launch browser
+while ! xrandr | grep -q "HDMI.*connected"; do sleep 2; done
+chromium-browser --kiosk --display=:0.1 \
+    --window-size=800,480 \
+    --app=http://localhost:5003 &
+```
+
+---
+
+## USB Device Port Assignment
+
+When multiple USB serial devices are connected, Linux assigns `/dev/ttyUSBx`
+in detection order (which can vary). Use **udev rules** for consistent naming:
+
+```bash
+# Create udev rules for persistent device names
+sudo cat > /etc/udev/rules.d/99-bcm-usb.rules << 'EOF'
+# Arduino Sensor Hub (e.g., Arduino Nano with CH340)
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", \
+    ATTRS{serial}=="SENSOR_HUB", SYMLINK+="bcm_sensor_hub"
+
+# USB-UART K-Line adapter (CP2102)
+SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", \
+    SYMLINK+="bcm_kline"
+
+# Arduino Central Lock (Pro Mini with FTDI)
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", \
+    SYMLINK+="bcm_central_lock"
+EOF
+
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+Then update `config/bcm_config_redmi.yaml`:
+```yaml
+serial:
+  kline:
+    port_redmi: /dev/bcm_kline
+  sensor_hub:
+    port: /dev/bcm_sensor_hub
+central_lock:
+  port: /dev/bcm_central_lock
+```
+
+---
+
+## Power Supply
+
+### In-Car Power Chain
+
+```
+Car Battery (12V)
+    │
+    ├── [25A fuse] ──→ TDA7388 amplifier (12V direct)
+    │                  TDA2050 subwoofer amp (12V direct)
+    │
+    └── [5A fuse] ──→ LM2596 DC-DC (12V → 5.1V, 4A)
+                       │
+                       └── USB-C PD input on hub
+                            │
+                            ├── Phone charging (5V/2A)
+                            └── USB devices power (5V total ~1.5A)
+```
+
+### Power Budget (5V rail)
+
+| Device | Current (mA) |
+|--------|-------------|
+| Redmi Note 8 Pro (charging) | ~1500 |
+| USB-C Hub overhead | ~100 |
+| Arduino Sensor Hub | ~50 |
+| USB-UART (CP2102) | ~30 |
+| USB DAC (ES9038Q2M) | ~200 |
+| AHD Grabber | ~500 |
+| Arduino Central Lock | ~50 |
+| USB Microphone | ~50 |
+| **Total** | **~2480** |
+
+> Use a **4A LM2596** or better — the phone's charging alone takes 1.5A.
+> A powered USB-C hub with its own power input is essential.
+
+### Power-On / Power-Off Sequence
+
+```
+Ignition ON  → 12V to LM2596 → Hub powers up → Phone wakes → BCM auto-starts
+Ignition OFF → Sensor hub detects (optoisolator) → BCM shutdown sequence
+             → 30s delay → Phone sleeps → LM2596 stays powered (standby)
+```
+
+---
+
+## USB Bandwidth Considerations
+
+USB-C on Redmi Note 8 Pro supports **USB 2.0** (480 Mbps). With all devices
+connected through one hub, bandwidth allocation matters:
+
+| Device | Bandwidth | Type |
+|--------|-----------|------|
+| AHD Grabber (720p) | ~50 Mbps | Isochronous |
+| USB DAC (48kHz/16bit) | ~1.5 Mbps | Isochronous |
+| Serial devices (3×) | ~0.3 Mbps | Bulk |
+| USB Microphone | ~1.5 Mbps | Isochronous |
+| **Total** | **~53 Mbps** | |
+
+This is well within USB 2.0 limits (480 Mbps). However, isochronous
+transfers (audio, video) get priority. If you experience USB glitches:
+
+1. Use a hub with **TT (Transaction Translator)** — most modern hubs have this
+2. Move the AHD grabber to a direct USB-C port if possible
+3. Reduce camera resolution to 480p
+4. Ensure the hub has its own power supply (not bus-powered)
+
+---
+
+## Wiring Diagram (Car Installation)
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  REDMI NOTE 8 PRO                   │
+│               (mounted in DIN slot)                 │
+│                                                     │
+│  USB-C ──────→ USB-C Hub (behind dashboard)         │
+│                 │                                   │
+│  Built-in:      │   ┌─ HDMI ──→ 4.3" Display       │
+│  - GPS          │   ├─ USB1 ──→ Sensor Hub Arduino  │
+│  - LTE          │   ├─ USB2 ──→ CP2102 (K-Line)    │
+│  - Bluetooth    │   ├─ USB3 ──→ USB DAC             │
+│  - WiFi         │   ├─ USB4 ──→ AHD Grabber         │
+│  - Mic          │   ├─ USB5 ──→ Central Lock Arduino│
+│  - Screen       │   ├─ USB6 ──→ USB Mic (Vosk)     │
+│  - Battery      │   └─ PD IN ←─ 5V/4A (LM2596)    │
+└─────────────────────────────────────────────────────┘
+
+                        Sensor Hub Arduino
+                        ├── HC-SR04 ×4 (parking)
+                        ├── Piezo buzzer
+                        ├── DS18B20 (temperature)
+                        ├── PC817 ×4 (ignition, door, rain, lock)
+                        └── Relay (wiper)
+
+                        Central Lock Arduino
+                        ├── Relay module ×8
+                        ├── RXB6 433MHz receiver
+                        └── LED alarm
+```
+
+---
+
+## Comparison: Cable Options for Second Screen
+
+| Method | Works on UT? | Quality | Latency | Cost |
+|--------|-------------|---------|---------|------|
+| USB-C Hub with HDMI | YES | 800×480 native | <1ms | Included in hub |
+| USB-C to HDMI adapter | YES | 800×480 native | <1ms | 40-80 PLN |
+| Miracast / Wi-Fi Display | NO | N/A | N/A | N/A |
+| Chromecast | NO | N/A | N/A | N/A |
+| VNC / remote desktop | Possible but laggy | Low | 50-200ms | Free |
+| Second phone via WiFi | YES (web viewer) | Good | 10-50ms | Free if you have one |
+
+**Recommended:** USB-C hub with built-in HDMI port (Option A).
+
+**Alternative:** If you have a spare phone/tablet, use it as the 4.3" display
+by simply opening `http://<redmi-ip>:5003` in its browser. This requires no
+cable and works well for the stats carousel. However, the reverse camera
+feed may have 50-100ms additional latency over WiFi.

--- a/main.py
+++ b/main.py
@@ -77,7 +77,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--platform",
-        choices=["x86", "opi", "auto"],
+        choices=["x86", "opi", "redmi", "auto"],
         default="auto",
         help="Target platform (default: auto-detect)",
     )
@@ -273,14 +273,15 @@ def main() -> None:
         # Always start demo data generators on x86
         demo = None
         demo_media = None
-        if config.platform == "x86":
+        if config.platform in ("x86", "redmi"):
             from src.dashboard.renderer import DemoDataGenerator
             from src.multimedia.bluetooth import DemoMediaGenerator
             demo = DemoDataGenerator(event_bus)
             demo.start()
             demo_media = DemoMediaGenerator(event_bus)
             demo_media.start()
-            log.info("Demo data generators started (OBD + Media)")
+            log.info("Demo data generators started (OBD + Media) "
+                     "[platform=%s]", config.platform)
 
         if args.frontend:
             # HTML5/Tailwind frontend mode — no Pygame needed

--- a/requirements-redmi.txt
+++ b/requirements-redmi.txt
@@ -1,0 +1,31 @@
+# BCM v8.5 — Redmi Note 8 Pro (Ubuntu Touch) dependencies
+#
+# Install: pip install -r requirements.txt -r requirements-redmi.txt -r requirements-x86.txt
+#
+# On Ubuntu Touch, some packages may need to be installed via apt in a
+# Libertine container or via the UT package manager.
+
+# Serial communication (K-Line OBD via USB-UART, sensor hub Arduino)
+pyserial>=3.5
+
+# Web frontend (same as x86 — phone runs the Flask web viewer)
+flask>=3.0
+flask-sock>=0.7
+simple-websocket>=1.0
+
+# Image processing (dashcam thumbnails, camera)
+Pillow>=10.0
+
+# OpenCV for camera capture (headless — no GUI needed)
+opencv-python-headless>=4.8
+
+# Config
+PyYAML>=6.0
+
+# Note: On Ubuntu Touch, the following are typically available system-wide:
+# - PipeWire / PulseAudio (audio)
+# - BlueZ (Bluetooth)
+# - GStreamer (camera/DVR)
+# - NetworkManager (WiFi AP, LTE)
+#
+# No gpiod/spidev/smbus2 needed — GPIO is handled via Arduino sensor hub.

--- a/run_redmi.sh
+++ b/run_redmi.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# BCM v8.5 — Alfa Romeo 156 Head Unit — Redmi Note 8 Pro (Ubuntu Touch) launcher
+#
+# This script launches BCM on a Redmi Note 8 Pro running Ubuntu Touch.
+# The phone acts as the main 7" touchscreen display, with all GPIO-dependent
+# modules offloaded to an Arduino sensor hub via USB-C OTG.
+#
+# Usage:
+#   ./run_redmi.sh                     # Full system (HTML5 frontend)
+#   ./run_redmi.sh --desk              # Desk testing (no sensor hub needed)
+#   ./run_redmi.sh --modules obd,dashboard  # Specific modules only
+#   ./run_redmi.sh --headless          # Backend only, web viewer on :5002
+#
+# Prerequisites:
+#   - Ubuntu Touch installed on Redmi Note 8 Pro (begonia)
+#   - Libertine container or native Python 3 environment
+#   - USB-C OTG hub connected (for production use)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# ── Detect environment ──────────────────────────────────────────────────────
+
+# Check if running on Ubuntu Touch
+IS_UT=false
+if [ -d "/etc/ubuntu-touch-session.d" ] || [ -d "/android/data" ]; then
+    IS_UT=true
+fi
+
+# Activate venv if present
+if [ -f ".venv/bin/activate" ]; then
+    # shellcheck disable=SC1091
+    source .venv/bin/activate
+    echo "[run_redmi] Using venv: $(which python3)"
+elif command -v python3 &>/dev/null; then
+    echo "[run_redmi] Using system python3: $(which python3)"
+else
+    echo "[run_redmi] ERROR: Python 3 not found"
+    exit 1
+fi
+
+# ── Parse arguments ─────────────────────────────────────────────────────────
+
+MODE="frontend"
+DESK_MODE=false
+PASSTHROUGH_ARGS=()
+
+for arg in "$@"; do
+    case "$arg" in
+        --desk)
+            DESK_MODE=true
+            ;;
+        --headless)
+            MODE="headless"
+            ;;
+        *)
+            PASSTHROUGH_ARGS+=("$arg")
+            ;;
+    esac
+done
+
+# Build argument list
+ARGS=("--platform" "redmi" "--frontend")
+ARGS+=("--config" "config/bcm_config_redmi.yaml")
+
+if [ "$MODE" = "headless" ]; then
+    ARGS+=("--headless")
+fi
+
+ARGS+=("${PASSTHROUGH_ARGS[@]}")
+
+# ── Environment variables for Ubuntu Touch ──────────────────────────────────
+
+if [ "$IS_UT" = true ]; then
+    # Ubuntu Touch Halium environment
+    export UBUNTU_TOUCH=1
+    # PulseAudio socket on UT
+    export PULSE_SERVER="unix:/run/user/$(id -u)/pulse/native"
+fi
+
+# ── Clean shutdown ──────────────────────────────────────────────────────────
+
+cleanup() {
+    echo ""
+    echo "[run_redmi] Shutting down..."
+    if [ -n "${PID:-}" ]; then
+        kill -TERM "$PID" 2>/dev/null || true
+        wait "$PID" 2>/dev/null || true
+    fi
+    echo "[run_redmi] Stopped."
+}
+trap cleanup SIGTERM SIGINT
+
+# ── Banner ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "  ╔══════════════════════════════════════════════════╗"
+echo "  ║   BCM v8.5 — Alfa Romeo 156 Head Unit           ║"
+echo "  ║   Platform: Redmi Note 8 Pro (Ubuntu Touch)      ║"
+echo "  ╠══════════════════════════════════════════════════╣"
+
+if [ "$DESK_MODE" = true ]; then
+    echo "  ║   Mode: DESK TESTING (no sensor hub required)    ║"
+    echo "  ║   Demo data generators active                    ║"
+else
+    echo "  ║   Mode: Production / Car Install                 ║"
+    echo "  ║   Sensor hub: Arduino via USB-C OTG              ║"
+fi
+
+echo "  ║                                                  ║"
+echo "  ║   Main display: http://localhost:5002             ║"
+echo "  ║   Small display: http://localhost:5003            ║"
+echo "  ║                                                  ║"
+echo "  ║   Phone screen = 7\" touch (A1-A8 + Settings)     ║"
+echo "  ║   Second screen via USB-C HDMI adapter (4.3\")    ║"
+echo "  ╚══════════════════════════════════════════════════╝"
+echo ""
+
+if [ "$IS_UT" = true ]; then
+    echo "[run_redmi] Running on Ubuntu Touch (Halium)"
+else
+    echo "[run_redmi] Not on Ubuntu Touch — using simulation mode"
+fi
+
+if [ "$DESK_MODE" = true ]; then
+    echo "[run_redmi] Desk testing mode — all sensors simulated"
+fi
+
+echo "[run_redmi] Starting BCM..."
+echo ""
+
+python3 main.py "${ARGS[@]}" &
+PID=$!
+wait "$PID"

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -13,11 +13,43 @@ DEFAULT_CONFIG_PATH = Path(__file__).resolve().parent.parent.parent / "config" /
 
 
 def _detect_platform() -> str:
-    """Detect whether we're running on x86 or Orange Pi (arm64)."""
+    """Detect whether we're running on x86, Orange Pi, or Redmi (Ubuntu Touch).
+
+    Detection order:
+      1. Check for Ubuntu Touch marker (/etc/ubuntu-touch-session.d or UBUNTU_TOUCH env)
+      2. Check for Redmi Note 8 Pro (begonia) device tree
+      3. Generic ARM64 → opi
+      4. Fallback → x86
+    """
     machine = platform.machine().lower()
     if machine in ("aarch64", "armv7l", "armv8l"):
+        # Check for Ubuntu Touch / Redmi environment
+        if (os.environ.get("UBUNTU_TOUCH") == "1"
+                or os.path.exists("/etc/ubuntu-touch-session.d")
+                or os.path.exists("/android/data")  # Halium-based UT
+                or _is_redmi_device()):
+            return "redmi"
         return "opi"
     return "x86"
+
+
+def _is_redmi_device() -> bool:
+    """Check if running on Redmi Note 8 Pro (begonia) via device tree."""
+    try:
+        dt_model = Path("/proc/device-tree/model")
+        if dt_model.exists():
+            model = dt_model.read_text().lower()
+            if "begonia" in model or "redmi" in model:
+                return True
+        # Halium: check Android props
+        prop_file = Path("/android/system/build.prop")
+        if prop_file.exists():
+            props = prop_file.read_text().lower()
+            if "begonia" in props or "redmi note 8 pro" in props:
+                return True
+    except Exception:
+        pass
+    return False
 
 
 def _deep_merge(base: dict, override: dict) -> dict:

--- a/src/core/hal.py
+++ b/src/core/hal.py
@@ -268,11 +268,197 @@ class RealOneWire:
 
 
 # ---------------------------------------------------------------------------
+# Redmi / Ubuntu Touch implementations
+# ---------------------------------------------------------------------------
+
+class RedmiSensorHubGPIO:
+    """GPIO proxy via Arduino sensor hub over USB serial.
+
+    On Redmi Note 8 Pro (Ubuntu Touch), there is no GPIO header.
+    All GPIO-dependent sensors (parking, ignition, rain, etc.) are
+    offloaded to an Arduino Nano/ESP32 "sensor hub" connected via
+    USB-C OTG hub. The Arduino reads sensors and relays and
+    communicates via JSON over serial.
+
+    Wire protocol (newline-delimited JSON):
+        BCM → Arduino: {"cmd":"write","pin":84,"val":1}
+        BCM → Arduino: {"cmd":"read","pin":85}
+        Arduino → BCM: {"pin":85,"val":1}
+        Arduino → BCM: {"type":"parking","distances":[0.5,1.2,1.8,2.5]}
+        Arduino → BCM: {"type":"ignition","val":1}
+    """
+
+    def __init__(self, pin: int, direction: str = "in",
+                 hub: Optional[Any] = None):
+        self.pin = pin
+        self.direction = direction
+        self._value = 0
+        self._hub = hub  # Reference to shared SensorHubSerial instance
+        log.debug("RedmiSensorHubGPIO pin %d configured as %s (via USB hub)",
+                  pin, direction)
+
+    def read(self) -> int:
+        if self._hub:
+            return self._hub.read_pin(self.pin)
+        return self._value
+
+    def write(self, value: int) -> None:
+        self._value = value
+        if self._hub:
+            self._hub.write_pin(self.pin, value)
+        log.debug("RedmiSensorHubGPIO pin %d -> %d", self.pin, value)
+
+    def set_mock_value(self, value: int) -> None:
+        """Allow simulators to inject values (desk testing without hub)."""
+        self._value = value
+
+
+class SensorHubSerial:
+    """Manages serial connection to Arduino sensor hub for Redmi platform.
+
+    The sensor hub Arduino handles:
+    - HC-SR04 parking sensors (4x)
+    - Parking buzzer
+    - Ignition/door/rain optoisolated inputs
+    - Wiper relay output
+    - DS18B20 temperature (via Arduino 1-Wire)
+    - PWM backlight (if external display used)
+
+    All data exchanged as newline-delimited JSON at 115200 baud.
+    """
+
+    def __init__(self, port: str = "/dev/ttyUSB0", baudrate: int = 115200):
+        self.port = port
+        self.baudrate = baudrate
+        self._serial = None
+        self._pin_values: dict[int, int] = {}
+        self._temperature: Optional[float] = None
+        self._distances: list[float] = [2.5, 2.5, 2.5, 2.5]
+        self._lock = __import__("threading").Lock()
+        self._running = False
+        self._thread: Optional[Any] = None
+        log.info("SensorHub initialized: %s @ %d baud", port, baudrate)
+        self._connect()
+
+    def _connect(self) -> None:
+        """Attempt to open serial connection to sensor hub."""
+        try:
+            import serial  # type: ignore
+            self._serial = serial.Serial(
+                self.port, self.baudrate, timeout=0.1
+            )
+            log.info("SensorHub connected: %s", self.port)
+        except Exception as e:
+            log.warning("SensorHub not available (%s) — running in "
+                        "simulation mode", e)
+            self._serial = None
+
+    def read_pin(self, pin: int) -> int:
+        with self._lock:
+            return self._pin_values.get(pin, 0)
+
+    def write_pin(self, pin: int, value: int) -> None:
+        with self._lock:
+            self._pin_values[pin] = value
+        if self._serial:
+            import json
+            cmd = json.dumps({"cmd": "write", "pin": pin, "val": value})
+            try:
+                self._serial.write((cmd + "\n").encode())
+            except Exception:
+                log.warning("SensorHub write failed for pin %d", pin)
+
+    @property
+    def temperature(self) -> Optional[float]:
+        with self._lock:
+            return self._temperature
+
+    @property
+    def distances(self) -> list[float]:
+        with self._lock:
+            return list(self._distances)
+
+    def start_listener(self) -> None:
+        """Start background thread that reads sensor hub data."""
+        if self._running or not self._serial:
+            return
+        self._running = True
+        self._thread = __import__("threading").Thread(
+            target=self._listen_loop, daemon=True
+        )
+        self._thread.start()
+        log.info("SensorHub listener started")
+
+    def stop(self) -> None:
+        self._running = False
+        if self._thread:
+            self._thread.join(timeout=2)
+        if self._serial:
+            self._serial.close()
+
+    def _listen_loop(self) -> None:
+        """Read JSON lines from sensor hub and update pin values."""
+        import json
+        while self._running and self._serial:
+            try:
+                line = self._serial.readline().decode("utf-8", errors="replace").strip()
+                if not line:
+                    continue
+                data = json.loads(line)
+                with self._lock:
+                    if "pin" in data and "val" in data:
+                        self._pin_values[data["pin"]] = data["val"]
+                    if data.get("type") == "parking":
+                        self._distances = data.get("distances", self._distances)
+                    if data.get("type") == "temperature":
+                        self._temperature = data.get("value")
+            except Exception:
+                pass  # Malformed line, skip
+
+
+class RedmiOneWire:
+    """1-Wire proxy via Arduino sensor hub for Redmi platform.
+
+    DS18B20 temperature sensor is connected to the Arduino sensor hub
+    (since Redmi has no GPIO). The hub reports temperature via JSON serial.
+    Falls back to mock if hub not available.
+    """
+
+    def __init__(self, sensor_hub: Optional[SensorHubSerial] = None):
+        self._hub = sensor_hub
+        self._mock_devices: dict[str, float] = {}
+        log.debug("RedmiOneWire initialized (hub=%s)",
+                  "connected" if sensor_hub else "mock")
+
+    def add_device(self, device_id: str, initial_value: float = 20.0) -> None:
+        self._mock_devices[device_id] = initial_value
+
+    def list_devices(self) -> list[str]:
+        if self._hub and self._hub.temperature is not None:
+            return ["28-redmi-hub"]
+        return list(self._mock_devices.keys())
+
+    def read_temperature(self, device_id: str) -> Optional[float]:
+        if self._hub and device_id == "28-redmi-hub":
+            return self._hub.temperature
+        return self._mock_devices.get(device_id)
+
+    def set_mock_temperature(self, device_id: str, temp: float) -> None:
+        self._mock_devices[device_id] = temp
+
+
+# ---------------------------------------------------------------------------
 # HAL factory
 # ---------------------------------------------------------------------------
 
 class HAL:
     """Hardware Abstraction Layer — factory for platform-appropriate drivers.
+
+    Supported platforms:
+        - "x86"   — Mock drivers for development/testing
+        - "opi"   — Real GPIO/UART/SPI/I2C via libgpiod/pyserial on Orange Pi
+        - "redmi" — USB-serial sensor hub + native phone hardware on
+                     Redmi Note 8 Pro with Ubuntu Touch
 
     Usage:
         hal = HAL(platform="x86")
@@ -285,21 +471,41 @@ class HAL:
 
     def __init__(self, platform: str = "x86"):
         self.platform = platform
+        self._sensor_hub: Optional[SensorHubSerial] = None
+
+        # On Redmi, initialize the sensor hub (Arduino via USB serial)
+        if platform == "redmi":
+            hub_port = "/dev/ttyUSB0"
+            try:
+                self._sensor_hub = SensorHubSerial(port=hub_port)
+                self._sensor_hub.start_listener()
+            except Exception as e:
+                log.warning("Sensor hub init failed (%s) — GPIO will use "
+                            "mock values", e)
+
         log.info("HAL initialized for platform: %s", platform)
+
+    @property
+    def sensor_hub(self) -> Optional[SensorHubSerial]:
+        """Access the sensor hub (Redmi only, None on other platforms)."""
+        return self._sensor_hub
 
     def gpio(self, pin: int, direction: str = "in") -> Any:
         if self.platform == "opi":
             return RealGPIOPin(pin, direction)
+        if self.platform == "redmi":
+            return RedmiSensorHubGPIO(pin, direction, hub=self._sensor_hub)
         return MockGPIOPin(pin, direction)
 
     def uart(self, port: str, baudrate: int = 9600) -> Any:
-        if self.platform == "opi":
+        if self.platform in ("opi", "redmi"):
             return RealUART(port, baudrate)
         return MockUART(port, baudrate)
 
     def pwm(self, pin: int, frequency: int = 1000) -> Any:
         # Real PWM on OPi would use sysfs or a dedicated library
-        # For now, mock on both platforms (real PWM added in Part 10)
+        # On Redmi: backlight is handled by phone OS, external display
+        # PWM via sensor hub Arduino
         return MockPWM(pin, frequency)
 
     def spi(self, bus: int = 0, device: int = 0) -> Any:
@@ -315,4 +521,11 @@ class HAL:
     def onewire(self) -> Any:
         if self.platform == "opi":
             return RealOneWire()
+        if self.platform == "redmi":
+            return RedmiOneWire(sensor_hub=self._sensor_hub)
         return MockOneWire()
+
+    def shutdown(self) -> None:
+        """Clean up HAL resources."""
+        if self._sensor_hub:
+            self._sensor_hub.stop()


### PR DESCRIPTION
- Add "redmi" platform to HAL with SensorHubSerial (Arduino GPIO proxy over USB serial), RedmiSensorHubGPIO, and RedmiOneWire classes
- Auto-detect Ubuntu Touch / Halium / begonia device in config.py
- Add --platform redmi CLI option in main.py
- Create run_redmi.sh launcher with --desk mode for testing
- Create bcm_config_redmi.yaml with phone-specific defaults (built-in GPS/BT/LTE, USB-UART for K-Line, sensor hub ports)
- Create requirements-redmi.txt (no gpiod/spidev needed)
- Add docs: REDMI_SETUP.md (5-phase testing guide), REDMI_USB_HUB.md (USB-C hub wiring and second screen via HDMI), REDMI_SHOPPING_LIST.md (4-stage BOM with prices, ~1650-2800 PLN)

https://claude.ai/code/session_01PgaWsDvQrFHK2pP46qFcut