### PR TITLE
Fix: run Android Auto inside matchbox-window-manager for auto-maximize

### DIFF
--- a/docs/OPI5PRO_SETUP.md
+++ b/docs/OPI5PRO_SETUP.md
@@ -41,9 +41,17 @@ sudo apt install -y \
   v4l-utils ffmpeg \
   gstreamer1.0-tools gstreamer1.0-plugins-good \
   gstreamer1.0-plugins-bad gstreamer1.0-rockchip1 \
+  xdotool matchbox-window-manager \
   usb-modeswitch \
   i2c-tools
 ```
+
+> **Important:** `matchbox-window-manager` is what makes Android Auto
+> fill the whole screen. BCM launches it inside the Xvfb / :0 display
+> before starting autoapp so every Qt window is forced to maximize.
+> Without it, OpenAuto opens at its internal default of ~800×480 and
+> leaves a black strip on the right, which also breaks touch
+> coordinate mapping. `xdotool` is the secondary fallback.
 
 ## 3. Clone BCM + create venv
 

--- a/docs/OPI_PC_SETUP.md
+++ b/docs/OPI_PC_SETUP.md
@@ -65,6 +65,7 @@ sudo apt install -y \
   pipewire pipewire-alsa wireplumber \
   bluez blueman \
   v4l-utils ffmpeg \
+  xdotool matchbox-window-manager \
   usb-modeswitch \
   i2c-tools
 ```

--- a/src/multimedia/openauto.py
+++ b/src/multimedia/openauto.py
@@ -136,6 +136,7 @@ class OpenAutoController:
         self._binary = _find_openauto()
         self._process: Optional[subprocess.Popen] = None
         self._xvfb_process: Optional[subprocess.Popen] = None
+        self._wm_process: Optional[subprocess.Popen] = None
         self._running = False
         self._monitor_thread: Optional[threading.Thread] = None
         self._log_thread: Optional[threading.Thread] = None
@@ -188,6 +189,11 @@ class OpenAutoController:
             env["DISPLAY"] = ":0"
             env["SDL_VIDEODRIVER"] = "kmsdrm"
             log.info("OPi display config: DISPLAY=:0, SDL_VIDEODRIVER=kmsdrm")
+            # On a real OPi the framebuffer usually doesn't have a WM
+            # either (bcm-kiosk runs Chromium directly via Xorg). Start
+            # a matchbox-window-manager on :0 so the autoapp window is
+            # forced fullscreen, same trick as the x86 Xvfb path.
+            self._start_window_manager(":0")
         else:
             # On x86: render to Xvfb virtual display for browser streaming
             if not env.get("DISPLAY"):
@@ -362,6 +368,61 @@ class OpenAutoController:
                     log.debug("windowsize failed: %s", e)
             time.sleep(0.5)
 
+    def _start_window_manager(self, display: str) -> None:
+        """Launch a minimal WM inside Xvfb so every window auto-maximises.
+
+        Tries candidates in order of preference:
+          1. matchbox-window-manager — tiny, kiosk-friendly, always-fullscreen
+          2. openbox — slightly heavier but widely available
+          3. twm — ancient fallback, ships with X.org
+
+        Each candidate is launched non-blocking; if none are available
+        the worker falls back to the xdotool windowsize trick in
+        _force_fullscreen_window(). Logs a warning but never raises.
+        """
+        if self._wm_process and self._wm_process.poll() is None:
+            return
+
+        env = {**os.environ, "DISPLAY": display}
+        candidates = [
+            ["matchbox-window-manager", "-use_titlebar", "no",
+             "-use_cursor", "no"],
+            ["openbox"],
+            ["twm"],
+        ]
+        for cmd in candidates:
+            try:
+                self._wm_process = subprocess.Popen(
+                    cmd, env=env,
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                )
+                time.sleep(0.3)
+                if self._wm_process.poll() is None:
+                    log.info("Window manager running inside %s: %s",
+                             display, cmd[0])
+                    return
+            except FileNotFoundError:
+                continue
+            except Exception as e:
+                log.debug("WM candidate %s failed: %s", cmd[0], e)
+                continue
+
+        log.warning(
+            "No window manager found inside Xvfb — install "
+            "`matchbox-window-manager` (apt) for best results. Falling "
+            "back to xdotool windowsize which is less reliable."
+        )
+        self._wm_process = None
+
+    def _stop_window_manager(self) -> None:
+        if self._wm_process and self._wm_process.poll() is None:
+            self._wm_process.terminate()
+            try:
+                self._wm_process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self._wm_process.kill()
+            self._wm_process = None
+
     def _start_xvfb(self) -> Optional[str]:
         """Start Xvfb virtual framebuffer for AA rendering."""
         if self._xvfb_process and self._xvfb_process.poll() is None:
@@ -391,6 +452,15 @@ class OpenAutoController:
                 log.error("Xvfb exited immediately: %s", stderr)
                 return None
             log.info("Xvfb started on %s (%dx%d)", display_num, width, height)
+
+            # Launch a minimal window manager inside Xvfb so that every
+            # top-level window created by openauto/autoapp is forced to
+            # maximize to the full canvas. Without a WM, Qt apps open at
+            # their internal default size (typically 800x480) leaving a
+            # black strip on the right and breaking touch coordinate
+            # mapping.
+            self._start_window_manager(display_num)
+
             return display_num
         except FileNotFoundError:
             log.warning("Xvfb not installed")
@@ -436,7 +506,8 @@ class OpenAutoController:
             log.debug("Xvfb stale cleanup: %s", e)
 
     def _stop_xvfb(self) -> None:
-        """Stop Xvfb."""
+        """Stop Xvfb and any window manager we launched inside it."""
+        self._stop_window_manager()
         if self._xvfb_process and self._xvfb_process.poll() is None:
             self._xvfb_process.terminate()
             try:


### PR DESCRIPTION
The xdotool windowsize approach wasn't reliable — autoapp/Qt would keep resetting its geometry, so the window kept coming up at 800x480 with black space on the right and touch coordinates landing outside the AA canvas.

Proper fix: launch a minimal window manager *inside* the same X display autoapp renders into. Every top-level window spawned on that display then auto-maximizes to the full canvas with no per-app cooperation required.

Implementation:
- New _start_window_manager(display) helper that tries matchbox- window-manager, openbox, and twm in that order and keeps the first one that actually starts. matchbox-window-manager is preferred because it's ~50 KB, draws no titlebars, and always forces new windows to fullscreen — exactly the "window block" behaviour we need.
- Invoked after Xvfb starts (x86) and just before autoapp launch on OPi (DISPLAY=:0), so both code paths benefit.
- _stop_window_manager() called from _stop_xvfb() for clean teardown.
- If no WM is installed, xdotool windowsize (previous commit) still runs as a fallback and a log warning points the user at the apt package.

Docs:
- OPI5PRO_SETUP.md and OPI_PC_SETUP.md add matchbox-window-manager and xdotool to the apt install line. OPi5Pro guide calls out why the package is important for AA fullscreen and touch.

https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf