### PR TITLE
Fix: drop spidev + smbus2 from OPi PC pip requirements

### DIFF
--- a/docs/OPI_PC_SETUP.md
+++ b/docs/OPI_PC_SETUP.md
@@ -213,18 +213,27 @@ pip install -r requirements.txt -r requirements-opi-pc.txt
 > `--frontend` mode using Flask + Chromium instead of the pygame
 > dashboard renderer, so pygame is genuinely unnecessary here.
 
-> **Also note — `opencv-python-headless` and `Pillow` are NOT in
-> `requirements-opi-pc.txt`.** Neither package has pre-built wheels
-> for `armv7l` on PyPI, so pip would otherwise try to build them
-> from source which needs 4+ GB of RAM and an hour of compile time —
-> the OPi PC's 1 GB will OOM-kill the build. The BCM code uses both
-> libraries only through lazy `try/except import` blocks
+> **Also note — `opencv-python-headless`, `Pillow`, `spidev` and
+> `smbus2` are NOT in `requirements-opi-pc.txt`.** All four would
+> compile C code on install:
+>
+> - `opencv-python-headless` and `Pillow` have no pre-built armv7l
+>   wheels on PyPI, so pip falls back to a 4+ GB RAM source build
+>   that OOM-kills on the 1 GB OPi PC.
+> - `spidev` always ships as a source distribution and its C
+>   extension refuses to build against the Python 3.13 headers that
+>   Armbian Trixie installs.
+> - `smbus2` is pure Python but depends on `i2c-tools` + kernel
+>   i2c-dev nodes that the bench rig doesn't use yet.
+>
+> BCM uses all four through lazy `try/except import` blocks
 > (`src/dashboard/web_viewer.py`, `src/dashboard/small_viewer.py`,
-> `src/dashboard/overlays.py`, `src/location/map_renderer.py`), so
-> BCM starts and runs cleanly without them — the camera stream
-> endpoint just returns a placeholder JPEG. That is exactly what
-> you want for the desk test in Parts 1–2 anyway, because there
-> is no camera attached yet.
+> `src/dashboard/overlays.py`, `src/location/map_renderer.py`,
+> `src/core/hal.py::RealSPI`, `src/core/hal.py::RealI2C`), so BCM
+> starts and runs cleanly without them — SPI / I²C / camera /
+> map-image features just stay inactive. That is exactly what you
+> want for the desk test in Parts 1–2 because neither a camera
+> nor an I²C sensor is connected yet.
 
 Sanity-check that every **required** runtime import succeeds — this
 catches missing `libgpiod2` or `python3-dev` early:
@@ -1177,6 +1186,22 @@ or `ninja` error during pip install
   → Same story — Pillow is not a required OPi PC dep, use
   `sudo apt install -y python3-pil` plus `--system-site-packages`
   as above.
+
+**`Failed to build spidev`** / `Python.h: No such file or directory`
+  or `error: unknown type name 'PyObject'` against Python 3.13
+  → spidev is NOT required for the desk test (Parts 1-2) or for any
+  currently-shipping BCM module; it's listed as a stub in
+  `src/core/hal.py::RealSPI` for future MCP3008 SWC decoder use. If
+  you need it later (Part 4+), install via apt and recreate the
+  venv with `--system-site-packages`:
+  ```bash
+  sudo apt install -y python3-spidev python3-smbus
+  cd /opt/bcm
+  rm -rf .venv
+  python3 -m venv --system-site-packages .venv
+  source .venv/bin/activate
+  pip install -r requirements.txt -r requirements-opi-pc.txt
+  ```
 
 **`Failed to build pygame`** / `sdl-config: command not found`
   → You accidentally installed `requirements-x86.txt`. Rebuild the

--- a/requirements-opi-pc.txt
+++ b/requirements-opi-pc.txt
@@ -9,15 +9,15 @@
 # uses Flask + Chromium instead of the pygame renderer).
 #
 # The OPi PC has only 1 GB RAM. Keep dependencies lean.
+# Everything in this file ships as a pure-Python wheel on PyPI —
+# there are NO C extensions to build and the install takes under
+# a minute even on the OPi PC.
 
-# GPIO via libgpiod (H3 uses gpiochip0, sun8i-h3-pinctrl)
+# GPIO via libgpiod (H3 uses gpiochip0, sun8i-h3-pinctrl).
+# gpiod 2.x is a pure-Python package that wraps the libgpiod2 C
+# library via ctypes — the C library itself comes from the apt
+# package libgpiod2, installed in §1.3 of OPI_PC_SETUP.md.
 gpiod>=2.0
-
-# SPI bus (MCP3008 ADC for SWC analog, optional)
-spidev>=3.6
-
-# I2C bus (optional, for future sensor expansion)
-smbus2>=0.4
 
 # Flask web frontend (A1-A8 dashboard on :5002, small display on :5003)
 flask>=3.0
@@ -27,22 +27,38 @@ simple-websocket>=1.0
 # -----------------------------------------------------------------------------
 # NOT installed via pip on armv7l:
 #
-#   Pillow (PIL) and opencv-python-headless are *only* used inside lazy
-#   try/except imports in src/dashboard/web_viewer.py, src/dashboard/
-#   small_viewer.py, src/dashboard/overlays.py, and
-#   src/location/map_renderer.py — BCM degrades gracefully (camera stream
-#   returns a placeholder, map overlay skips image composition) when they
-#   aren't available. The desk test in docs/OPI_PC_SETUP.md Parts 1-2 does
-#   not need either package.
+#   spidev and smbus2 — both would compile a tiny C extension on
+#   install (spidev in particular fails against Python 3.13 headers
+#   on Debian Trixie). BCM's HAL only imports them lazily inside
+#   src/core/hal.py::RealSPI.__init__ and RealI2C.__init__, and no
+#   module currently calls hal.spi() / hal.i2c() — they are stubs
+#   reserved for a future MCP3008 ADC and I²C sensor expansion.
+#   Skip them on the OPi PC until you actually need them, then:
 #
-#   Both packages have no pre-built armv7l wheels on PyPI, so pip falls
-#   back to a source build that needs 4+ GB RAM and a full C++ toolchain.
-#   The OPi PC can't do that — it OOM-kills mid-build and wastes an hour.
+#     sudo apt install -y python3-spidev python3-smbus
+#     cd /opt/bcm
+#     rm -rf .venv
+#     python3 -m venv --system-site-packages .venv
+#     source .venv/bin/activate
+#     pip install -r requirements.txt -r requirements-opi-pc.txt
 #
-#   If you later want the /api/camera/stream endpoint to work with a real
-#   USB webcam (Part 3.4) or GPS overlay images on the map, install the
-#   Debian system packages instead and expose them to the venv with
-#   --system-site-packages:
+#   Pillow (PIL) and opencv-python-headless — only used inside
+#   lazy try/except imports in src/dashboard/web_viewer.py, src/
+#   dashboard/small_viewer.py, src/dashboard/overlays.py, and
+#   src/location/map_renderer.py — BCM degrades gracefully (camera
+#   stream returns a placeholder, map overlay skips image
+#   composition) when they aren't available. The desk test in
+#   docs/OPI_PC_SETUP.md Parts 1-2 does not need either package.
+#
+#   Both opencv and Pillow have no pre-built armv7l wheels on
+#   PyPI, so pip would otherwise fall back to a source build
+#   that needs 4+ GB RAM and a full C++ toolchain. The OPi PC
+#   can't do that — it OOM-kills mid-build.
+#
+#   If you later want the /api/camera/stream endpoint to work with
+#   a real USB webcam (Part 3.4) or GPS overlay images on the map,
+#   install the Debian system packages instead and expose them to
+#   the venv with --system-site-packages:
 #
 #     sudo apt install -y python3-opencv python3-pil
 #     cd /opt/bcm
@@ -51,9 +67,9 @@ simple-websocket>=1.0
 #     source .venv/bin/activate
 #     pip install -r requirements.txt -r requirements-opi-pc.txt
 #
-#   On Armbian Trixie (Debian 13) python3-opencv is ~80 MB and builds on
-#   prebuilt wheels shipped in the distro — it is *not* compiled on the
-#   device.
+#   On Armbian Trixie (Debian 13) python3-opencv is ~80 MB and
+#   ships as a prebuilt distro binary — nothing is compiled on
+#   the device.
 # -----------------------------------------------------------------------------
 
 # Note: System packages required (install via apt) — see docs/OPI_PC_SETUP.md


### PR DESCRIPTION
spidev's C extension fails to build against the Python 3.13 headers shipped by Armbian Trixie (missing `PyObject` / Py_UNICODE macros that were removed in 3.12+). Nothing in BCM currently calls hal.spi() or hal.i2c() — both live as stubs in src/core/hal.py::RealSPI / RealI2C that only `import spidev` and `import smbus2` inside __init__, so they're entirely unused today and block the desk test for no reason.

Fix:
- requirements-opi-pc.txt: remove spidev and smbus2. Extend the existing "not installed via pip on armv7l" comment block to cover them and document the apt + --system-site-packages fallback for when the user actually wires an MCP3008 or I²C sensor in Part 4+.
- docs/OPI_PC_SETUP.md §1.7: the "Also note" block now lists all four skipped-on-armv7l packages (cv2, Pillow, spidev, smbus2) with a one-line reason for each.
- docs/OPI_PC_SETUP.md troubleshooting: new entry for "Failed to build spidev / Python.h not found / PyObject missing" with the apt install recipe.

Verified main.py still imports cleanly when pygame, spidev, smbus2, cv2 AND PIL are all blocked via a sys.meta_path loader.

https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf