### PR TITLE
Fix: drop opencv/Pillow from OPi PC reqs (no armv7l PyPI wheels)

### DIFF
--- a/docs/OPI_PC_SETUP.md
+++ b/docs/OPI_PC_SETUP.md
@@ -211,17 +211,30 @@ pip install -r requirements.txt -r requirements-opi-pc.txt
 > `libsdl2-ttf-dev`, `libfreetype6-dev`, `libportmidi-dev`) and will
 > fail to build from source on armv7l. The OPi PC runs BCM in
 > `--frontend` mode using Flask + Chromium instead of the pygame
-> dashboard renderer, so pygame is genuinely unnecessary here. Both
-> `requirements.txt` and `requirements-opi-pc.txt` already list
-> every runtime dependency (Flask, flask-sock, Pillow, opencv-python-headless,
-> gpiod, pyserial, PyYAML) the web frontend needs.
+> dashboard renderer, so pygame is genuinely unnecessary here.
 
-Sanity-check that every runtime import succeeds — this catches
-missing `libgpiod2` or `python3-dev` early:
+> **Also note — `opencv-python-headless` and `Pillow` are NOT in
+> `requirements-opi-pc.txt`.** Neither package has pre-built wheels
+> for `armv7l` on PyPI, so pip would otherwise try to build them
+> from source which needs 4+ GB of RAM and an hour of compile time —
+> the OPi PC's 1 GB will OOM-kill the build. The BCM code uses both
+> libraries only through lazy `try/except import` blocks
+> (`src/dashboard/web_viewer.py`, `src/dashboard/small_viewer.py`,
+> `src/dashboard/overlays.py`, `src/location/map_renderer.py`), so
+> BCM starts and runs cleanly without them — the camera stream
+> endpoint just returns a placeholder JPEG. That is exactly what
+> you want for the desk test in Parts 1–2 anyway, because there
+> is no camera attached yet.
+
+Sanity-check that every **required** runtime import succeeds — this
+catches missing `libgpiod2` or `python3-dev` early:
 
 ```bash
-python3 -c "import gpiod, yaml, flask, flask_sock, serial, PIL, cv2; print('ok')"
+python3 -c "import gpiod, yaml, flask, flask_sock, serial; print('ok')"
 ```
+
+(Don't add `cv2` or `PIL` here — see the next section for when you
+actually want them.)
 
 If you see `ImportError: No module named gpiod` even though the
 apt package is installed, your venv was created before libgpiod2
@@ -231,6 +244,33 @@ If you see `ImportError: No module named pygame` when you later
 run `main.py` **without** `--frontend`, you accidentally installed
 the x86 requirements. Rebuild the venv and install only
 `requirements.txt` + `requirements-opi-pc.txt`.
+
+#### Optional — enabling the camera stream endpoint later
+
+Once you actually plug in a USB webcam in Part 3.4 and want the
+`/api/camera/stream?cam=front` endpoint on `:5002`/`:5003` to
+return real frames instead of a placeholder, install the Debian
+system packages and recreate the venv with `--system-site-packages`
+so the apt-installed OpenCV is visible from inside the venv:
+
+```bash
+sudo apt install -y python3-opencv python3-pil
+
+cd /opt/bcm
+rm -rf .venv
+python3 -m venv --system-site-packages .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt -r requirements-opi-pc.txt
+
+# Verify
+python3 -c "import cv2, PIL; print(cv2.__version__, PIL.__version__)"
+```
+
+The `--system-site-packages` flag is the critical bit — without
+it the venv hides the `python3-opencv` apt package. On Armbian
+Trixie the Debian `python3-opencv` binary weighs ~80 MB and is
+pre-built by the distro; the OPi PC never has to compile anything.
 
 ### 1.8 Lean the config for a 1 GB RAM bench test
 
@@ -647,7 +687,7 @@ lsusb
 ls -la /dev/video*
 v4l2-ctl --list-devices
 
-# Capture one frame
+# Capture one frame (purely through ffmpeg — no opencv needed here)
 ffmpeg -f v4l2 -video_size 640x480 -i /dev/video0 -frames 1 /tmp/test.jpg
 ls -l /tmp/test.jpg
 ```
@@ -656,6 +696,16 @@ In `config/bcm_config_opi_pc.yaml` the front camera already
 defaults to `/dev/video0`, so BCM picks it up automatically. In
 the running dashboard you should see a preview whenever the
 camera module is active.
+
+> **If the browser shows "NO CAMERA" instead of a live feed**, the
+> BCM `/api/camera/stream?cam=front` endpoint needs OpenCV to turn
+> V4L2 frames into MJPEG. On the OPi PC (armv7l) OpenCV is an
+> optional extra — run the Debian `python3-opencv` install recipe
+> from §1.7 ("Optional — enabling the camera stream endpoint later")
+> to install it through apt and expose it to the venv with
+> `--system-site-packages`. Restart BCM afterwards. The ffmpeg
+> capture above still works regardless — it bypasses OpenCV
+> entirely.
 
 ### 3.5 USB GPS (u-blox 7 / 8)
 
@@ -1102,6 +1152,40 @@ build: [`OPI5PRO_BOM.md`](OPI5PRO_BOM.md).
   → Another process already owns the GPIO. Usually
   `bcm-ignition-watcher` started from a previous run. Stop it:
   `sudo systemctl stop bcm-ignition-watcher`.
+
+### pip install fails
+
+**`Failed to build opencv-python-headless`** / `skbuild`, `cmake`,
+or `ninja` error during pip install
+  → You're on the OPi PC (armv7l) and pip is trying to build
+  OpenCV from source because PyPI has no pre-built wheel for this
+  architecture. This **should not happen** with a fresh
+  `requirements-opi-pc.txt` checkout (opencv was dropped from it
+  in commit `ccb8761` and the file explicitly explains why).
+  If it does, you probably have an older copy of the file — `git
+  pull` and try again, or install via apt:
+  ```bash
+  sudo apt install -y python3-opencv
+  cd /opt/bcm
+  rm -rf .venv
+  python3 -m venv --system-site-packages .venv
+  source .venv/bin/activate
+  pip install -r requirements.txt -r requirements-opi-pc.txt
+  ```
+
+**`Failed to build Pillow`** / missing `zlib.h`, `jpeglib.h`, etc.
+  → Same story — Pillow is not a required OPi PC dep, use
+  `sudo apt install -y python3-pil` plus `--system-site-packages`
+  as above.
+
+**`Failed to build pygame`** / `sdl-config: command not found`
+  → You accidentally installed `requirements-x86.txt`. Rebuild the
+  venv and only install `requirements.txt` + `requirements-opi-pc.txt`.
+
+**`error: externally-managed-environment`** (Debian Trixie)
+  → You ran `pip install` outside a virtual environment. Always
+  `source .venv/bin/activate` first. Never `sudo pip install`
+  anything.
 
 ### Chromium / kiosk
 

--- a/requirements-opi-pc.txt
+++ b/requirements-opi-pc.txt
@@ -24,12 +24,37 @@ flask>=3.0
 flask-sock>=0.7
 simple-websocket>=1.0
 
-# Pillow — image helpers for the small display snapshots
-Pillow>=10.0
-
-# opencv-python-headless — camera MJPEG endpoint, no GUI deps needed.
-# Pre-built wheels exist for armv7l on piwheels.
-opencv-python-headless>=4.8
+# -----------------------------------------------------------------------------
+# NOT installed via pip on armv7l:
+#
+#   Pillow (PIL) and opencv-python-headless are *only* used inside lazy
+#   try/except imports in src/dashboard/web_viewer.py, src/dashboard/
+#   small_viewer.py, src/dashboard/overlays.py, and
+#   src/location/map_renderer.py — BCM degrades gracefully (camera stream
+#   returns a placeholder, map overlay skips image composition) when they
+#   aren't available. The desk test in docs/OPI_PC_SETUP.md Parts 1-2 does
+#   not need either package.
+#
+#   Both packages have no pre-built armv7l wheels on PyPI, so pip falls
+#   back to a source build that needs 4+ GB RAM and a full C++ toolchain.
+#   The OPi PC can't do that — it OOM-kills mid-build and wastes an hour.
+#
+#   If you later want the /api/camera/stream endpoint to work with a real
+#   USB webcam (Part 3.4) or GPS overlay images on the map, install the
+#   Debian system packages instead and expose them to the venv with
+#   --system-site-packages:
+#
+#     sudo apt install -y python3-opencv python3-pil
+#     cd /opt/bcm
+#     rm -rf .venv
+#     python3 -m venv --system-site-packages .venv
+#     source .venv/bin/activate
+#     pip install -r requirements.txt -r requirements-opi-pc.txt
+#
+#   On Armbian Trixie (Debian 13) python3-opencv is ~80 MB and builds on
+#   prebuilt wheels shipped in the distro — it is *not* compiled on the
+#   device.
+# -----------------------------------------------------------------------------
 
 # Note: System packages required (install via apt) — see docs/OPI_PC_SETUP.md
 #   Core:

--- a/requirements-opi.txt
+++ b/requirements-opi.txt
@@ -7,6 +7,14 @@
 # pygame which isn't needed for the Flask / Chromium kiosk path
 # and requires the full libsdl2-dev toolchain to build from source.
 #
+# aarch64 has pre-built PyPI wheels for both opencv-python-headless
+# and Pillow, so unlike the armv7l OPi PC build this file *does*
+# include them. If pip ever falls back to a source build (old PyPI
+# cache, unusual Python version), the Armbian apt packages
+# python3-opencv and python3-pil are the same-day replacement —
+# create the venv with `python3 -m venv --system-site-packages .venv`
+# so the system packages are visible from inside it.
+
 # Python dependencies
 gpiod>=2.0
 spidev>=3.6
@@ -18,6 +26,7 @@ flask-sock>=0.7
 simple-websocket>=1.0
 
 # Pillow + opencv for camera MJPEG and small-display snapshots
+# (both have pre-built aarch64 wheels on PyPI, no compilation needed)
 Pillow>=10.0
 opencv-python-headless>=4.8
 


### PR DESCRIPTION
Both opencv-python-headless and Pillow have no pre-built armv7l wheels on PyPI. On the OPi PC (1 GB RAM) pip falls back to a source build that requires 4+ GB of RAM and a full C++ toolchain — the board OOM-kills the build and the install fails. BCM only touches cv2 and PIL through lazy try/except imports in:

  src/dashboard/web_viewer.py:846,897   (/api/camera/stream)
  src/dashboard/small_viewer.py:218     (/api/camera/stream)
  src/dashboard/overlays.py:58,113      (reverse cam overlay)
  src/location/map_renderer.py:328      (GPS map image compose)

so BCM starts and runs without them — the camera stream endpoint just returns a placeholder JPEG, which is exactly the desired behaviour on a desk rig with no camera attached.

- requirements-opi-pc.txt: remove opencv-python-headless and Pillow. Add a long comment explaining the armv7l wheel gap and documenting the opt-in recipe: sudo apt install python3-opencv python3-pil python3 -m venv --system-site-packages .venv so the user can still enable the camera stream endpoint later once they actually plug in a real webcam.
- requirements-opi.txt: keep opencv + Pillow for aarch64 (pre-built wheels exist on PyPI), but add a comment explaining why the OPi PC file is different and how to fall back to the apt packages if pip ever decides to build from source.
- docs/OPI_PC_SETUP.md:
  * §1.7: new "Also note" block and an "Optional — enabling the camera stream endpoint later" subsection with the apt + --system-site-packages recipe.
  * §1.7 sanity check no longer imports cv2/PIL.
  * §3.4 USB webcam: note that ffmpeg capture works without OpenCV; if the browser shows "NO CAMERA", follow the §1.7 recipe to install python3-opencv.
  * New "pip install fails" troubleshooting subsection covering opencv build failure, Pillow build failure, pygame build failure (wrong requirements file), and the Debian Trixie `externally-managed-environment` error.

https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf