### PR TITLE
Fix ignition watcher crash when /dev/gpiochip0 is missing

### DIFF
--- a/src/power/ignition_watcher.py
+++ b/src/power/ignition_watcher.py
@@ -436,7 +436,18 @@ def main() -> None:
     else:
         watcher = GPIOIgnitionWatcher(cfg)
 
-    watcher.setup()
+    try:
+        watcher.setup()
+    except (FileNotFoundError, PermissionError, OSError) as exc:
+        if not simulate:
+            log(f"GPIO setup failed: {exc}")
+            log("Falling back to simulation mode — "
+                "check that /dev/gpiochip0 exists (ls /dev/gpiochip*)")
+            simulate = True
+            watcher = SimulatedIgnitionWatcher()
+            watcher.setup()
+        else:
+            raise
 
     # Select SWC monitor
     if simulate:


### PR DESCRIPTION
gpiod library can be installed but the GPIO chip device file may not exist (kernel module not loaded, DT overlay missing). Catch FileNotFoundError/PermissionError from gpiod.Chip() and fall back to simulation mode with a helpful diagnostic message.

https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf