### PR TITLE
Fix: AA canvas exactly matches content-area, no header/nav overlap

### DIFF
--- a/src/dashboard/web/js/screens/android_auto.js
+++ b/src/dashboard/web/js/screens/android_auto.js
@@ -43,12 +43,11 @@ App.registerScreen("a2", (() => {
             ${AppBar.render(theme, data)}
             <main class="content-area relative overflow-hidden bg-black">
                 ${statusBadge}
-                <!-- AA Stream — fills content area between header and nav.
-                     object-cover prevents the letterboxed right/bottom
-                     black bars that appeared with the previous object-fill
-                     when the AA canvas aspect didn't match the panel. -->
+                <!-- AA Stream — Xvfb renders at exactly the content-area
+                     size (dashboard height − AppBar − NavBar) so
+                     object-fill maps it 1:1 without cropping or letterbox. -->
                 <img id="aa-stream" src="/aa/stream" alt=""
-                     class="absolute inset-0 w-full h-full object-cover z-0"
+                     class="absolute inset-0 w-full h-full object-fill z-0"
                      style="display:none;"
                      onload="this.style.display='block';document.getElementById('aa-placeholder').style.display='none';document.getElementById('aa-touch-overlay').style.display='block';"
                      onerror="this.style.display='none';document.getElementById('aa-placeholder').style.display='flex';document.getElementById('aa-touch-overlay').style.display='none';">

--- a/src/dashboard/web_viewer.py
+++ b/src/dashboard/web_viewer.py
@@ -388,11 +388,24 @@ class WebViewer:
 
         # --- Android Auto — direct Xvfb MJPEG stream (no port 5001) ---
 
+        def _aa_canvas_size_local() -> tuple[int, int]:
+            """Match the AA canvas calculation in src.multimedia.openauto.
+
+            Imported lazily so the web viewer doesn't hard-fail if the
+            multimedia module is missing (e.g. when AA is disabled).
+            """
+            try:
+                from src.multimedia.openauto import _aa_canvas_size
+                return _aa_canvas_size(viewer._config) if viewer._config else (1024, 504)
+            except Exception:
+                cfg = viewer._config
+                w = cfg.get("display.multimedia.width", 1024) if cfg else 1024
+                h = cfg.get("display.multimedia.height", 504) if cfg else 504
+                return int(w), int(h)
+
         def _aa_mjpeg_generator():
             """Stream MJPEG frames from Xvfb (:99) using ffmpeg."""
-            cfg = viewer._config
-            w = cfg.get("display.multimedia.width", 1024) if cfg else 1024
-            h = cfg.get("display.multimedia.height", 600) if cfg else 600
+            w, h = _aa_canvas_size_local()
             try:
                 proc = subprocess.Popen(
                     ["ffmpeg", "-f", "x11grab", "-framerate", "25",
@@ -454,9 +467,7 @@ class WebViewer:
             data = request.get_json(silent=True) or {}
             rel_x = data.get("x", 0.5)
             rel_y = data.get("y", 0.5)
-            cfg = viewer._config
-            w = cfg.get("display.multimedia.width", 1024) if cfg else 1024
-            h = cfg.get("display.multimedia.height", 600) if cfg else 600
+            w, h = _aa_canvas_size_local()
             px = max(0, min(w, int(rel_x * w)))
             py = max(0, min(h, int(rel_y * h)))
             try:

--- a/src/multimedia/openauto.py
+++ b/src/multimedia/openauto.py
@@ -36,6 +36,27 @@ def _find_openauto() -> Optional[str]:
     return None
 
 
+def _aa_canvas_size(app_config: Any) -> tuple[int, int]:
+    """Return the (width, height) that AA / Xvfb should use.
+
+    BCM renders a 48 px AppBar at the top and a 48 px NavBar at the
+    bottom of every A-screen, so the actual content area available to
+    the Android Auto iframe is ``(dashboard.width, dashboard.height -
+    48 - 48)``.  If ``display.multimedia.{width,height}`` is explicitly
+    set in the config we honour it verbatim; otherwise we compute the
+    inner-frame size so the AA canvas never gets clipped behind the
+    header or the nav bar.
+    """
+    dash_w = int(app_config.get("display.dashboard.width", 1024))
+    dash_h = int(app_config.get("display.dashboard.height", 600))
+    appbar = int(app_config.get("display.appbar_px", 48))
+    navbar = int(app_config.get("display.navbar_px", 48))
+    inner_h = max(240, dash_h - appbar - navbar)
+    w = int(app_config.get("display.multimedia.width", dash_w))
+    h = int(app_config.get("display.multimedia.height", inner_h))
+    return w, h
+
+
 def _create_openauto_config(project_dir: str, app_config: Any = None) -> None:
     """Create openauto.ini in the project directory (autoapp's working dir).
 
@@ -58,12 +79,11 @@ def _create_openauto_config(project_dir: str, app_config: Any = None) -> None:
     ssid = ""
     password = ""
     width = 1024
-    height = 600
+    height = 504  # 600 - AppBar 48 - NavBar 48
     if app_config:
         ssid = app_config.get("wifi.ssid", "")
         password = app_config.get("wifi.password", "")
-        width = app_config.get("display.multimedia.width", 1024)
-        height = app_config.get("display.multimedia.height", 600)
+        width, height = _aa_canvas_size(app_config)
 
     # OpenAuto Resolution codes (per autoapp source):
     #   0 = 480p, 1 = 720p, 2 = 1080p, 3 = auto/stretch
@@ -317,8 +337,7 @@ class OpenAutoController:
         few times in case the window gets re-created after a phone
         reconnect.
         """
-        width = int(self._config.get("display.multimedia.width", 1024))
-        height = int(self._config.get("display.multimedia.height", 600))
+        width, height = _aa_canvas_size(self._config)
         env = {**os.environ, "DISPLAY": display}
         candidates = ["autoapp", "OpenAuto", "openauto", "openDsh"]
         last_wid: Optional[str] = None
@@ -434,8 +453,7 @@ class OpenAutoController:
         self._cleanup_stale_xvfb(display_num)
 
         try:
-            width = self._config.get("display.multimedia.width", 1024)
-            height = self._config.get("display.multimedia.height", 600)
+            width, height = _aa_canvas_size(self._config)
             self._xvfb_process = subprocess.Popen(
                 ["Xvfb", display_num, "-screen", "0",
                  f"{width}x{height}x24", "-ac"],


### PR DESCRIPTION
Previously Xvfb ran at the full panel resolution (1024x600) and the A2 MJPEG stream was stretched to fit the content-area with object-cover, which cropped the top and bottom 48 px of AA behind the AppBar and NavBar. The user saw AA content cut off under both bars.

Fix: compute the AA canvas size as
    (dashboard.width, dashboard.height − AppBar − NavBar)
so Xvfb, the ffmpeg grab, openauto.ini TouchscreenWidth/Height, the /aa/touch coordinate mapping, and the <img> container all use the exact same inner-frame size. No cropping, no letterboxing, perfect 1:1 touch coordinates.

- New helper _aa_canvas_size(config) in openauto.py does the math: respects display.multimedia.{width,height} if explicitly set, otherwise derives them from display.dashboard minus AppBar (display.appbar_px, default 48) and NavBar (display.navbar_px, default 48).
- _start_xvfb, _create_openauto_config, and _force_fullscreen_window all call the helper so the whole stack is consistent.
- web_viewer.py gets a local wrapper that imports _aa_canvas_size lazily; _aa_mjpeg_generator and /aa/touch both use it.
- A2 img switches from object-cover (cropping) to object-fill (1:1 mapping) since the source now matches the container aspect exactly.

https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf