### PR TITLE
Rewrite x86 docs for Lenovo M910q: complete 13-section setup guide

### DIFF
--- a/assets/splash/README.md
+++ b/assets/splash/README.md
@@ -5,8 +5,14 @@ boot log with a branded BCM startup animation:
 
 | File | Target display | Audio? | Suggested format |
 |------|----------------|--------|------------------|
-| `main.mp4`  | Main 7" / 8" touchscreen (HDMI 2.1, `HDMI-A-1`) | **Yes — plays through the car audio system during boot** | 1024×600 or 1280×800, 5–10 s seamless loop, H.264 video + AAC/MP3 audio track |
-| `small.mp4` | Small 4.3" stats display (HDMI 2.0, `HDMI-A-2`) — breathing Alfa Romeo logo | No (silent) | 800×480, 3–5 s loop, no audio track, H.264 |
+| `main.mp4`  | Main 7"/10" touchscreen | **Yes — plays through the car audio system during boot** | 1024×600 or 1280×800, 5–10 s seamless loop, H.264 video + AAC/MP3 audio track |
+| `small.mp4` | Small 4.3" stats display — breathing Alfa Romeo logo | No (silent) | 800×480, 3–5 s loop, no audio track, H.264 |
+
+**DRM connector names vary by platform:**
+- OPi 5 Pro (2× HDMI): `HDMI-A-1` (main), `HDMI-A-2` (small)
+- Lenovo M910q (2× DP): `DP-1` (main), `DP-2` (small) — use passive DP-to-HDMI adapters for HDMI displays
+- GA-N3050N-D2P (HDMI+VGA): `HDMI-1` (main), `DP-2` (VGA/small)
+- Discover yours: `for f in /sys/class/drm/card*-*/status; do echo "$f: $(cat $f)"; done`
 
 Both are picked up by the two systemd services at
 `config/systemd/bcm-splash-main.service` and

--- a/config/bcm_config.yaml
+++ b/config/bcm_config.yaml
@@ -20,8 +20,8 @@ modules:
   blinker_monitor: true      # GPIO watcher that publishes vehicle.left_blinker/right_blinker
 display:
   dashboard:
-    width: 800
-    height: 480
+    width: 1024       # 7" display; for 10" use 1280
+    height: 600       # 7" display; for 10" use 800
     fps: 15
     theme: heritage
     brightness: 70

--- a/config/scripts/xinitrc-x86-dual
+++ b/config/scripts/xinitrc-x86-dual
@@ -1,6 +1,7 @@
 #!/bin/sh
-# BCM kiosk — x86 dual display (HDMI-1 + DP-2/VGA)
-# No window manager — Chromium handles its own windows.
+# BCM kiosk — x86 dual DisplayPort (M910q: DP-1 main + DP-2 small)
+# Both outputs are DisplayPort. Use passive DP-to-HDMI adapters
+# if your displays have HDMI inputs.
 # Copy to ~/.xinitrc
 
 # Disable screen blanking and cursor
@@ -9,22 +10,28 @@ xset -dpms
 xset s noblank
 unclutter -idle 0.5 -root &
 
-# Set up dual display
+# Set up dual display — discover connected outputs
 sleep 1
-xrandr --output HDMI-1 --primary --mode 1024x600 --pos 0x0 \
-       --output DP-2 --mode 800x600 --pos 1024x0
+xrandr --output DP-1 --primary --auto --pos 0x0
+xrandr --output DP-2 --right-of DP-1 --mode 800x480 2>/dev/null || \
+    xrandr --output DP-2 --right-of DP-1 --auto
 
-# Map touchscreen to main display only (prevents touch offset).
-# Auto-detect common touch controllers, then fall back to matching any pointer.
-TOUCH_MAPPED=false
-for TOUCH in $(xinput list --name-only | grep -iE "touch|eGalax|ILITEK|Goodix|FT5|QDtech|MPI"); do
-    xinput map-to-output "$TOUCH" HDMI-1 2>/dev/null && \
-        TOUCH_MAPPED=true && echo "Mapped touch '$TOUCH' → HDMI-1"
-done
-if [ "$TOUCH_MAPPED" = "false" ]; then
-    echo "WARNING: no touchscreen auto-detected. Map manually:"
-    echo "  xinput map-to-output '<device-name>' HDMI-1"
+# Auto-detect main display resolution for scaling
+MAIN_W=$(xrandr | grep 'DP-1 connected' | grep -oP '\d+(?=x)' | head -1)
+SCALE=1.0
+if [ -n "$MAIN_W" ] && [ "$MAIN_W" -le 1024 ] 2>/dev/null; then
+    SCALE=1.1
 fi
+
+# Get main display width for positioning the small display window
+MAIN_FULL_W=$(xrandr | grep 'DP-1 connected' | grep -oP '\d+(?=x)' | head -1)
+MAIN_FULL_W=${MAIN_FULL_W:-1024}
+
+# Map touchscreen to main display only (prevents touch offset)
+for TOUCH in $(xinput list --name-only 2>/dev/null | grep -iE "touch|eGalax|ILITEK|Goodix|FT5|QDtech|MPI"); do
+    xinput map-to-output "$TOUCH" DP-1 2>/dev/null && \
+        echo "Mapped touch '$TOUCH' → DP-1"
+done
 
 # Wait for BCM Flask server
 for i in $(seq 1 90); do
@@ -32,12 +39,13 @@ for i in $(seq 1 90); do
     sleep 1
 done
 
-# Clean old profiles
+# Clean stale Chromium profiles
 rm -rf /tmp/bcm-chromium-main /tmp/bcm-chromium-small
 
-# Main display (HDMI-1) — use --app for no UI chrome
+# Main display (DP-1) — with auto scale factor
 chromium --app=http://localhost:5002 \
-    --window-size=1024,600 --window-position=0,0 \
+    --force-device-scale-factor=$SCALE \
+    --window-size=${MAIN_FULL_W},600 --window-position=0,0 \
     --noerrdialogs --disable-infobars \
     --disable-features=TranslateUI --no-first-run \
     --disable-session-crashed-bubble \
@@ -45,9 +53,9 @@ chromium --app=http://localhost:5002 \
 
 sleep 2
 
-# Small display (DP-2/VGA) — positioned at x=1024 (right of main)
+# Small display (DP-2) — no scale, positioned right of main
 chromium --app=http://localhost:5003 \
-    --window-size=800,600 --window-position=1024,0 \
+    --window-size=800,480 --window-position=${MAIN_FULL_W},0 \
     --noerrdialogs --disable-infobars \
     --disable-features=TranslateUI --no-first-run \
     --disable-session-crashed-bubble \

--- a/config/systemd/bcm-splash-small.service
+++ b/config/systemd/bcm-splash-small.service
@@ -1,46 +1,53 @@
 [Unit]
-Description=BCM Boot Splash — small display (HDMI 2.0, silent)
+Description=BCM Boot Splash — small display (DP-2 / secondary HDMI)
 Documentation=https://github.com/geek95dg/Alfa156-headunit
 DefaultDependencies=no
 
-# Same timing as the main splash: fire before the BCM stack comes
-# up, yield the framebuffer once Chromium takes over. No sound.target
-# dependency because this unit never opens the audio device.
 After=systemd-vconsole-setup.service
-Before=multi-user.target bcm-ignition-watcher.service bcm-headunit.service bcm-kiosk.service
-
-PartOf=bcm-headunit.service
+Before=multi-user.target bcm-ignition-watcher.service
 
 ConditionPathExists=/opt/bcm/assets/splash/small.mp4
 
 [Service]
 Type=simple
 
-# Small display = second HDMI connector. On the OPi 5 Pro that's
-# `HDMI-A-2`; on a single-HDMI rig (OPi PC bench test) the file
-# /opt/bcm/assets/splash/small.mp4 is usually absent and this
-# service just no-ops via ConditionPathExists.
-#
-# Content suggestion: a slow breathing Alfa Romeo logo loop
-# (~3-5 s), SILENT (no audio track), 800x480, user-supplied at
-#   /opt/bcm/assets/splash/small.mp4
-# Audio playback for the bigger "startup jingle" happens on the
-# main display via bcm-splash-main.service.
+# DRM connector for the small display. Override per platform:
+#   M910q (2× DP):     DP-2
+#   OPi 5 Pro (2× HDMI): HDMI-A-2
+#   GA-N3050N-D2P (VGA): DP-2
+# To find your connector names: ls /sys/class/drm/
+# Override: systemctl edit bcm-splash-small → [Service] Environment=BCM_SPLASH_DRM_SMALL=HDMI-A-2
+Environment=BCM_SPLASH_DRM_SMALL=DP-2
+
+# Play splash on secondary display (silent, no audio).
+# Polls Flask :5002 — keeps playing until dashboard is ready.
 ExecStart=/bin/bash -c '\
-    MPV=$(command -v mpv 2>/dev/null || command -v ffplay 2>/dev/null); \
-    if [ -z "$MPV" ]; then \
-        echo "bcm-splash: no mpv/ffplay found — install with apt"; \
-        exit 0; \
-    fi; \
-    exec "$MPV" \
-        --fs --loop-file=inf --really-quiet --no-audio \
-        --vo=drm --drm-connector=HDMI-A-2 \
-        /opt/bcm/assets/splash/small.mp4'
+    MPV=$(command -v mpv 2>/dev/null); \
+    if [ -z "$MPV" ]; then exit 0; fi; \
+    "$MPV" --fs --loop-file=inf --really-quiet --no-audio \
+        --vo=drm,gpu,sdl \
+        --hwdec=auto \
+        --drm-connector=${BCM_SPLASH_DRM_SMALL} \
+        --input-conf=/dev/null \
+        /opt/bcm/assets/splash/small.mp4 & \
+    MPV_PID=$!; \
+    for i in $(seq 1 120); do \
+        if curl -sf http://localhost:5002 >/dev/null 2>&1; then \
+            sleep 5; \
+            kill $MPV_PID 2>/dev/null; \
+            exit 0; \
+        fi; \
+        sleep 1; \
+    done; \
+    kill $MPV_PID 2>/dev/null; \
+    exit 0'
+
+ExecStop=/bin/bash -c 'pkill -f "mpv.*small" 2>/dev/null; true'
 
 SuccessExitStatus=0 1
 Restart=no
 
-# Framebuffer access only; no audio device needed.
+User=root
 SupplementaryGroups=video
 
 StandardOutput=journal

--- a/docs/X86_PLATFORM_SETUP.md
+++ b/docs/X86_PLATFORM_SETUP.md
@@ -1,140 +1,67 @@
-# BCM v8.5 — x86 Platform Setup (Car PC)
+# BCM v8.5 — x86 Platform Setup (Lenovo M910q)
 
-Running the BCM headunit on a standard x86 PC (Intel Celeron N or similar)
-inside the car. All GPIO is handled by USB Arduinos — the x86 board only
-needs USB + HDMI + audio.
+Complete step-by-step guide to building the BCM headunit on a Lenovo
+ThinkCentre M910q Tiny (or similar x86 mini-PC). Covers everything from
+bare hardware to a fully working dual-display car dashboard with wireless
+Android Auto, splash video, suspend/wake, and Arduino vehicle control.
 
-> **Tested on:** Gigabyte GA-N3050N-D2P (Celeron N3050, 4 GB DDR3L,
-> 64 GB SSD, single HDMI, Debian 12 Bookworm minimal).
+> **Primary platform:** Lenovo M910q Tiny (i5-6400T, 8GB DDR4, 256GB NVMe)
+> **Also tested:** Gigabyte GA-N3050N-D2P (Celeron N3050, legacy — some
+> sections note differences)
 
 ---
 
-## 1. Hardware Requirements
+## 1. Hardware Overview
 
-### 1.1 Minimum x86 specs
+### 1.1 Lenovo M910q specs
 
-| Component | Minimum | Recommended |
-|-----------|---------|-------------|
-| CPU | Celeron N3050 (2C/2T) | Celeron N100/N5105 (4C/4T) |
-| RAM | 2 GB | 4 GB |
-| Storage | 16 GB SSD | 64 GB+ SSD (DVR recording) |
-| USB | 4× USB 2.0 (use hub) | 6+ USB (mix 2.0/3.0) |
-| HDMI | 1× HDMI | 1× is enough (see §1.6) |
-| Audio | USB DAC (ES9038Q2M) | same |
-| Network | USB WiFi + USB BT | same |
+| Component | Spec |
+|-----------|------|
+| CPU | Intel i5-6400T (4C/4T, 2.2-2.8GHz, Skylake) |
+| GPU | Intel HD 530 (VAAPI hardware decode) |
+| RAM | 8 GB DDR4 2400 |
+| Storage | 256 GB NVMe SSD |
+| WiFi | Intel 8265 2×2 802.11ac (built-in) |
+| Bluetooth | Intel 8265 BT 4.2 (built-in) |
+| Display outputs | **2× DisplayPort** (mini-DP, model-dependent) |
+| USB | 6× USB 3.0 + 1× USB-C |
+| Power | 65W external 20V barrel jack |
+| Form factor | 1 litre Tiny — fits behind car dash |
 
-### 1.2 Displays — HDMI + optional USB-HDMI
+### 1.2 Dual display setup
 
-Most mini-ITX Celeron boards (including GA-N3050N-D2P) have only **one
-HDMI output**. For a second display, use a USB-to-HDMI adapter with
-a DisplayLink chipset.
+The M910q has **two DisplayPort outputs** — both can drive displays
+simultaneously with no USB adapter needed.
 
-**Primary:** HDMI → 7" touchscreen (main dashboard, port 5002)
-**Secondary (optional):** USB-HDMI → 4.3" display (small dashboard, port 5003)
+| Output | Display | Resolution | Content |
+|--------|---------|-----------|---------|
+| DP-1 | 7" or 10" IPS touchscreen (main) | 1024×600 or 1280×800 | BCM dashboard (port 5002) |
+| DP-2 | 4.3" TFT (small, status) | 800×480 | Small dashboard (port 5003) |
 
-#### USB-HDMI adapter setup (DisplayLink)
+Most car displays have HDMI input. Use **passive DP-to-HDMI adapter
+cables** (~10-15 PLN each). Active adapters are not needed for
+single-link resolutions under 1920×1200.
 
-DisplayLink adapters need the proprietary `evdi` kernel module.
+### 1.3 WiFi and Bluetooth
 
-```bash
-# 1. Install build dependencies
-sudo apt install -y dkms build-essential linux-headers-$(uname -r)
+The Intel 8265 provides both WiFi and Bluetooth. For wireless Android
+Auto, you need a 5GHz WiFi access point:
 
-# 2. Download the DisplayLink driver
-#    Go to https://www.synaptics.com/products/displaylink-graphics/downloads/ubuntu
-#    Download the latest .run file (e.g., DisplayLink USB Graphics Software for Ubuntu 6.x)
-#    Or from the direct URL:
-cd /tmp
-wget https://www.synaptics.com/sites/default/files/exe_files/2024-04/DisplayLink%20USB%20Graphics%20Software%20for%20Ubuntu6.0-EXE.zip
-unzip "DisplayLink USB Graphics Software for Ubuntu6.0-EXE.zip"
-chmod +x displaylink-driver-*.run
-sudo ./displaylink-driver-*.run
+- **Intel 8265 AP mode:** supports AP on 5GHz non-DFS channels (36-48)
+  on Linux. Test first (see §10). If it works, no external dongle needed.
+- **Fallback:** USB WiFi dongle with RTL8812BU chipset (TP-Link Archer
+  T3U Plus, ~70 PLN) if Intel AP mode doesn't work on 5GHz.
+- **Bluetooth:** Intel 8265 BT 4.2 is sufficient for AA pairing. No
+  external BT dongle needed.
 
-# 3. Reboot
-sudo reboot
-
-# 4. Verify the adapter appears as a display
-xrandr --listmonitors
-# Should show: HDMI-1 (or similar) + DVI-I-1-1 (DisplayLink)
-```
-
-**Known limitations:**
-- ~10-30ms latency compared to native HDMI (acceptable for status display)
-- CPU usage ~5-10% for USB frame compression
-- Must use the proprietary driver — no open-source alternative
-- Some cheap adapters have compatibility issues — recommended chipsets:
-  DL-3500, DL-3900, DL-6950
-
-**Configure dual display in .xinitrc** (see §4.4 for full file):
-```bash
-# After matchbox starts, arrange displays:
-xrandr --output HDMI-1 --primary --auto
-xrandr --output DVI-I-1-1 --right-of HDMI-1 --auto
-# Then open two Chromium windows on each display
-```
-
-If DisplayLink doesn't work on your hardware, use the single HDMI for
-the main display and optionally drive the small screen from a Raspberry
-Pi Zero W showing `http://<x86-ip>:5003` in its own Chromium kiosk.
-
-### 1.3 WiFi and Bluetooth dongles
-
-The GA-N3050N-D2P has no built-in WiFi or Bluetooth. For wireless
-Android Auto you need:
-
-| Dongle | Chipset | Purpose | Price (PLN) |
-|--------|---------|---------|-------------|
-| TP-Link Archer T3U Plus | RTL8812BU | WiFi 5GHz AP (AA wireless) | ~70 |
-| TP-Link UB500 | RTL8761B | Bluetooth 5.0 (AA pairing) | ~35 |
-
-Install drivers after OS setup (see §3.3).
-
-### 1.4 Power supply — DC-ATX for car 12V
-
-A standard ATX PSU cannot run from car 12V. Use a **DC-ATX converter**
-(PicoPSU) that takes 12V DC input and outputs all ATX voltages via the
-24-pin connector.
-
-| Module | Input | Output | Price (PLN) | Notes |
-|--------|-------|--------|-------------|-------|
-| **PicoPSU-160-XT** | 12-25V DC | 160W ATX | 150-250 | Most popular, proven |
-| **M4-ATX** | 6-30V DC | 250W ATX | 300-500 | Built-in ignition logic |
-| Generic "DC-ATX 200W" | 12-24V DC | 200W | 60-120 | AliExpress, works fine |
-
-**Wiring:**
+### 1.4 USB device layout
 
 ```
-Car Battery 12V ──┐
-                  ├──[25A fuse]──► DC-ATX ──► 24-pin ATX + 4-pin CPU
-                  │
-ACC/Ignition ─────┼──[PC817]──► Arduino (reports IGN:1 over serial)
-                  │
-                  └──[20A fuse]──► TDA7388 amp (direct 12V)
-```
-
-### 1.5 Suspend / wake (power button + ignition)
-
-The x86 board supports S3 suspend (sleep). BCM uses this for instant
-wake (~2s) when ignition turns on or power button is pressed:
-
-| Event | Action | Wake time |
-|-------|--------|-----------|
-| Ignition ON | Resume from S3 (or start BCM if already awake) | ~2s |
-| Ignition OFF | Stop BCM, suspend to S3 | instant |
-| Power button press | Toggle: suspend ↔ wake | ~2s |
-| 12h standby timeout | Still in S3, next wake = cold splash | ~2s |
-
-See §4 for suspend setup.
-
-### 1.6 USB device layout
-
-```
-x86 motherboard USB ports
-  ├── USB Hub (powered, 7-port recommended)
-  │     ├── Arduino Pro Micro #1 (input controller)
-  │     ├── Arduino Nano #2 (relay controller)
-  │     ├── TP-Link UB500 (Bluetooth 5.0)
-  │     ├── TP-Link Archer T3U Plus (WiFi 5GHz AP)
+M910q USB ports (6× USB 3.0 + 1× USB-C)
+  ├── USB Hub (powered, 7-port, if needed)
+  │     ├── Arduino Pro Micro #1 (input: SWC, buttons, doors, sensors)
+  │     ├── Arduino Nano #2 (output: relays, lock, lights, wipers)
+  │     ├── USB WiFi dongle (only if Intel AP fails — see §10)
   │     ├── USB GPS (NEO-M8N)
   │     ├── USB LTE modem (Huawei E3372)
   │     └── USB microphone
@@ -142,21 +69,118 @@ x86 motherboard USB ports
   └── USB 4-ch AHD grabber (cameras)
 ```
 
+> **Legacy note (GA-N3050N-D2P):** Has HDMI + VGA (shows as DP-2 in
+> xrandr), no built-in WiFi/BT — needs both USB WiFi and BT dongles.
+> See earlier revisions of this file for N3050-specific instructions.
+
 ---
 
-## 2. OS Installation
+## 2. Power Supply + Battery Buffer
 
-### 2.1 Install Debian 12 minimal
+### 2.1 M910q power requirements
 
-Download **Debian 12 (Bookworm) netinst** amd64 ISO. Write to USB
-stick with Rufus/Etcher. Boot and install:
+The M910q uses a **65W 20V external barrel jack** — not an ATX 24-pin
+connector. In the car, you need to convert 12V to 20V.
 
-- **Partitioning:** single ext4 root, no swap (use zram instead)
-- **Software selection:** UNCHECK everything except "SSH server" and
-  "standard system utilities" — no desktop environment
-- **User:** create your user (e.g., `abner`), set root password
+### 2.2 12V → 20V DC-DC converter
 
-### 2.2 Post-install — essential packages
+| Module | Input | Output | Price (PLN) |
+|--------|-------|--------|-------------|
+| XL6019 step-up module (adjustable) | 5-32V | 5-35V, 5A | 15-30 |
+| Universal car laptop adapter (20V) | 12V cig. lighter | 19-20V, 3.5A | 50-100 |
+| MT3608 boost + fine-tune | 2-24V | up to 28V, 2A | 8-15 |
+
+**Recommended:** XL6019 module — set output to 20V with the trimmer
+potentiometer. Verify with a multimeter before connecting to the M910q.
+
+### 2.3 AGM battery buffer (12V 7.2Ah)
+
+An AGM battery between the car battery and the DC-DC converter provides:
+- **Cranking protection:** car battery voltage dips to ~9V during
+  starter engagement — AGM holds steady 12V for the M910q
+- **24h standby:** 7.2Ah at ~2W S3 draw ≈ 43 hours without car battery
+- **UPS:** graceful shutdown on battery disconnect or flat car battery
+
+### 2.4 Wiring diagram
+
+```
+                                   ┌─────────────────────┐
+Car Battery 12V ──[25A fuse]──┬────┤ Schottky diode      │
+                              │    │ (MBR2045, prevents   │
+                              │    │  backfeed to car)    │
+                              │    └──────────┬──────────┘
+                              │               │
+                              │          AGM 12V 7.2Ah
+                              │               │
+                              │    ┌──────────┘
+                              │    │
+                              └────┤
+                                   │
+                         ┌─────────┴──────────┐
+                         │ LVD cutoff (10.5V)  │ ← protects AGM from deep discharge
+                         └─────────┬──────────┘
+                                   │
+                    ┌──────────────┴──────────────┐
+                    │                              │
+              [12V→20V boost]                [20A fuse]
+                    │                              │
+              M910q barrel jack              TDA7388 amp
+                                          (direct 12V)
+```
+
+**Components:**
+- Schottky diode (MBR2045 or similar, 20A): prevents AGM from charging
+  the car battery backwards. One-way current flow: car → AGM.
+- Low-voltage disconnect (LVD): cuts power at 10.5V to protect AGM.
+  Use an adjustable buck module with enable pin, or a dedicated LVD
+  relay (~15 PLN). Set to reconnect at 12.5V (hysteresis).
+- AGM battery: maintenance-free, safe for enclosed mounting. Standard
+  UPS-style 12V 7.2Ah (~50-80 PLN).
+
+**Charging:** Car alternator charges AGM through the Schottky diode
+whenever the engine is running. No dedicated charge controller needed —
+car alternator regulates at ~14.4V which is correct for AGM float charge.
+
+### 2.5 Power budget
+
+| State | M910q draw | Amp draw | Total from 12V |
+|-------|-----------|----------|----------------|
+| S3 suspend | ~2W | 0W | ~0.2A |
+| Active (dashboard) | ~25W | ~5W | ~3A |
+| Active + audio | ~25W | ~40W | ~6A |
+
+AGM standby: 7.2Ah ÷ 0.2A = **36 hours** (exceeds 24h cycle requirement).
+
+---
+
+## 3. OS Installation
+
+### 3.1 Install Debian 12 (Bookworm) minimal
+
+Download **Debian 12 netinst** amd64 ISO. Write to USB stick (Rufus/Etcher).
+
+**Lenovo BIOS:** Press **F1** at boot (not DEL like Gigabyte).
+- Startup → Boot Priority → USB first
+- Boot from USB, install Debian
+
+**Install options:**
+- Partitioning: single ext4 root on NVMe, no swap (use zram)
+- Software: UNCHECK everything except "SSH server" and "standard system utilities"
+- No desktop environment
+- User: create your user (e.g., `abner`)
+
+### 3.2 Enable non-free firmware
+
+Intel 8265 needs `firmware-iwlwifi` from non-free:
+
+```bash
+sudo sed -i 's/main$/main contrib non-free non-free-firmware/' /etc/apt/sources.list
+sudo apt update
+```
+
+---
+
+## 4. System Packages
 
 ```bash
 sudo apt update && sudo apt upgrade -y
@@ -168,71 +192,80 @@ sudo apt install -y \
 
 # Display / kiosk
 sudo apt install -y \
-    xserver-xorg xserver-xorg-video-intel xinit x11-xserver-utils \
-    matchbox-window-manager unclutter chromium
+    xserver-xorg xinit x11-xserver-utils \
+    unclutter chromium
+
+# Intel GPU (VAAPI hardware video decode)
+sudo apt install -y \
+    intel-media-va-driver vainfo libva-drm2
 
 # Audio
 sudo apt install -y \
     pipewire pipewire-pulse wireplumber alsa-utils mpv
 
-# Bluetooth + networking
+# Intel WiFi + Bluetooth firmware
 sudo apt install -y \
-    bluez bluez-tools network-manager
+    firmware-iwlwifi bluez bluez-tools network-manager hostapd dnsmasq
 
 # Camera / video
 sudo apt install -y \
     ffmpeg v4l-utils
 
-# Suspend support
+# Suspend / power management
 sudo apt install -y \
-    acpid pm-utils
+    acpid
+
+# zram (replaces swap, no SSD wear)
+sudo apt install -y zram-tools
+echo -e 'ALGO=lz4\nPERCENT=50' | sudo tee /etc/default/zramswap
+sudo systemctl enable zramswap
+
+# Android Auto build dependencies (see §7)
+sudo apt install -y \
+    cmake build-essential \
+    libboost-all-dev libusb-1.0-0-dev libssl-dev \
+    libprotobuf-dev protobuf-compiler \
+    qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools \
+    qtmultimedia5-dev libqt5multimedia5-plugins \
+    qtconnectivity5-dev qtdeclarative5-dev \
+    qml-module-qtquick2 qml-module-qtquick-controls2 \
+    libqt5websockets5-dev libqt5bluetooth5 \
+    libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+    gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
+    gstreamer1.0-libav \
+    libtag1-dev librtaudio-dev \
+    xvfb matchbox-window-manager
 ```
 
-### 2.3 WiFi driver (RTL8812BU for Archer T3U Plus)
-
+Reboot after package install:
 ```bash
-sudo apt install -y dkms bc build-essential linux-headers-$(uname -r)
-cd /tmp
-git clone https://github.com/morrownr/88x2bu-20210702.git
-cd 88x2bu-20210702
-sudo ./install-driver.sh
+sudo reboot
 ```
 
-Verify after reboot:
+Verify VAAPI after reboot:
 ```bash
-iw list | grep -A5 "Supported interface modes"
-# Must show "AP" in the list
-```
-
-### 2.4 Bluetooth firmware (RTL8761B for UB500)
-
-```bash
-sudo apt install -y firmware-realtek
-# Reboot, then verify:
-bluetoothctl show
-# Should show "Powered: yes"
+vainfo
+# Should show "VAProfileH264" entries — hardware H.264 decode works
 ```
 
 ---
 
-## 3. Boot Optimization — Fast + Silent + Splash Video
+## 5. Boot Optimization
 
-Goal: **BIOS logo → black → your Alfa Romeo splash video → BCM dashboard**.
-No GRUB menu, no kernel log, no service status spam. The splash video
-(not a Plymouth spinner) plays from early boot until the dashboard is ready.
+Goal: **BIOS logo → black → splash video (both screens) → BCM dashboard**.
+No GRUB menu, no kernel log, no systemd service spam.
 
-### 3.1 BIOS settings (GA-N3050N-D2P)
+### 5.1 Lenovo BIOS settings
 
-Enter BIOS (press DEL at boot):
-- **Boot → Fast Boot:** Enabled
-- **Boot → Boot Option #1:** your SSD
-- **Boot → Quiet Boot:** Enabled (shows Gigabyte logo briefly)
-- **Peripherals → USB Configuration → Legacy USB:** Disabled
-  (saves ~2s — Linux handles USB natively)
-- **Power → Restore on AC Power Loss:** Power On (auto-boot after
-  battery disconnect/reconnect)
+Press **F1** at boot to enter BIOS:
+- **Startup → Fast Boot:** Enabled
+- **Startup → Primary Boot Sequence:** NVMe first
+- **Security → Secure Boot:** Disabled (Debian needs this off)
+- **Power → After Power Loss:** Power On (auto-boot after battery reconnect)
+- **USB Setup → USB Legacy Support:** Disabled (saves ~2s)
 
-### 3.2 GRUB — hidden, zero timeout, silent kernel
+### 5.2 GRUB — hidden, silent
 
 ```bash
 sudo cp /etc/default/grub /etc/default/grub.bak
@@ -251,78 +284,61 @@ EOF
 sudo update-grub
 ```
 
-Key parameters:
-- `quiet` — suppress kernel boot messages
-- `loglevel=0` — no kernel messages on console
-- `vt.global_cursor_default=0` — hide blinking text cursor
-- `rd.systemd.show_status=false` — hide `[  OK  ] Started ...` lines
-- `console=tty2` — redirect any remaining output to tty2 (invisible)
-- `fsck.mode=skip` — skip filesystem check on SSD
+**Do NOT add `splash`** — that enables Plymouth, which shows a spinner
+instead of your splash video.
 
-**Do NOT add `splash`** — that keyword enables Plymouth, which would
-show a spinner instead of your splash video.
-
-### 3.3 Disable Plymouth (we use mpv splash instead)
-
-Plymouth shows a spinner/logo during boot. We don't want that — we
-want the mpv splash video to own the screen from early boot.
+### 5.3 Remove Plymouth
 
 ```bash
-# Remove Plymouth completely
-sudo apt remove -y plymouth plymouth-themes
-# Or if you want to keep it installed but disabled:
-sudo systemctl mask plymouth-start.service
-sudo systemctl mask plymouth-quit.service
-sudo systemctl mask plymouth-quit-wait.service
-sudo systemctl mask plymouth-read-write.service
-
-# Rebuild initramfs without Plymouth
+sudo apt remove -y plymouth plymouth-themes 2>/dev/null
 sudo update-initramfs -u
 ```
 
-### 3.4 BCM splash video — plays from early boot
+### 5.4 Splash video on both screens
 
-The `bcm-splash-main.service` plays your MP4 fullscreen on the
-framebuffer using `mpv --vo=drm` (no X server needed). It starts
-immediately after the kernel hands off to systemd, and auto-stops
-when BCM takes over the display.
+The splash plays fullscreen via `mpv --vo=drm` (direct framebuffer, no X).
 
 ```bash
-# Install mpv
 sudo apt install -y mpv
 
-# Create splash directory and place your video
+# Create splash directory
 mkdir -p /opt/bcm/assets/splash
 
-# Your video should be H.264, matching display resolution (e.g. 1024x600),
-# 5-15 seconds, with optional audio track:
-cp your_alfa_romeo_animation.mp4 /opt/bcm/assets/splash/main.mp4
+# Main display splash (with audio, match your display resolution):
+# For 7":  ffmpeg -i source.mp4 -vf scale=1024:600 -c:v libx264 -crf 23 -c:a aac -y main.mp4
+# For 10": ffmpeg -i source.mp4 -vf scale=1280:800 -c:v libx264 -crf 23 -c:a aac -y main.mp4
+cp your_alfa_animation.mp4 /opt/bcm/assets/splash/main.mp4
 
-# Install and enable the splash service
-sudo cp /opt/bcm/config/systemd/bcm-splash-main.service /etc/systemd/system/
-sudo systemctl daemon-reload
-sudo systemctl enable bcm-splash-main
+# Small display splash (silent, 800x480):
+# ffmpeg -i source.mp4 -vf scale=800:480 -an -c:v libx264 -crf 23 -y small.mp4
+cp your_alfa_logo_loop.mp4 /opt/bcm/assets/splash/small.mp4
 ```
 
-**Test the splash manually** (without rebooting):
+**Discover your DRM connector names:**
 ```bash
-# This should play your video fullscreen, no X needed:
-sudo mpv --fs --vo=drm --drm-connector=HDMI-A-1 /opt/bcm/assets/splash/main.mp4
-
-# If --vo=drm doesn't work on your Intel GPU, try:
-sudo mpv --fs --vo=drm /opt/bcm/assets/splash/main.mp4
-# Or check which connectors exist:
-ls /sys/class/drm/
-# Look for card0-HDMI-A-1, card0-VGA-1, etc.
+for f in /sys/class/drm/card*-*/status; do echo "$f: $(cat $f)"; done
+# M910q typically shows: card0-DP-1 and card0-DP-2
 ```
 
-### 3.5 Disable unnecessary services (saves 3-5s boot time)
+**Test splash manually** (must stop X first):
+```bash
+# Switch to text console
+sudo chvt 2
+sudo pkill Xorg
+
+# Test main splash
+sudo mpv --fs --vo=drm --hwdec=auto /opt/bcm/assets/splash/main.mp4
+# Ctrl+C to stop
+
+# Test small splash (on second DP)
+sudo mpv --fs --vo=drm --drm-connector=DP-2 --no-audio /opt/bcm/assets/splash/small.mp4
+```
+
+### 5.5 Disable unnecessary services
 
 ```bash
-# Check what's slow:
 systemd-analyze blame | head -20
 
-# Disable common bloat:
 sudo systemctl disable ModemManager 2>/dev/null
 sudo systemctl disable apt-daily.timer
 sudo systemctl disable apt-daily-upgrade.timer
@@ -331,256 +347,25 @@ sudo systemctl disable man-db.timer 2>/dev/null
 sudo systemctl disable logrotate.timer
 ```
 
-### 3.6 Use zram instead of swap
-
-```bash
-sudo apt install -y zram-tools
-echo -e 'ALGO=lz4\nPERCENT=50' | sudo tee /etc/default/zramswap
-sudo systemctl enable zramswap
-```
-
-### 3.7 Expected boot timeline
+### 5.6 Expected boot timeline
 
 | Time | What happens |
 |------|-------------|
-| 0-3s | BIOS POST (Gigabyte logo — fast boot enabled) |
-| 3s | GRUB (hidden, zero timeout, instant) |
-| 3-5s | Kernel loads (black screen, silent — no Plymouth) |
-| 5-6s | `bcm-splash-main` starts → **your MP4 plays fullscreen** |
-| 6-12s | BCM loads behind splash (Flask starts, services init) |
-| 12-14s | X starts, Chromium kiosk opens, splash auto-stops |
-| **~14s** | **Dashboard visible** |
+| 0-2s | Lenovo BIOS (fast boot) |
+| 2s | GRUB (hidden, instant) |
+| 2-4s | Kernel loads (black screen, silent) |
+| 4-5s | Splash video starts on **both displays** (mpv DRM, VAAPI hw decode) |
+| 5-10s | BCM Flask starts behind splash |
+| 10-12s | Splash detects Flask ready → fades out → X starts |
+| 12-14s | Chromium kiosk opens on both displays |
+| **~12s** | **Dashboard visible** |
 
-Cold boot: **~12-15s**. S3 resume: **~3-5s**.
-After 24h standby, next wake replays the splash video (cold-like wake).
-
----
-
-## 4. Kiosk Display Setup
-
-### 4.1 Allow non-root startx
-
-```bash
-sudo tee /etc/X11/Xwrapper.config >/dev/null <<EOF
-allowed_users=anybody
-needs_root_rights=yes
-EOF
-```
-
-### 4.2 Autologin on tty1
-
-```bash
-sudo mkdir -p /etc/systemd/system/getty@tty1.service.d
-sudo tee /etc/systemd/system/getty@tty1.service.d/autologin.conf >/dev/null <<EOF
-[Service]
-ExecStart=
-ExecStart=-/sbin/agetty --autologin $USER --noclear %I \$TERM
-EOF
-sudo systemctl daemon-reload
-```
-
-### 4.3 Auto-start X on login (no cursor)
-
-```bash
-cat >> ~/.bash_profile <<'EOF'
-
-# BCM kiosk: start X on tty1 only, hide cursor
-if [ -z "$DISPLAY" ] && [ "$(tty)" = "/dev/tty1" ]; then
-    exec startx -- -nocursor
-fi
-EOF
-```
-
-### 4.4 Create ~/.xinitrc — kiosk Chromium
-
-**Single display (HDMI only):**
-
-```bash
-cat > ~/.xinitrc <<'XEOF'
-#!/bin/sh
-# BCM kiosk — single display
-
-xset s off && xset -dpms && xset s noblank
-unclutter -idle 0.5 -root &
-matchbox-window-manager -use_titlebar no -use_cursor no &
-
-# Wait for Flask (up to 60s)
-for i in $(seq 1 60); do
-    curl -sf http://localhost:5002 >/dev/null && break
-    sleep 1
-done
-
-# Clear stale Chromium profile (prevents "restore session" bar)
-rm -rf /tmp/bcm-chromium-main
-
-# Main dashboard — full kiosk
-chromium --kiosk --noerrdialogs --disable-infobars \
-    --disable-features=TranslateUI --no-first-run --fast \
-    --disable-session-crashed-bubble --disable-translate \
-    --disable-pinch --overscroll-history-navigation=0 \
-    --user-data-dir=/tmp/bcm-chromium-main \
-    http://localhost:5002 &
-
-wait
-XEOF
-chmod +x ~/.xinitrc
-```
-
-**Dual display (HDMI + USB-HDMI DisplayLink):**
-
-```bash
-cat > ~/.xinitrc <<'XEOF'
-#!/bin/sh
-# BCM kiosk — dual display (HDMI + DisplayLink)
-
-xset s off && xset -dpms && xset s noblank
-unclutter -idle 0.5 -root &
-matchbox-window-manager -use_titlebar no -use_cursor no &
-
-# Arrange displays (adjust output names from: xrandr --listmonitors)
-sleep 1
-xrandr --output HDMI-1 --primary --auto
-xrandr --output DVI-I-1-1 --right-of HDMI-1 --mode 800x480 2>/dev/null
-
-# Wait for Flask
-for i in $(seq 1 60); do
-    curl -sf http://localhost:5002 >/dev/null && break
-    sleep 1
-done
-
-rm -rf /tmp/bcm-chromium-main /tmp/bcm-chromium-small
-
-# Main display (HDMI) — port 5002
-chromium --kiosk --noerrdialogs --disable-infobars \
-    --disable-features=TranslateUI --no-first-run --fast \
-    --disable-session-crashed-bubble --disable-translate \
-    --disable-pinch --overscroll-history-navigation=0 \
-    --user-data-dir=/tmp/bcm-chromium-main \
-    http://localhost:5002 &
-
-sleep 2
-
-# Small display (DisplayLink) — port 5003
-# window-position places it on the second monitor
-MAIN_W=$(xrandr | grep 'HDMI-1' | grep -oP '\d+x\d+\+\K\d+' | head -1)
-chromium --kiosk --noerrdialogs --disable-infobars \
-    --disable-features=TranslateUI --no-first-run \
-    --window-size=800,480 \
-    --window-position=${MAIN_W:-1024},0 \
-    --user-data-dir=/tmp/bcm-chromium-small \
-    http://localhost:5003 &
-
-wait
-XEOF
-chmod +x ~/.xinitrc
-```
+Cold boot: **~10-12s** (NVMe). S3 resume: **~2-3s**.
+After 24h standby, next wake replays the splash (cold-like boot).
 
 ---
 
-## 5. Suspend / Wake Setup
-
-The power button on the x86 case and the ignition signal both control
-suspend (S3 sleep). This gives instant ~2s wake instead of cold boot.
-
-### 5.1 Configure ACPI power button for suspend
-
-By default, pressing the power button shuts down the PC. Change it to
-suspend instead:
-
-```bash
-# Install acpid
-sudo apt install -y acpid
-
-# Override power button action
-sudo mkdir -p /etc/acpi/events
-sudo tee /etc/acpi/events/power-button >/dev/null <<EOF
-event=button/power
-action=/usr/local/bin/bcm-power-toggle.sh
-EOF
-
-# Create the toggle script
-sudo tee /usr/local/bin/bcm-power-toggle.sh >/dev/null <<'EOF'
-#!/bin/bash
-# Power button: toggle between suspend and wake
-# (wake is handled by BIOS — pressing power in S3 wakes the system)
-
-STATE=$(cat /sys/power/state 2>/dev/null)
-if systemctl is-active --quiet bcm-headunit.service; then
-    # BCM is running → stop it and suspend
-    systemctl stop bcm-headunit.service
-    sleep 1
-    systemctl suspend
-else
-    # BCM is not running → just suspend
-    systemctl suspend
-fi
-EOF
-sudo chmod +x /usr/local/bin/bcm-power-toggle.sh
-
-# Restart acpid
-sudo systemctl enable acpid
-sudo systemctl restart acpid
-```
-
-### 5.2 Auto-start BCM after resume from suspend
-
-```bash
-# systemd service that starts BCM on resume
-sudo tee /etc/systemd/system/bcm-resume.service >/dev/null <<EOF
-[Unit]
-Description=BCM — Resume from suspend (restart headunit)
-After=suspend.target
-
-[Service]
-Type=oneshot
-ExecStart=/bin/bash -c 'sleep 2 && systemctl start bcm-headunit.service'
-
-[Install]
-WantedBy=suspend.target
-EOF
-
-sudo systemctl daemon-reload
-sudo systemctl enable bcm-resume
-```
-
-### 5.3 Ignition / Arduino poweroff → auto-suspend
-
-The ignition watcher has built-in suspend support. When BCM stops
-(ignition off, Arduino POWEROFF button, SWC MODE), it waits 5 seconds
-then suspends to S3 automatically. This is enabled in the config:
-
-```yaml
-# config/bcm_config.yaml → power.ignition_watcher:
-autostart: true            # start BCM immediately on boot
-suspend_on_stop: true      # suspend to S3 when BCM stops
-suspend_delay_seconds: 5   # wait before suspend (engine restart grace)
-standby_max_hours: 24      # after 24h, next wake = cold boot with splash
-```
-
-No extra scripts needed — the ignition watcher handles everything.
-
-### 5.4 BIOS wake settings
-
-Enter BIOS (DEL at boot):
-- **Power → Restore on AC Power Loss:** Power On (auto-boot if
-  battery was disconnected and reconnected)
-- **Power → Wake on USB:** Enabled (so USB Arduino can wake from S3)
-
-### 5.5 Test suspend/wake from command line
-
-```bash
-# Manual suspend
-sudo systemctl suspend
-
-# Press power button → should wake and BCM starts in ~3s
-
-# Check suspend worked
-journalctl -u bcm-resume --no-pager -n5
-```
-
----
-
-## 6. BCM Installation and Services
+## 6. BCM Installation
 
 ### 6.1 Clone and install
 
@@ -600,166 +385,401 @@ pip install -r requirements-x86.txt
 
 ```bash
 sudo usermod -aG dialout $USER
-# Log out and back in for this to take effect
+# Log out and back in
 ```
 
-### 6.3 Install systemd services
+### 6.3 Configuration
+
+The default config (`config/bcm_config.yaml`) has the display set to
+1024×600 (7" screen). For a 10" display, edit:
 
 ```bash
-# Copy service files
+nano /opt/bcm/config/bcm_config.yaml
+```
+
+```yaml
+display:
+  dashboard:
+    width: 1280       # 10" display (or 1024 for 7")
+    height: 800       # 10" display (or 600 for 7")
+```
+
+---
+
+## 7. Android Auto — Compile from Source
+
+Android Auto requires two open-source projects: **aasdk** (protocol library)
+and **openauto** (Qt5 UI app). Both must be compiled on the target machine.
+
+### 7.1 Build aasdk
+
+```bash
+cd /tmp
+git clone --recurse-submodules https://github.com/openDsh/aasdk.git
+cd aasdk
+
+# Fix OpenSSL 3.0 compatibility (FIPS_mode_set was removed)
+sed -i 's/FIPS_mode_set(0);/\/\/ FIPS_mode_set(0); \/\/ removed in OpenSSL 3.0/' \
+    src/Transport/SSLWrapper.cpp
+
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j$(nproc)
+sudo make install
+sudo ldconfig
+```
+
+### 7.2 Build h264bitstream (manual — no Makefile in repo)
+
+```bash
+cd /tmp
+git clone https://github.com/aizvorski/h264bitstream.git
+cd h264bitstream
+
+# Compile manually
+gcc -c -fPIC h264_stream.c h264_sei.c -I.
+ar rcs libh264bitstream.a h264_stream.o h264_sei.o
+
+# Install
+sudo cp libh264bitstream.a /usr/local/lib/
+sudo cp h264_stream.h h264_sei.h h264_avcc.h h264_slice_data.h bs.h \
+    /usr/local/include/
+sudo ldconfig
+```
+
+> **Note:** `h264_nal.h` does not exist in newer versions — this is normal.
+
+### 7.3 Build openauto
+
+```bash
+cd /tmp
+git clone --recurse-submodules https://github.com/openDsh/openauto.git
+cd openauto
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j$(nproc)
+sudo make install
+```
+
+### 7.4 Verify
+
+```bash
+ls -la /usr/local/bin/autoapp
+# Should show the binary (~5MB)
+```
+
+Restart BCM to pick up autoapp:
+```bash
+sudo systemctl restart bcm-ignition-watcher
+sudo journalctl -u bcm-headunit --no-pager | grep -i openauto
+# Should show: "OpenAuto found: /usr/local/bin/autoapp"
+```
+
+### 7.5 Phone setup for Android Auto
+
+On your Android phone:
+1. Install **Android Auto** from Play Store
+2. Enable **Developer options** → **USB debugging**
+3. Connect phone via USB cable
+4. Accept "Allow USB debugging" prompt on phone
+5. Select "Android Auto" when phone asks about USB mode
+6. AA should appear on BCM screen A2
+
+For wireless AA, complete the WiFi AP setup in §10 first.
+
+---
+
+## 8. Display Kiosk Setup
+
+### 8.1 Allow non-root startx
+
+```bash
+sudo tee /etc/X11/Xwrapper.config >/dev/null <<EOF
+allowed_users=anybody
+needs_root_rights=yes
+EOF
+```
+
+### 8.2 Autologin on tty1
+
+```bash
+sudo mkdir -p /etc/systemd/system/getty@tty1.service.d
+sudo tee /etc/systemd/system/getty@tty1.service.d/autologin.conf >/dev/null <<EOF
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin $USER --noclear %I \$TERM
+EOF
+sudo systemctl daemon-reload
+```
+
+### 8.3 Auto-start X on login (no cursor)
+
+```bash
+cat >> ~/.bash_profile <<'EOF'
+
+# BCM kiosk: start X on tty1 only, hide cursor
+if [ -z "$DISPLAY" ] && [ "$(tty)" = "/dev/tty1" ]; then
+    exec startx -- -nocursor
+fi
+EOF
+```
+
+### 8.4 Install the dual-display xinitrc
+
+```bash
+cp /opt/bcm/config/scripts/xinitrc-x86-dual ~/.xinitrc
+```
+
+This xinitrc:
+- Sets up DP-1 (main) + DP-2 (small) via xrandr
+- **Auto-detects resolution**: 7" (≤1024px) gets `scale-factor=1.1`
+  for +10% bigger UI; 10" (≥1280px) uses native scale (more room)
+- Maps touchscreen to DP-1 only (prevents touch offset)
+- Opens Chromium `--app` windows at correct positions per display
+- No window manager — prevents screen merging
+
+### 8.5 Display auto-adaptation
+
+The BCM frontend uses viewport-relative units and Tailwind responsive
+classes. It adapts to any resolution automatically:
+
+| Display | Resolution | Scale factor | Effective viewport |
+|---------|-----------|-------------|-------------------|
+| 7" IPS | 1024×600 | 1.1 (+10%) | 931×545 CSS px |
+| 10" IPS | 1280×800 | 1.0 (native) | 1280×800 CSS px |
+
+If elements overlap at 1.1x scale, reduce to 1.05:
+```bash
+# Edit ~/.xinitrc, find the SCALE= line:
+SCALE=1.05
+```
+
+---
+
+## 9. Systemd Services
+
+### 9.1 Install all services
+
+```bash
+cd /opt/bcm
+
+# Use the x86-specific headunit service
+sudo cp config/systemd/bcm-headunit-x86.service /etc/systemd/system/bcm-headunit.service
 sudo cp config/systemd/bcm-ignition-watcher.service /etc/systemd/system/
-sudo cp config/systemd/bcm-headunit.service /etc/systemd/system/
 sudo cp config/systemd/bcm-splash-main.service /etc/systemd/system/
+sudo cp config/systemd/bcm-splash-small.service /etc/systemd/system/
 sudo cp config/systemd/bcm-resume.service /etc/systemd/system/
 
-# The ignition watcher service already has --autostart and x86 config.
-# Edit the headunit service for x86:
-sudo sed -i 's/--platform opi_pc/--platform x86/' /etc/systemd/system/bcm-headunit.service
-sudo sed -i 's/bcm_config_opi_pc.yaml/bcm_config.yaml/' /etc/systemd/system/bcm-headunit.service
-
-# Mask the kiosk service (.xinitrc handles Chromium, not systemd)
+# Mask the kiosk service (.xinitrc handles Chromium)
 sudo systemctl mask bcm-kiosk.service
 
 # Enable services
 sudo systemctl daemon-reload
-sudo systemctl enable bcm-ignition-watcher   # starts BCM on boot (--autostart)
-sudo systemctl enable bcm-splash-main        # splash video on cold boot
-sudo systemctl enable bcm-resume             # restart BCM after S3 wake
+sudo systemctl enable bcm-ignition-watcher
+sudo systemctl enable bcm-splash-main
+sudo systemctl enable bcm-splash-small
+sudo systemctl enable bcm-resume
+```
 
-# Set up power button → suspend
-sudo apt install -y acpid
+### 9.2 Power button → suspend (acpid)
+
+```bash
 sudo mkdir -p /etc/acpi/events
 sudo tee /etc/acpi/events/power-button >/dev/null <<EOF
 event=button/power
 action=/usr/local/bin/bcm-power-toggle.sh
 EOF
+
 sudo cp /opt/bcm/config/scripts/bcm-power-toggle.sh /usr/local/bin/
 sudo chmod +x /usr/local/bin/bcm-power-toggle.sh
 sudo systemctl enable acpid
 ```
 
-**What happens on boot:**
-1. OS boots → splash video plays (mpv, no X)
-2. `bcm-ignition-watcher` starts with `--autostart`
-3. BCM starts immediately (no ignition file needed)
-4. X starts → Chromium kiosk opens → splash auto-stops
-5. Dashboard visible
+### 9.3 Lifecycle summary
 
-**What happens on standby trigger** (power button / Arduino / ignition off):
-1. BCM stops
-2. Wait 5 seconds (grace period)
-3. System suspends to S3 (~2W draw)
-4. Press power button (or ignition on) → wake in ~2-3s
-5. `bcm-resume.service` restarts BCM
+**Cold boot** (first power-on or after 24h standby):
+1. BIOS → GRUB (hidden) → kernel (silent)
+2. `bcm-splash-main` + `bcm-splash-small` → video on both screens
+3. `bcm-ignition-watcher` starts with `--autostart` → starts BCM immediately
+4. Flask starts → splash detects it → kills mpv after 5s overlap
+5. X starts → Chromium kiosk on both displays → dashboard visible
 
-**After 24h standby:** next wake replays the splash video (cold-like wake).
+**Standby** (power button / Arduino POWEROFF / ignition off):
+1. BCM stops → 5s grace period → system suspends to S3
+2. Power draw: ~2W from AGM battery
+3. AGM sustains 36+ hours of S3
 
-### 6.5 Test manually before reboot
+**Wake** (power button / ignition on):
+1. System resumes from S3 in ~2s
+2. `bcm-resume.service` restarts BCM
+3. Dashboard visible in ~3s total (no splash — warm wake)
+
+**24h cycle reset:**
+1. After 24h in standby, next wake is treated as cold boot
+2. Splash video replays on both screens
+3. Full BCM reinitialisation
+
+---
+
+## 10. WiFi Access Point for Wireless Android Auto
+
+Wireless AA requires a 5GHz WiFi access point. The phone pairs via
+Bluetooth (Intel 8265 built-in), then connects to the WiFi AP for
+the TCP data stream.
+
+### 10.1 Test Intel 8265 AP mode (try first)
 
 ```bash
-source /opt/bcm/.venv/bin/activate
-python3 main.py --platform x86 --config config/bcm_config.yaml --frontend
+# Check if AP mode is supported
+iw list | grep -A5 "Supported interface modes"
+# Must show "AP"
 
-# In another terminal: open browser to http://localhost:5002
-# Ctrl+C to stop
+# Set regulatory domain
+sudo iw reg set PL
+
+# Test 5GHz AP
+sudo tee /tmp/test-ap.conf >/dev/null <<EOF
+interface=wlan0
+driver=nl80211
+ssid=ALFA_AA
+hw_mode=a
+channel=36
+ieee80211n=1
+ieee80211ac=1
+wpa=2
+wpa_passphrase=AlfaRomeo156
+wpa_key_mgmt=WPA-PSK
+EOF
+
+sudo hostapd /tmp/test-ap.conf
+```
+
+If hostapd starts without errors and your phone can see "ALFA_AA" on
+5GHz — **Intel 8265 works, skip §10.2.**
+
+If it fails with "Could not set channel" or "DFS" errors — install
+a USB WiFi dongle (§10.2).
+
+### 10.2 USB WiFi dongle fallback (RTL8812BU)
+
+```bash
+sudo apt install -y dkms bc linux-headers-$(uname -r)
+cd /tmp
+git clone https://github.com/morrownr/88x2bu-20210702.git
+cd 88x2bu-20210702
+sudo ./install-driver.sh
+# Reboot, then verify:
+iw list | grep -A5 "Supported interface modes"
+```
+
+### 10.3 Persistent AP with hostapd + dnsmasq
+
+Once you know which interface works (wlan0 for Intel, wlx... for USB):
+
+```bash
+# Find your WiFi interface name
+ip link show | grep -E "wlan|wlx"
+WIFI_IFACE=wlan0  # or wlxXXXXXXXXXXXX for USB dongle
+
+# Configure hostapd
+sudo tee /etc/hostapd/hostapd.conf >/dev/null <<EOF
+interface=$WIFI_IFACE
+driver=nl80211
+ssid=ALFA
+hw_mode=a
+channel=36
+ieee80211n=1
+ieee80211ac=1
+wmm_enabled=1
+wpa=2
+wpa_passphrase=AlfaRomeo156
+wpa_key_mgmt=WPA-PSK
+rsn_pairwise=CCMP
+EOF
+
+sudo tee /etc/default/hostapd >/dev/null <<EOF
+DAEMON_CONF="/etc/hostapd/hostapd.conf"
+EOF
+
+# Configure dnsmasq for DHCP
+sudo tee /etc/dnsmasq.d/bcm-ap.conf >/dev/null <<EOF
+interface=$WIFI_IFACE
+dhcp-range=192.168.44.10,192.168.44.50,255.255.255.0,24h
+EOF
+
+# Static IP for the AP interface
+sudo tee /etc/network/interfaces.d/bcm-ap >/dev/null <<EOF
+auto $WIFI_IFACE
+iface $WIFI_IFACE inet static
+    address 192.168.44.1
+    netmask 255.255.255.0
+EOF
+
+# Enable services
+sudo systemctl unmask hostapd
+sudo systemctl enable hostapd dnsmasq
+sudo systemctl start hostapd dnsmasq
+```
+
+### 10.4 BCM config for WiFi
+
+Edit `/opt/bcm/config/bcm_config.yaml`:
+```yaml
+wifi:
+  enabled: true
+  ssid: ALFA
+  password: AlfaRomeo156
 ```
 
 ---
 
-## 7. Troubleshooting
+## 11. Arduino Wiring Reference
 
-**Chromium not in kiosk mode (shows address bar, tabs):**
-- The `--kiosk` flag in `.xinitrc` must be present
-- Delete old profile: `rm -rf /tmp/bcm-chromium-main`
-- Ensure matchbox-window-manager is running (`-use_titlebar no`)
-- Check that `.xinitrc` is executable: `chmod +x ~/.xinitrc`
+All vehicle I/O goes through USB Arduinos — no GPIO on the x86 board.
 
-**Kernel messages visible during boot:**
-- Run: `sudo update-grub` after editing `/etc/default/grub`
-- Verify with: `cat /proc/cmdline` — should show `quiet splash loglevel=0`
-- Install Plymouth: `sudo apt install plymouth plymouth-themes`
-
-**GRUB menu still showing:**
-- Set `GRUB_TIMEOUT=0` and `GRUB_HIDDEN_TIMEOUT=0`
-- Run `sudo update-grub`
-- Remove `/etc/grub.d/30_os-prober`: `sudo chmod -x /etc/grub.d/30_os-prober`
-
-**Splash video not playing:**
-- Check file exists: `ls -la /opt/bcm/assets/splash/main.mp4`
-- Check mpv is installed: `which mpv`
-- Test manually: `mpv --fs --vo=drm /opt/bcm/assets/splash/main.mp4`
-- Check journal: `journalctl -u bcm-splash-main`
-
-**USB-to-HDMI adapter not working:**
-- DisplayLink adapters require proprietary `evdi` kernel module
-- On Linux this is unreliable — **do not use**
-- Use single HDMI for main display, skip small display
-
-**Suspend not working:**
-- Check: `cat /sys/power/state` — should list `mem` (S3)
-- Test: `sudo systemctl suspend` — should sleep, power button wakes
-- BIOS: ensure S3 is enabled (not S0ix/Modern Standby)
-- Check acpid: `sudo systemctl status acpid`
-
-**Arduino not detected:**
-```bash
-ls /dev/ttyACM* /dev/ttyUSB*
-dmesg | grep -i "arduino\|acm\|usb"
-# If permission denied:
-sudo usermod -aG dialout $USER
-```
-
-**No sound from USB DAC:**
-```bash
-wpctl status                    # list PipeWire devices
-wpctl set-default <sink-id>     # set DAC as default
-speaker-test -D plughw:1,0 -t sine   # test ALSA directly
-```
-
----
-
-## 8. Arduino Wiring Reference
-
-### Arduino #1 — Input controller (Pro Micro, 115200 baud)
+### 11.1 Arduino #1 — Input controller (Pro Micro, 115200 baud)
 
 ```
 Analog:
-  A0 ← SWC pod 1 (resistor ladder)
-  A1 ← LDR (ambient light)
-  A6 ← SWC pod 2 / music panel
+  A0 ← SWC pod 1 (resistor ladder, 12 buttons)
+  A1 ← LDR (ambient light sensor)
+  A6 ← SWC pod 2 / music panel (resistor ladder)
 
-Digital (PC817 optoisolators, active-low):
-  D2 ← Ignition/ACC 12V
-  D3 ← Handbrake
-  D4 ← Door FL        D5 ← Door FR
-  D6 ← Door RL        D7 ← Door RR
-  D8 ← Bonnet         D9 ← Trunk
-  D10 ← Rain sensor
+Digital inputs (PC817 optoisolators, active-low):
+  D2 ← Ignition/ACC 12V detect
+  D3 ← Handbrake switch
+  D4 ← Door FL       D5 ← Door FR
+  D6 ← Door RL       D7 ← Door RR
+  D8 ← Bonnet        D9 ← Trunk
+  D10 ← Rain sensor digital output
 
-DS18B20 (1-Wire):  D14 ← Ext. temperature
+DS18B20 (1-Wire):
+  D14 ← External temperature probe
 
-HC-SR04 parking:
+HC-SR04 parking sensors:
   D15 → TRIG (shared)
-  D16 ← ECHO FL       A2 ← ECHO FR
-  A3 ← ECHO RL        A7 ← ECHO RR
+  D16 ← ECHO FL      A2 ← ECHO FR
+  A3 ← ECHO RL       A7 ← ECHO RR
+
+USB HID output: button keycodes (volume, media, nav)
+Serial output: LIGHT, DOOR, HBRAKE, IGN, RAIN, TEMP, PARK
 ```
 
-### Arduino #2 — Output controller (Nano, 9600 baud JSON)
+### 11.2 Arduino #2 — Output controller (Nano, 9600 baud JSON)
 
 ```
-Relay outputs:
-  D2 → Lock       D3 → Unlock     D4 → Trunk
-  D5 → Window up  D6 → Window dn  D7 → Headlights
-  D8 → L blinker  D9 → R blinker  D10 → Wipers
-  D11 → Horn
+Relay outputs (10-channel relay module):
+  D2 → Central lock (LOCK)      D3 → Central lock (UNLOCK)
+  D4 → Trunk release            D5 → Window up (all)
+  D6 → Window down (all)        D7 → Headlights (follow-me-home)
+  D8 → Left blinker             D9 → Right blinker
+  D10 → Wiper motor relay       D11 → Horn (alarm)
 
 Input:
-  D12 ← RF 433MHz receiver (RXB6)
+  D12 ← RF 433MHz receiver (RXB6) — key fob signal
 ```
 
-### Serial protocol
-
-See `src/input/arduino_serial.py` for the full parser. Messages:
+### 11.3 Serial protocol
 
 | Direction | Message | Example |
 |-----------|---------|---------|
@@ -772,3 +792,121 @@ See `src/input/arduino_serial.py` for the full parser. Messages:
 | Arduino→BCM | `PARK:keys` | `PARK:FL=45,FR=60,RL=120,RR=150` |
 | BCM→Arduino | JSON | `{"cmd":"lock"}` |
 | BCM→Arduino | JSON | `{"cmd":"lights","state":1,"timeout":60}` |
+| BCM→Arduino | JSON | `{"cmd":"wiper","state":1}` |
+| BCM→Arduino | JSON | `{"cmd":"blink","count":2}` |
+
+---
+
+## 12. Verification Checklist
+
+After completing all steps, verify each feature:
+
+```
+[ ] Both displays show splash video on cold boot
+[ ] Main splash has audio through USB DAC / speakers
+[ ] Small splash is silent
+[ ] Splash stops when dashboard appears (no manual intervention)
+[ ] BCM dashboard loads on DP-1 (main), small dashboard on DP-2
+[ ] Touch only registers on DP-1 (main display)
+[ ] UI is 10% larger on 7" screen (or native on 10")
+[ ] No element overlapping on any screen (A1-A8 + Settings)
+[ ] Power button press → suspend to S3
+[ ] Power button again → wake in ~3s, dashboard appears
+[ ] After 24h standby → next wake shows splash (cold-like)
+[ ] Audio plays through USB DAC / speakers
+[ ] Android Auto connects (USB cable to phone)
+[ ] WiFi AP visible on phone (for wireless AA)
+[ ] BT pairing works (Intel 8265)
+[ ] Arduino serial data appears: journalctl -u bcm-headunit | grep Arduino
+```
+
+---
+
+## 13. Troubleshooting
+
+**DRM connector names — how to find yours:**
+```bash
+for f in /sys/class/drm/card*-*/status; do echo "$f: $(cat $f)"; done
+# M910q: card0-DP-1: connected, card0-DP-2: connected
+```
+
+**Splash video laggy:**
+- Re-encode to match display resolution (not 720p/1080p)
+- Verify VAAPI: `vainfo | grep H264`
+- Add `--hwdec=vaapi` explicitly to mpv command
+
+**Splash not showing / DRM busy:**
+- Splash must start before X. Check service ordering:
+  `systemctl list-dependencies bcm-splash-main`
+- If testing manually, stop X first: `sudo pkill Xorg`
+
+**Screens merged into one (Chromium spans both):**
+- Don't use matchbox-window-manager for dual display
+- Use the `xinitrc-x86-dual` script (no WM, `--app` mode)
+- Verify xrandr: `DISPLAY=:0 xrandr --listmonitors`
+
+**Touch offset (pointer doesn't match finger):**
+```bash
+DISPLAY=:0 xinput list
+# Find your touchscreen device name
+DISPLAY=:0 xinput map-to-output "YourTouchDevice" DP-1
+```
+
+**Android Auto: FIPS_mode_set error (aasdk build):**
+```bash
+sed -i 's/FIPS_mode_set(0);/\/\/ removed in OpenSSL 3.0/' src/Transport/SSLWrapper.cpp
+```
+
+**Android Auto: missing h264bitstream (openauto build):**
+```bash
+cd /tmp/h264bitstream
+gcc -c -fPIC h264_stream.c h264_sei.c -I.
+ar rcs libh264bitstream.a h264_stream.o h264_sei.o
+sudo cp libh264bitstream.a /usr/local/lib/
+sudo cp *.h /usr/local/include/
+sudo ldconfig
+```
+
+**Android Auto: missing Qt5Qml:**
+```bash
+sudo apt install -y qtdeclarative5-dev qml-module-qtquick2
+```
+
+**Intel 8265 WiFi won't create 5GHz AP:**
+- Set country code: `sudo iw reg set PL`
+- Use channel 36 (non-DFS)
+- If still fails: install USB RTL8812BU dongle (§10.2)
+
+**BCM not starting (autostart fails):**
+```bash
+sudo journalctl -u bcm-ignition-watcher --no-pager -n 20
+sudo journalctl -u bcm-headunit --no-pager -n 20
+# Common: wrong config path, venv broken, Python import error
+```
+
+**Suspend not working:**
+```bash
+cat /sys/power/state    # should list "mem"
+sudo systemctl suspend  # test manually
+# If no "mem": BIOS → enable S3 (not S0ix/Modern Standby)
+```
+
+**Scale factor causes overlapping:**
+```bash
+# Edit ~/.xinitrc — reduce scale
+SCALE=1.05   # or 1.0 for no scaling
+```
+
+**No sound:**
+```bash
+wpctl status                  # list sinks
+wpctl set-default <sink-id>   # set your DAC as default
+speaker-test -t sine -l 1     # test
+```
+
+**Arduino not detected:**
+```bash
+ls /dev/ttyACM* /dev/ttyUSB*
+dmesg | grep -i "arduino\|acm"
+sudo usermod -aG dialout $USER  # then re-login
+```


### PR DESCRIPTION
docs/X86_PLATFORM_SETUP.md — 912-line complete rewrite:
- M910q as primary platform (i5-6400T, dual DP, Intel 8265 WiFi/BT)
- AGM 12V 7.2Ah battery buffer with Schottky diode and LVD cutoff
- 12V→20V DC-DC converter (not ATX) for M910q barrel jack
- Full Android Auto compile: aasdk (OpenSSL 3.0 FIPS fix), h264bitstream (manual gcc+ar build), openauto (Qt5Qml fix) — all issues documented
- Dual DP display: DP-1 main (7" or 10"), DP-2 small (4.3")
- Auto-adaptive UI: 7" gets 1.1x scale, 10" native resolution
- Intel 8265 WiFi AP mode on 5GHz (ch36) with USB dongle fallback
- hostapd + dnsmasq config for persistent AP
- Splash video on both screens (VAAPI hw decode, no lag on i5)
- 24h standby cycle, suspend/wake, power button toggle
- 12-point verification checklist
- Comprehensive troubleshooting (every error encountered during testing)

config/bcm_config.yaml:
- Display dimensions: 800×480 → 1024×600 (with 10" comment)

bcm-splash-small.service:
- Configurable DRM connector via environment variable
- Poll-based (waits for Flask like main splash)
- Added --hwdec=auto for VAAPI

xinitrc-x86-dual:
- Both outputs DP (DP-1 + DP-2), auto-detect resolution
- Scale factor: auto 1.1x for 7", 1.0x for 10"
- Touch mapping to DP-1

assets/splash/README.md:
- Platform-specific DRM connector name table

https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf