### PR TITLE
Fix systemd services: remove missing groups, set User=abner

### DIFF
--- a/config/systemd/bcm-headunit.service
+++ b/config/systemd/bcm-headunit.service
@@ -30,11 +30,15 @@ KillSignal=SIGTERM
 # Do NOT auto-restart — ignition watcher manages lifecycle
 Restart=no
 
-# Run as root for GPIO access
+# Run as root for GPIO access — root already has full device access,
+# but we add common hardware groups if they exist on the system.
 User=root
 
-# GPIO + audio + video access
-SupplementaryGroups=gpio i2c spi audio video render
+# Audio + video groups (gpio/i2c/spi/render may not exist on all images —
+# if systemd fails with "Failed to determine supplementary groups", remove
+# the missing groups from this line, or just comment it out since root
+# already has full access).
+SupplementaryGroups=audio video
 
 # Logging
 StandardOutput=journal

--- a/config/systemd/bcm-kiosk.service
+++ b/config/systemd/bcm-kiosk.service
@@ -41,8 +41,9 @@ Environment=DISPLAY=:0
 Restart=on-failure
 RestartSec=3
 
-# Run as the display user (not root)
-User=bcm
+# Run as the display user (not root).
+# Must match the user who owns the X/Wayland session (DISPLAY=:0).
+User=abner
 
 StandardOutput=journal
 StandardError=journal

--- a/config/systemd/bcm-splash-main.service
+++ b/config/systemd/bcm-splash-main.service
@@ -64,7 +64,7 @@ SuccessExitStatus=0 1
 Restart=no
 
 # Needs framebuffer (DRM) access and the sound card.
-SupplementaryGroups=video render audio
+SupplementaryGroups=video audio
 
 StandardOutput=journal
 StandardError=journal

--- a/config/systemd/bcm-splash-small.service
+++ b/config/systemd/bcm-splash-small.service
@@ -41,7 +41,7 @@ SuccessExitStatus=0 1
 Restart=no
 
 # Framebuffer access only; no audio device needed.
-SupplementaryGroups=video render
+SupplementaryGroups=video
 
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
- bcm-headunit: strip gpio/i2c/spi/render from SupplementaryGroups (root already has full access; those groups don't exist on stock Armbian)
- bcm-kiosk: User=bcm → User=abner (actual user on the OPi PC)
- bcm-splash-main/small: remove "render" group (may not exist)

Fixes "Failed to determine supplementary groups: No such process"

https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf