### PR TITLE
Bigger touch targets, remove scale factor, fix splash XDG_RUNTIME_DIR

### DIFF
--- a/config/scripts/xinitrc-x86-dual
+++ b/config/scripts/xinitrc-x86-dual
@@ -63,11 +63,7 @@ if [ -n "$SMALL" ]; then
     xrandr --output "$SMALL" --right-of "$MAIN" --auto
 fi
 
-# Scale: 7" (<=1024) gets 1.1x, 10"+ gets native
-SCALE=1.0
-if [ -n "$MAIN_W" ] && [ "$MAIN_W" -le 1024 ] 2>/dev/null; then
-    SCALE=1.1
-fi
+# No whole-UI scaling — button sizes are handled in CSS/JS directly
 
 # Map touchscreen to main display
 for TOUCH in $(xinput list --name-only 2>/dev/null | grep -iE "touch|eGalax|ILITEK|Goodix|FT5|QDtech|MPI"); do
@@ -85,7 +81,6 @@ rm -rf /tmp/bcm-chromium-main /tmp/bcm-chromium-small
 
 # Main display — BCM dashboard
 chromium --app=http://localhost:5002 \
-    --force-device-scale-factor=$SCALE \
     --window-size=${MAIN_W},${MAIN_H} --window-position=0,0 \
     --noerrdialogs --disable-infobars \
     --disable-features=TranslateUI --no-first-run \

--- a/config/systemd/bcm-splash-main.service
+++ b/config/systemd/bcm-splash-main.service
@@ -42,6 +42,7 @@ SuccessExitStatus=0 1
 Restart=no
 
 User=root
+Environment=XDG_RUNTIME_DIR=/run/user/0
 SupplementaryGroups=video audio
 
 StandardOutput=journal

--- a/src/dashboard/web/js/components/appbar.js
+++ b/src/dashboard/web/js/components/appbar.js
@@ -45,11 +45,11 @@ const AppBar = (() => {
             <div class="flex-1 flex justify-center">
                 ${_logoImg(theme)}
             </div>
-            <div class="flex items-center gap-3 w-[200px] justify-end">
+            <div class="flex items-center gap-4 w-[200px] justify-end">
                 <span class="${tempColor} text-sm font-bold" data-bind="ext_temp">${temp}</span>
                 ${btIcon}
-                <span class="material-symbols-outlined text-zinc-600 text-[18px] cursor-pointer hover:text-zinc-400" onclick="App.navigateTo('audio')">equalizer</span>
-                <span class="material-symbols-outlined text-zinc-600 text-[18px] cursor-pointer hover:text-zinc-400" onclick="App.navigateTo('settings')">settings</span>
+                <span class="material-symbols-outlined text-zinc-600 text-[24px] cursor-pointer hover:text-zinc-400 p-1" onclick="App.navigateTo('audio')">equalizer</span>
+                <span class="material-symbols-outlined text-zinc-600 text-[24px] cursor-pointer hover:text-zinc-400 p-1" onclick="App.navigateTo('settings')">settings</span>
             </div>
         </header>`;
     }

--- a/src/dashboard/web/js/components/navbar.js
+++ b/src/dashboard/web/js/components/navbar.js
@@ -36,28 +36,28 @@ const NavBar = (() => {
             const iconStyle = isActive ? "font-variation-settings:'FILL' 1;" : "";
 
             if (isDisabled && !isActive) {
-                return `<div class="flex items-center justify-center text-zinc-500 w-10 h-10 cursor-pointer opacity-50 transition-all"
+                return `<div class="flex items-center justify-center text-zinc-500 w-12 h-12 cursor-pointer opacity-50 transition-all"
                          title="${item.tip} (unavailable)" onclick="App.navigateTo('${item.screen}')">
-                    <span class="material-symbols-outlined" style="font-size:22px;">${item.icon}</span>
+                    <span class="material-symbols-outlined" style="font-size:26px;">${item.icon}</span>
                 </div>`;
             }
             if (isActive) {
-                return `<div class="flex items-center justify-center ${activeBg} ${activeColor} rounded-xl w-10 h-10 cursor-pointer transition-all"
+                return `<div class="flex items-center justify-center ${activeBg} ${activeColor} rounded-xl w-12 h-12 cursor-pointer transition-all"
                          title="${item.tip}" onclick="App.navigateTo('${item.screen}')">
-                    <span class="material-symbols-outlined" style="font-size:22px;${iconStyle}">${item.icon}</span>
+                    <span class="material-symbols-outlined" style="font-size:26px;${iconStyle}">${item.icon}</span>
                 </div>`;
             }
-            return `<div class="flex items-center justify-center ${inactiveColor} w-10 h-10 cursor-pointer hover:text-zinc-300 transition-all"
+            return `<div class="flex items-center justify-center ${inactiveColor} w-12 h-12 cursor-pointer hover:text-zinc-300 transition-all"
                      title="${item.tip}" onclick="App.navigateTo('${item.screen}')">
-                <span class="material-symbols-outlined" style="font-size:22px;">${item.icon}</span>
+                <span class="material-symbols-outlined" style="font-size:26px;">${item.icon}</span>
             </div>`;
         }).join("");
 
         return `<nav class="w-full z-50 flex justify-around items-center h-12 ${barCls} border-t shrink-0">
             ${items}
-            <div class="flex items-center justify-center text-zinc-600 w-10 h-10 cursor-pointer hover:text-zinc-400 transition-all"
+            <div class="flex items-center justify-center text-zinc-600 w-12 h-12 cursor-pointer hover:text-zinc-400 transition-all"
                  title="Settings" onclick="App.navigateTo('settings')">
-                <span class="material-symbols-outlined" style="font-size:20px;">settings</span>
+                <span class="material-symbols-outlined" style="font-size:24px;">settings</span>
             </div>
         </nav>`;
     }


### PR DESCRIPTION
navbar.js: buttons w-10 h-10 → w-12 h-12 (40px → 48px), icons 22px → 26px
appbar.js: icons 18px → 24px with p-1 padding for easier touch

xinitrc: removed --force-device-scale-factor (wrong approach — scaling the whole UI caused layout issues). Touch targets are now bigger in CSS.

bcm-splash-main.service: added Environment=XDG_RUNTIME_DIR=/run/user/0 to fix ALSA "XDG_RUNTIME_DIR is invalid" error at boot.

https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf