### PR TITLE
Fix: make pygame optional so OPi PC / OPi 5 Pro don't need SDL2

### DIFF
--- a/docs/OPI_PC_SETUP.md
+++ b/docs/OPI_PC_SETUP.md
@@ -205,16 +205,32 @@ pip install --upgrade pip
 pip install -r requirements.txt -r requirements-opi-pc.txt
 ```
 
+> **Important — do NOT install `requirements-x86.txt` on the OPi PC.**
+> The x86 file pulls `pygame`, which in turn requires the full SDL2
+> dev toolchain (`libsdl2-dev`, `libsdl2-image-dev`, `libsdl2-mixer-dev`,
+> `libsdl2-ttf-dev`, `libfreetype6-dev`, `libportmidi-dev`) and will
+> fail to build from source on armv7l. The OPi PC runs BCM in
+> `--frontend` mode using Flask + Chromium instead of the pygame
+> dashboard renderer, so pygame is genuinely unnecessary here. Both
+> `requirements.txt` and `requirements-opi-pc.txt` already list
+> every runtime dependency (Flask, flask-sock, Pillow, opencv-python-headless,
+> gpiod, pyserial, PyYAML) the web frontend needs.
+
 Sanity-check that every runtime import succeeds — this catches
 missing `libgpiod2` or `python3-dev` early:
 
 ```bash
-python3 -c "import gpiod, yaml, flask, flask_sock, serial; print('ok')"
+python3 -c "import gpiod, yaml, flask, flask_sock, serial, PIL, cv2; print('ok')"
 ```
 
 If you see `ImportError: No module named gpiod` even though the
 apt package is installed, your venv was created before libgpiod2
 landed — rebuild it: `rm -rf .venv && python3 -m venv .venv`.
+
+If you see `ImportError: No module named pygame` when you later
+run `main.py` **without** `--frontend`, you accidentally installed
+the x86 requirements. Rebuild the venv and install only
+`requirements.txt` + `requirements-opi-pc.txt`.
 
 ### 1.8 Lean the config for a 1 GB RAM bench test
 

--- a/main.py
+++ b/main.py
@@ -19,7 +19,18 @@ from src.core.config import BCMConfig
 from src.core.logger import setup_logging, get_logger
 from src.core.event_bus import EventBus
 from src.core.hal import HAL
-from src.dashboard.renderer import start_dashboard
+
+# NOTE: ``start_dashboard`` is imported lazily so ``main.py`` can run
+# on hosts that don't have ``pygame`` installed. In --frontend mode
+# (OPi PC, OPi 5 Pro, Redmi) the dashboard is rendered by the Flask
+# ``WebViewer`` and pygame never gets exercised. The legacy pygame
+# renderer lives in ``requirements-x86.txt`` and is dev/debug-only.
+def _lazy_start_dashboard(*args, **kwargs):
+    from src.dashboard.renderer import start_dashboard as _sd
+    return _sd(*args, **kwargs)
+
+start_dashboard = _lazy_start_dashboard
+
 from src.obd.simulator import start_obd
 from src.parking.simulator import start_parking
 from src.environment.simulator import start_environment

--- a/requirements-opi-pc.txt
+++ b/requirements-opi-pc.txt
@@ -1,9 +1,14 @@
 # BCM v8.5 — Orange Pi PC 1.2 (Allwinner H3, armv7l) dependencies
 #
-# Install: pip install -r requirements.txt -r requirements-opi-pc.txt -r requirements-x86.txt
+# Install:
+#   pip install -r requirements.txt -r requirements-opi-pc.txt
 #
-# The OPi PC has only 1GB RAM. Keep dependencies lean.
-# Flask/web frontend deps come from requirements-x86.txt (same web stack).
+# DO NOT also install requirements-x86.txt on the OPi PC — it pulls
+# pygame which fails to build from source on ARM without the full
+# libsdl2-dev toolchain and isn't needed anyway (--frontend mode
+# uses Flask + Chromium instead of the pygame renderer).
+#
+# The OPi PC has only 1 GB RAM. Keep dependencies lean.
 
 # GPIO via libgpiod (H3 uses gpiochip0, sun8i-h3-pinctrl)
 gpiod>=2.0
@@ -13,6 +18,18 @@ spidev>=3.6
 
 # I2C bus (optional, for future sensor expansion)
 smbus2>=0.4
+
+# Flask web frontend (A1-A8 dashboard on :5002, small display on :5003)
+flask>=3.0
+flask-sock>=0.7
+simple-websocket>=1.0
+
+# Pillow — image helpers for the small display snapshots
+Pillow>=10.0
+
+# opencv-python-headless — camera MJPEG endpoint, no GUI deps needed.
+# Pre-built wheels exist for armv7l on piwheels.
+opencv-python-headless>=4.8
 
 # Note: System packages required (install via apt) — see docs/OPI_PC_SETUP.md
 #   Core:

--- a/requirements-opi.txt
+++ b/requirements-opi.txt
@@ -1,11 +1,25 @@
-# BCM v8.5 — Orange Pi 5 Pro 4GB / 5 Plus (arm64) dependencies
+# BCM v8.5 — Orange Pi 5 Pro 4GB / 5 Plus (aarch64) dependencies
 #
-# Install: pip install -r requirements.txt -r requirements-opi.txt -r requirements-x86.txt
+# Install:
+#   pip install -r requirements.txt -r requirements-opi.txt
+#
+# DO NOT also install requirements-x86.txt on the OPi — it pulls
+# pygame which isn't needed for the Flask / Chromium kiosk path
+# and requires the full libsdl2-dev toolchain to build from source.
 #
 # Python dependencies
 gpiod>=2.0
 spidev>=3.6
 smbus2>=0.4
+
+# Flask web frontend (A1-A8 dashboard on :5002, small display on :5003)
+flask>=3.0
+flask-sock>=0.7
+simple-websocket>=1.0
+
+# Pillow + opencv for camera MJPEG and small-display snapshots
+Pillow>=10.0
+opencv-python-headless>=4.8
 
 # Note: System packages required (install via apt) — see docs/OPI5PRO_SETUP.md
 #   Core:

--- a/requirements-x86.txt
+++ b/requirements-x86.txt
@@ -1,6 +1,18 @@
-# BCM v8 — x86 development/simulation dependencies
+# BCM v8.5 — x86 development / simulation dependencies
+#
+# The Flask web frontend + PyGame legacy dashboard both live here.
+# --frontend mode doesn't use pygame; it's kept in this file only
+# because x86 is the one platform where we still run the original
+# pygame renderer for dev/debug. OPi PC (armv7l) and OPi 5 Pro
+# (aarch64) should install requirements-opi-pc.txt or
+# requirements-opi.txt instead — neither of which pulls pygame.
 flask>=3.0
 flask-sock>=0.7
 simple-websocket>=1.0
 Pillow>=10.0
 opencv-python-headless>=4.8
+
+# PyGame legacy renderer (x86 only — never install on OPi).
+# System packages required on Debian: libsdl2-dev libsdl2-image-dev
+# libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev
+pygame>=2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,9 @@
-# BCM v7 — Common dependencies (all platforms)
+# BCM v8.5 — Common dependencies (all platforms)
+#
+# These are safe to install on any target — no C extensions that need
+# SDL / X / GTK. The pygame-based PyGame dashboard renderer is opt-in
+# and lives in requirements-x86.txt so armv7l / aarch64 builds that
+# use the Flask frontend (--frontend) don't have to build pygame
+# from source.
 PyYAML>=6.0
 pyserial>=3.5
-pygame>=2.5


### PR DESCRIPTION
The common requirements.txt listed pygame>=2.5, which on armv7l forces pip to build pygame from source. That needs the full libsdl2-dev toolchain the OPi PC image doesn't ship with, and on 1 GB RAM it regularly ran the board out of memory mid-build.

Pygame is only used by the legacy dashboard renderer (src/dashboard/renderer.py + screens/*). Production OPi PC and OPi 5 Pro run BCM with --frontend which renders the dashboard in Flask + Chromium instead, so pygame is never exercised at runtime.

Fix:
- requirements.txt: drop pygame. Now only PyYAML + pyserial.
- requirements-x86.txt: pygame moves here with a comment listing the libsdl2-* apt packages needed to build it.
- requirements-opi-pc.txt: add flask / flask-sock / simple-websocket / Pillow / opencv-python-headless so the OPi PC install line is just `pip install -r requirements.txt -r requirements-opi-pc.txt` with no reference to requirements-x86.txt.
- requirements-opi.txt: same additions for the OPi 5 Pro target.
- main.py: defer the `from src.dashboard.renderer import start_dashboard` import to a tiny lazy wrapper. The MODULE_REGISTRY still holds the wrapper reference so --dry-run reporting works, but pygame isn't touched until somebody actually calls start_dashboard (i.e. never in --frontend mode). Verified with an import-time smoke test that installs a meta-path blocker on the pygame name and runs `import main` successfully.
- docs/OPI_PC_SETUP.md §1.7: add a big Important block telling the reader NOT to install requirements-x86.txt on the OPi PC, and explain why (pygame/SDL2 build chain). Sanity-check import now also checks Pillow + cv2.

https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf