### PR TITLE
Add x86 platform support: expanded Arduino serial protocol + docs

### DIFF
--- a/docs/X86_PLATFORM_SETUP.md
+++ b/docs/X86_PLATFORM_SETUP.md
@@ -1,0 +1,349 @@
+# BCM v8.5 — x86 Platform Setup (Car PC)
+
+Running the BCM headunit on a standard x86 PC/SBC (Intel Celeron N or
+similar) inside the car. All GPIO is handled by USB Arduinos — the x86
+board only needs USB + HDMI + audio.
+
+---
+
+## 1. Hardware Requirements
+
+### 1.1 Minimum x86 specs
+
+| Component | Minimum | Recommended |
+|-----------|---------|-------------|
+| CPU | Celeron N3350 (2C/2T) | Celeron N100/N5105 (4C/4T) |
+| RAM | 2 GB | 4 GB |
+| Storage | 16 GB eMMC/SSD | 64 GB+ SSD (DVR recording) |
+| USB | 4× USB 2.0 (use hub) | 6+ USB (mix 2.0/3.0) |
+| HDMI | 1× HDMI | 2× HDMI (main + small display) |
+| Audio | USB DAC (ES9038Q2M) | same |
+| Network | USB WiFi/LTE | built-in WiFi + USB LTE |
+
+Suitable boards: any mini-ITX/thin-ITX with Celeron N, Pentium Silver,
+or even old Core i3/i5. Fanless preferred for car environment.
+
+### 1.2 Power supply — DC-ATX for car 12V
+
+A standard ATX PSU can't run from car 12V. Use a **DC-ATX converter**
+(also called PicoPSU or DC-DC ATX). This takes car 12V and outputs all
+ATX voltages (3.3V, 5V, 12V, -12V) via the 24-pin ATX connector.
+
+**Recommended options:**
+
+| Module | Input | Output | Price (PLN) | Notes |
+|--------|-------|--------|-------------|-------|
+| **PicoPSU-160-XT** | 12-25V DC | 160W ATX | 150-250 | Most popular, proven |
+| **M4-ATX** | 6-30V DC | 250W ATX | 300-500 | Has ignition logic built-in |
+| **HD-Plex 200W** | 12-24V DC | 200W ATX | 200-350 | 19V laptop brick compatible |
+| Generic "DC-ATX 200W" | 12-24V DC | 200W | 60-120 | AliExpress, works fine |
+
+**Wiring diagram:**
+
+```
+Car Battery 12V ──┐
+                  ├──[25A fuse]──► DC-ATX module ──► 24-pin ATX connector
+                  │                    │                 └──► CPU 4/8-pin
+                  │                    │
+ACC/Ignition ─────┼──[PC817]──► Arduino (reports IGN:1 over USB serial)
+                  │
+                  └──[20A fuse]──► TDA7388 amp (direct 12V, no ATX needed)
+```
+
+### 1.3 DC-ATX wiring steps
+
+1. **Input power:** Connect car 12V (after 25A fuse) to DC-ATX input.
+   Use 2.5mm² wire minimum. Ground to chassis.
+
+2. **ATX connectors:** Plug 24-pin into motherboard, 4-pin CPU power.
+   The DC-ATX usually includes both cables.
+
+3. **Power control (ignition on/off):** Two approaches:
+
+   **Option A — Software controlled (recommended):**
+   - DC-ATX always powered (car battery → DC-ATX → motherboard standby)
+   - Arduino detects ignition 12V via optoisolator, sends `IGN:1` over serial
+   - BCM ignition_watcher receives the serial event and starts the dashboard
+   - On IGN off: BCM gracefully shuts down, x86 goes to S3 sleep or stays idle
+   - Power draw in idle: ~3-5W (acceptable for car battery)
+
+   **Option B — M4-ATX with built-in ignition logic:**
+   - Wire ACC/ignition to M4-ATX "IGN" input
+   - M4-ATX handles delayed startup (wait for cranking) and delayed shutdown
+   - Programmable timers via DIP switches or USB config tool
+   - More expensive but fully autonomous — works without software support
+
+4. **Grounding:** Single chassis ground point near battery. Star topology —
+   never daisy-chain ground wires.
+
+### 1.4 Startup / shutdown sequence
+
+```
+Ignition ON
+  → DC-ATX powers motherboard (or wakes from S3)
+  → Linux boots (or resumes from suspend)
+  → systemd starts bcm-ignition-watcher
+  → Arduino reports IGN:1 over serial
+  → ignition_watcher starts bcm-headunit.service
+  → Flask starts, Chromium kiosk opens
+
+Ignition OFF
+  → Arduino reports IGN:0
+  → ignition_watcher stops bcm-headunit
+  → Optional: suspend to S3 (instant wake next time)
+  → DC-ATX keeps standby power (motherboard draws <2W in S3)
+```
+
+### 1.5 Sleep vs always-on
+
+| Mode | Wake time | Idle draw | Complexity |
+|------|-----------|-----------|-----------|
+| Always-on (idle) | Instant | 8-15W | Simple |
+| S3 suspend | 2-5s | 2-3W | Needs `rtcwake` or WoL |
+| Full shutdown + M4-ATX | 15-30s (cold boot) | <0.5W | M4-ATX handles everything |
+
+For Celeron N with SSD: cold boot ≈ 10-15s, S3 resume ≈ 2s.
+
+---
+
+## 2. USB Device Layout
+
+All I/O goes through USB. No PCIe GPIO card needed.
+
+```
+x86 motherboard USB ports
+  ├── USB Hub (powered, 7-port)
+  │     ├── Arduino Pro Micro #1 (input: SWC, buttons, LDR, ignition,
+  │     │                          doors, handbrake, temp, rain, parking)
+  │     ├── Arduino Nano #2 (output: relays for lock, lights, wipers,
+  │     │                     windows + RF 433MHz receiver)
+  │     ├── USB BT 5.0 dongle
+  │     ├── USB GPS (NEO-M8N)
+  │     ├── USB LTE modem (Huawei E3372)
+  │     └── USB microphone
+  ├── USB DAC (ES9038Q2M) → RCA → TDA7388 + TDA2050
+  └── USB 4-ch AHD grabber (cameras)
+```
+
+### 2.1 Arduino #1 — Input controller
+
+Reads all vehicle sensors and buttons, reports over USB Serial (115200 baud):
+
+```
+Analog inputs:
+  A0 ← SWC pod 1 (resistor ladder, 12 buttons)
+  A1 ← LDR (ambient light)
+  A6 ← SWC pod 2 / music panel (resistor ladder)
+
+Digital inputs (active-low, PC817 optoisolators):
+  D2 ← Ignition/ACC 12V detect
+  D3 ← Handbrake switch
+  D4 ← Door FL (front-left)
+  D5 ← Door FR (front-right)
+  D6 ← Door RL (rear-left)
+  D7 ← Door RR (rear-right)
+  D8 ← Bonnet switch
+  D9 ← Trunk switch
+  D10 ← Rain sensor digital output
+
+DS18B20 (1-Wire):
+  D14 ← External temperature probe
+
+HC-SR04 parking sensors:
+  D15 (TRIG shared) → all 4 sensors
+  D16 ← ECHO front-left
+  A2 ← ECHO front-right
+  A3 ← ECHO rear-left
+  A7 ← ECHO rear-right
+
+USB HID output: button keycodes (volume, media, nav)
+Serial output: LIGHT, DOOR, HBRAKE, IGN, RAIN, TEMP, PARK messages
+```
+
+### 2.2 Arduino #2 — Output controller (relay board)
+
+Controls relays and receives RF commands. JSON protocol over USB serial (9600 baud):
+
+```
+Digital outputs → relay module (10-channel):
+  Relay 1: Central lock (LOCK)
+  Relay 2: Central lock (UNLOCK)
+  Relay 3: Trunk release
+  Relay 4: Window up (all)
+  Relay 5: Window down (all)
+  Relay 6: Headlights (follow-me-home)
+  Relay 7: Left blinker (greeting/alarm)
+  Relay 8: Right blinker (greeting/alarm)
+  Relay 9: Wiper motor relay
+  Relay 10: Horn (alarm)
+
+Input:
+  RF 433MHz receiver (RXB6) ← key fob signal
+```
+
+---
+
+## 3. Software Setup
+
+### 3.1 OS installation
+
+Any Debian 12+ / Ubuntu 22.04+ x86_64 works. Minimal server install
+recommended (no desktop environment — BCM provides its own kiosk).
+
+```bash
+# After fresh install:
+sudo apt update && sudo apt upgrade -y
+sudo apt install -y \
+    python3 python3-venv python3-pip python3-dev \
+    git curl chromium xserver-xorg xinit \
+    matchbox-window-manager unclutter x11-xserver-utils \
+    pipewire pipewire-pulse wireplumber \
+    bluez bluez-tools \
+    ffmpeg v4l-utils
+```
+
+### 3.2 BCM installation
+
+```bash
+cd /opt
+sudo git clone https://github.com/geek95dg/Alfa156-headunit.git bcm
+sudo chown -R $USER:$USER /opt/bcm
+cd /opt/bcm
+
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pip install -r requirements-x86.txt
+```
+
+### 3.3 Configuration
+
+Use the x86 config as base, adjust for your hardware:
+
+```bash
+cp config/bcm_config.yaml config/bcm_config_x86_car.yaml
+```
+
+Edit `config/bcm_config_x86_car.yaml`:
+```yaml
+system:
+  name: BCM v8.5
+  platform: x86
+  log_level: INFO
+
+# Arduino input controller serial port
+arduino:
+  input_port: /dev/ttyACM0    # Arduino #1 (auto-detected)
+  input_baud: 115200
+
+# Central lock Arduino
+central_lock:
+  port: /dev/ttyACM1           # Arduino #2
+  baudrate: 9600
+```
+
+### 3.4 Autologin + kiosk (same as OPi)
+
+Follow the same autologin → startx → .xinitrc pattern from the
+OPi PC setup guide (Part 2). The kiosk chain is identical:
+
+1. Autologin on tty1
+2. `~/.bash_profile` runs `exec startx -- -nocursor`
+3. `~/.xinitrc` starts matchbox + waits for Flask + opens Chromium kiosk
+
+### 3.5 Systemd services
+
+```bash
+sudo cp config/systemd/bcm-ignition-watcher.service /etc/systemd/system/
+sudo cp config/systemd/bcm-headunit.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable bcm-ignition-watcher
+```
+
+Edit `/etc/systemd/system/bcm-headunit.service` — change the ExecStart
+config path to your x86 config:
+
+```ini
+ExecStart=/bin/bash -c '... main.py --platform x86 --config config/bcm_config_x86_car.yaml --frontend'
+```
+
+---
+
+## 4. x86 vs OPi — Feature Parity
+
+| Feature | x86 + USB Arduinos | OPi 5 Pro (native GPIO) |
+|---------|-------------------|------------------------|
+| Dashboard UI | Identical | Identical |
+| Audio/EQ | Identical (USB DAC) | Identical |
+| Android Auto | Identical | Identical |
+| Bluetooth | Identical (USB dongle) | Built-in |
+| Parking sensors | Arduino timing (better!) | GPIO (tight timing) |
+| Door/handbrake/ignition | Arduino + optoisolators | GPIO + optoisolators |
+| Central lock + relays | Arduino #2 | Arduino #2 (same) |
+| Wipers/lights | Arduino #2 relays | Arduino #2 (same) |
+| Boot time (cold) | 10-15s (SSD) | 8-12s (eMMC) |
+| Power draw (active) | 15-25W | 5-10W |
+| Power draw (idle) | 3-5W (S3: 2W) | 2-3W |
+| Form factor | Mini-ITX: 170×170mm | 56×90mm |
+| Cost | Free (existing HW) | 350-450 PLN |
+
+---
+
+## 5. Arduino Serial Protocol Reference
+
+### Input Arduino (#1) → BCM (115200 baud)
+
+| Message | Example | Frequency | Event bus topic |
+|---------|---------|-----------|-----------------|
+| `LIGHT:XXX` | `LIGHT:512` | Every 2s | `arduino.light_level` |
+| `DOOR:keys` | `DOOR:FL=1,FR=0,RL=0,RR=0,BONNET=0,TRUNK=0` | On change | `vehicle.doors` |
+| `HBRAKE:X` | `HBRAKE:1` | On change | `vehicle.handbrake` |
+| `IGN:X` | `IGN:1` | On change | `vehicle.ignition_raw` |
+| `RAIN:X` | `RAIN:1` | On change | `vehicle.rain` |
+| `TEMP:XX.X` | `TEMP:23.5` | Every 10s | `vehicle.ext_temp_raw` |
+| `PARK:keys` | `PARK:FL=45,FR=60,RL=120,RR=150` | 10Hz when reverse | `vehicle.parking_raw` |
+| `CRUISE:X` | `CRUISE:1` | On change | `vehicle.cruise` |
+| `IMMO:X` | `IMMO:1` | On startup | `vehicle.immo_ok` |
+| `AIRBAG:X` | `AIRBAG:1` | On startup | `vehicle.airbag_ok` |
+
+### Output Arduino (#2) ← BCM (9600 baud, JSON)
+
+| Command | JSON | Action |
+|---------|------|--------|
+| Lock | `{"cmd":"lock"}` | Pulse relay 1 for 500ms |
+| Unlock | `{"cmd":"unlock"}` | Pulse relay 2 for 500ms |
+| Trunk | `{"cmd":"trunk"}` | Pulse relay 3 for 1s |
+| Wipers on | `{"cmd":"wiper","state":1}` | Relay 9 on |
+| Wipers off | `{"cmd":"wiper","state":0}` | Relay 9 off |
+| Headlights | `{"cmd":"lights","state":1,"timeout":60}` | Relay 6 on for 60s |
+| Blinker greet | `{"cmd":"blink","count":2}` | Flash relays 7+8 |
+
+---
+
+## 6. Troubleshooting
+
+**Arduino not detected:**
+```bash
+ls /dev/ttyACM* /dev/ttyUSB*
+# If missing — check USB cable, try different port
+dmesg | grep -i "arduino\|acm\|usb"
+```
+
+**Permission denied on serial port:**
+```bash
+sudo usermod -aG dialout $USER
+# Log out and back in
+```
+
+**DC-ATX doesn't start motherboard:**
+- Check green wire (PS_ON) is connected — some DC-ATX modules have a
+  jumper or switch to enable always-on mode
+- Verify input voltage is >11.5V (car battery under load can dip)
+- Some boards need a brief PS_ON pulse to wake from S5
+
+**Display blank but Flask running:**
+```bash
+curl http://localhost:5002   # Should return HTML
+# If yes → X/Chromium issue, check .xinitrc
+# If no → BCM not started, check journalctl -u bcm-headunit
+```

--- a/src/dashboard/web_viewer.py
+++ b/src/dashboard/web_viewer.py
@@ -204,6 +204,13 @@ class WebViewer:
             "audio_balance": _val("audio.balance", 0),
             # Notifications
             "notifications": _val("system.notifications", []),
+            # Vehicle status (from Arduino serial)
+            "vehicle_doors": _val("vehicle.doors", {}),
+            "vehicle_handbrake": _val("vehicle.handbrake", False),
+            "vehicle_cruise": _val("vehicle.cruise", False),
+            "vehicle_immo_ok": _val("vehicle.immo_ok", True),
+            "vehicle_airbag_ok": _val("vehicle.airbag_ok", True),
+            "vehicle_rain": _val("vehicle.rain", False),
             # Parking
             "parking_distances": _val("parking.distances", []),
             "parking_active": _val("parking.active", False),

--- a/src/input/arduino_serial.py
+++ b/src/input/arduino_serial.py
@@ -1,15 +1,25 @@
-"""Arduino serial data reader — parses non-HID data from Arduino Pro Micro.
+"""Arduino serial data reader — parses telemetry and vehicle signals.
 
-The Arduino sends HID keycodes for button presses (handled by evdev),
-but also sends serial text data for:
-    - Light sensor readings: "LIGHT:XXX" (ADC 0-1023)
-    - Debug messages: "SWC: ...", "MUSIC: ...", etc.
+The Arduino sends HID keycodes for button presses (handled by evdev/arduino_hid),
+but also sends plain-text serial data for sensors and vehicle status:
 
-This module reads the serial port and publishes light sensor data
-to the event bus for the BrightnessController.
+    Inputs (Arduino reads):
+        LIGHT:XXX          — LDR light sensor (ADC 0-1023)
+        DOOR:FL=1,FR=0,RL=0,RR=0,BONNET=0,TRUNK=0  — door/panel states
+        HBRAKE:1           — handbrake engaged (1) or released (0)
+        IGN:1              — ignition/ACC 12V detected
+        RAIN:1             — rain sensor triggered
+        TEMP:23.5          — DS18B20 external temperature
+        PARK:FL=123,FR=45,RL=200,RR=180  — parking sensor distances (cm)
+        CRUISE:1           — cruise control active
+        IMMO:1             — immobilizer recognized key
+        AIRBAG:1           — airbag system OK (0=fault)
 
-On x86: tries /dev/ttyACM0, falls back to stub mode.
-On OPi: uses configured port (default /dev/ttyACM0).
+    Debug (logged only):
+        SWC:..., MUSIC:..., STALK:...
+
+On x86: tries /dev/ttyACM0..1, /dev/ttyUSB0..2, falls back to stub mode.
+On OPi: same auto-detection.
 """
 
 import threading
@@ -31,6 +41,8 @@ ARDUINO_SERIAL_PORTS = [
     "/dev/ttyACM0",
     "/dev/ttyACM1",
     "/dev/ttyUSB0",
+    "/dev/ttyUSB1",
+    "/dev/ttyUSB2",
 ]
 BAUD_RATE = 115200
 
@@ -51,7 +63,20 @@ def find_arduino_serial() -> Optional[str]:
 
 
 class ArduinoSerialListener:
-    """Reads serial data from Arduino and publishes to event bus."""
+    """Reads serial data from Arduino and publishes to event bus.
+
+    Publishes:
+        arduino.light_level  — int (0-1023 ADC)
+        vehicle.doors        — dict {fl, fr, rl, rr, bonnet, trunk} bool
+        vehicle.handbrake    — bool
+        vehicle.ignition_raw — bool (raw 12V detection from Arduino)
+        vehicle.rain         — bool
+        vehicle.ext_temp_raw — float (DS18B20 reading)
+        vehicle.parking_raw  — dict {fl, fr, rl, rr} int (cm)
+        vehicle.cruise       — bool
+        vehicle.immo_ok      — bool
+        vehicle.airbag_ok    — bool
+    """
 
     def __init__(self, event_bus: EventBus):
         self._bus = event_bus
@@ -73,7 +98,7 @@ class ArduinoSerialListener:
             self._thread.start()
             log.info("Arduino serial listener started: %s", self._port)
         else:
-            log.info("Arduino serial: no port found (light sensor disabled)")
+            log.info("Arduino serial: no port found (sensors disabled)")
 
     def stop(self) -> None:
         self._running = False
@@ -97,12 +122,64 @@ class ArduinoSerialListener:
             self._running = False
 
     def _parse_line(self, line: str) -> None:
-        """Parse Arduino serial output."""
-        if line.startswith("LIGHT:"):
-            try:
-                adc = int(line[6:])
-                self._bus.publish("arduino.light_level", adc)
-            except ValueError:
-                pass
-        elif line.startswith("SWC:") or line.startswith("MUSIC:") or line.startswith("STALK:"):
-            log.debug("Arduino: %s", line)
+        """Parse Arduino serial output line."""
+        try:
+            if line.startswith("LIGHT:"):
+                self._bus.publish("arduino.light_level", int(line[6:]))
+
+            elif line.startswith("DOOR:"):
+                self._parse_doors(line[5:])
+
+            elif line.startswith("HBRAKE:"):
+                self._bus.publish("vehicle.handbrake", line[7:] == "1")
+
+            elif line.startswith("IGN:"):
+                self._bus.publish("vehicle.ignition_raw", line[4:] == "1")
+
+            elif line.startswith("RAIN:"):
+                self._bus.publish("vehicle.rain", line[5:] == "1")
+
+            elif line.startswith("TEMP:"):
+                self._bus.publish("vehicle.ext_temp_raw", float(line[5:]))
+
+            elif line.startswith("PARK:"):
+                self._parse_parking(line[5:])
+
+            elif line.startswith("CRUISE:"):
+                self._bus.publish("vehicle.cruise", line[7:] == "1")
+
+            elif line.startswith("IMMO:"):
+                self._bus.publish("vehicle.immo_ok", line[5:] == "1")
+
+            elif line.startswith("AIRBAG:"):
+                self._bus.publish("vehicle.airbag_ok", line[7:] == "1")
+
+            elif line.startswith(("SWC:", "MUSIC:", "STALK:")):
+                log.debug("Arduino: %s", line)
+
+            else:
+                log.debug("Arduino unknown: %s", line)
+
+        except (ValueError, IndexError) as e:
+            log.debug("Parse error '%s': %s", line, e)
+
+    def _parse_doors(self, payload: str) -> None:
+        """Parse DOOR:FL=1,FR=0,RL=0,RR=0,BONNET=0,TRUNK=0"""
+        doors = {}
+        for pair in payload.split(","):
+            if "=" in pair:
+                key, val = pair.split("=", 1)
+                doors[key.strip().lower()] = val.strip() == "1"
+        self._bus.publish("vehicle.doors", doors)
+
+    def _parse_parking(self, payload: str) -> None:
+        """Parse PARK:FL=123,FR=45,RL=200,RR=180 (distances in cm)"""
+        distances = {}
+        for pair in payload.split(","):
+            if "=" in pair:
+                key, val = pair.split("=", 1)
+                try:
+                    distances[key.strip().lower()] = int(val.strip())
+                except ValueError:
+                    distances[key.strip().lower()] = 999
+        self._bus.publish("vehicle.parking_raw", distances)


### PR DESCRIPTION
Expanded arduino_serial.py to parse all vehicle signals from Arduino:
- DOOR (per-door open/close), HBRAKE, IGN, RAIN, TEMP, PARK
- CRUISE, IMMO, AIRBAG status indicators
- All published to event bus for dashboard display

Added vehicle status to WebSocket broadcast (doors, handbrake, cruise, immo, airbag, rain).

New doc: X86_PLATFORM_SETUP.md covering:
- DC-ATX power supply options and wiring (PicoPSU, M4-ATX)
- USB device layout (no PCIe GPIO needed)
- Arduino #1 (input) and #2 (output) pinout and protocol
- Full serial message reference table
- Software setup, startup sequence, sleep modes

https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf