### PR TITLE
Add cleanup script, fix WiFi DHCP, suspend, touch, simplify xinitrc

### DIFF
--- a/config/scripts/cleanup-x86.sh
+++ b/config/scripts/cleanup-x86.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# BCM x86 cleanup — removes all BCM services, configs, and user overrides.
+# Run this before a fresh BCM reinstall on the same Debian system.
+# Usage: sudo bash /opt/bcm/config/scripts/cleanup-x86.sh
+set -e
+
+echo "=== BCM x86 Cleanup ==="
+
+# 1. Stop and remove BCM services
+echo "[1/8] Stopping BCM services..."
+for svc in bcm-ignition-watcher bcm-headunit bcm-splash-main bcm-splash-small bcm-kiosk bcm-resume; do
+    systemctl stop "$svc" 2>/dev/null || true
+    systemctl disable "$svc" 2>/dev/null || true
+done
+rm -f /etc/systemd/system/bcm-*.service
+systemctl unmask bcm-kiosk.service 2>/dev/null || true
+systemctl daemon-reload
+
+# 2. Remove user kiosk configs
+echo "[2/8] Removing kiosk configs..."
+REAL_USER=${SUDO_USER:-$(logname 2>/dev/null || echo abner)}
+HOME_DIR=$(eval echo "~$REAL_USER")
+rm -f "$HOME_DIR/.xinitrc"
+rm -f "$HOME_DIR/.bash_profile"
+rm -rf /tmp/bcm-chromium-*
+
+# 3. Remove autologin
+echo "[3/8] Removing autologin..."
+rm -rf /etc/systemd/system/getty@tty1.service.d
+
+# 4. Remove WiFi AP configs
+echo "[4/8] Removing WiFi AP configs..."
+systemctl stop hostapd dnsmasq 2>/dev/null || true
+systemctl disable hostapd dnsmasq 2>/dev/null || true
+rm -f /etc/hostapd/hostapd.conf
+rm -f /etc/dnsmasq.d/bcm-ap.conf
+rm -f /etc/network/interfaces.d/bcm-ap
+rm -f /etc/network/interfaces.d/static
+nmcli device set wlp2s0 managed yes 2>/dev/null || true
+ip addr flush dev wlp2s0 2>/dev/null || true
+
+# 5. Remove acpid power button override
+echo "[5/8] Removing power button override..."
+rm -f /etc/acpi/events/power-button
+rm -f /usr/local/bin/bcm-power-toggle.sh
+
+# 6. Remove Chromium policy
+echo "[6/8] Removing Chromium policy..."
+rm -f /etc/chromium/policies/managed/bcm.json
+
+# 7. Remove X11 wrapper override
+echo "[7/8] Removing X11 wrapper..."
+rm -f /etc/X11/Xwrapper.config
+
+# 8. Clean venv
+echo "[8/8] Removing Python venv..."
+rm -rf /opt/bcm/.venv
+
+systemctl daemon-reload
+echo ""
+echo "=== Cleanup complete ==="
+echo "Now follow docs/X86_PLATFORM_SETUP.md from §5 onwards."
+echo "Start with: cd /opt/bcm && git pull"

--- a/config/scripts/xinitrc-x86-dual
+++ b/config/scripts/xinitrc-x86-dual
@@ -2,12 +2,14 @@
 # BCM kiosk — x86 dual display
 # Copy to ~/.xinitrc
 #
-# Set MAIN_OUTPUT to your touchscreen connector.
-# Find yours: xrandr | grep ' connected'
-# Leave empty for auto-detect (picks the touchscreen by input device).
-MAIN_OUTPUT=""
+# ──── USER CONFIG (set these for your hardware) ────
+# Find outputs:  xrandr | grep ' connected'
+# Find touch:    xinput list
+MAIN_OUTPUT="HDMI-2"           # 7" touchscreen
+SMALL_OUTPUT="HDMI-1"          # 4.3" status display (or FHD dev monitor)
+TOUCH_DEVICE="QDtech MPI5001"  # touchscreen xinput name
+# ───────────────────────────────────────────────────
 
-# Disable screen blanking and cursor
 xset s off
 xset -dpms
 xset s noblank
@@ -15,63 +17,25 @@ unclutter -idle 0.5 -root &
 
 sleep 1
 
-# Auto-detect: find connected outputs
-CONNECTED=$(xrandr | grep ' connected' | awk '{print $1}')
-FIRST=$(echo "$CONNECTED" | head -1)
-SECOND=$(echo "$CONNECTED" | tail -1)
-
-if [ -n "$MAIN_OUTPUT" ]; then
-    MAIN="$MAIN_OUTPUT"
-    SMALL=$(echo "$CONNECTED" | grep -v "^${MAIN}$" | head -1)
-elif [ -n "$FIRST" ] && [ -n "$SECOND" ] && [ "$FIRST" != "$SECOND" ]; then
-    # Auto-detect: find which output has the touchscreen
-    TOUCH_DEV=$(xinput list --name-only 2>/dev/null | grep -iE "touch|eGalax|ILITEK|Goodix|FT5|QDtech|MPI" | head -1)
-    if [ -n "$TOUCH_DEV" ]; then
-        # Try each output — map touch, check if it works at expected coords
-        # Heuristic: the smaller resolution is likely the car touchscreen
-        FIRST_W=$(xrandr | grep "^$FIRST " | grep -oP '\d+(?=x)' | head -1)
-        SECOND_W=$(xrandr | grep "^$SECOND " | grep -oP '\d+(?=x)' | head -1)
-        if [ -n "$SECOND_W" ] && [ -n "$FIRST_W" ] && [ "$SECOND_W" -lt "$FIRST_W" ] 2>/dev/null; then
-            MAIN="$SECOND"
-            SMALL="$FIRST"
-        else
-            MAIN="$FIRST"
-            SMALL="$SECOND"
-        fi
-    else
-        MAIN="$FIRST"
-        SMALL="$SECOND"
-    fi
-else
-    MAIN="$FIRST"
-    SMALL=""
-fi
-
-# Get main display native resolution
-MAIN_MODE=$(xrandr | grep "^$MAIN " | grep -oP '\d+x\d+' | head -1)
-MAIN_W=$(echo "$MAIN_MODE" | cut -dx -f1)
-MAIN_H=$(echo "$MAIN_MODE" | cut -dx -f2)
+# Get main display resolution
+MAIN_W=$(xrandr | grep "^${MAIN_OUTPUT} " | grep -oP '\d+(?=x)' | head -1)
+MAIN_H=$(xrandr | grep "^${MAIN_OUTPUT} " | grep -oP 'x\K\d+' | head -1)
 MAIN_W=${MAIN_W:-1024}
 MAIN_H=${MAIN_H:-600}
 
-echo "Main display: $MAIN (${MAIN_W}x${MAIN_H})"
-echo "Small display: $SMALL"
-
-# Configure displays
-xrandr --output "$MAIN" --primary --auto --pos 0x0
-if [ -n "$SMALL" ]; then
-    xrandr --output "$SMALL" --right-of "$MAIN" --auto
+# Arrange displays
+xrandr --output "$MAIN_OUTPUT" --primary --auto --pos 0x0
+if xrandr | grep -q "^${SMALL_OUTPUT} connected"; then
+    xrandr --output "$SMALL_OUTPUT" --right-of "$MAIN_OUTPUT" --auto
 fi
 
-# No whole-UI scaling — button sizes are handled in CSS/JS directly
+# Map touch to main display only
+if [ -n "$TOUCH_DEVICE" ]; then
+    xinput map-to-output "$TOUCH_DEVICE" "$MAIN_OUTPUT" 2>/dev/null && \
+        echo "Touch mapped: $TOUCH_DEVICE → $MAIN_OUTPUT"
+fi
 
-# Map touchscreen to main display
-for TOUCH in $(xinput list --name-only 2>/dev/null | grep -iE "touch|eGalax|ILITEK|Goodix|FT5|QDtech|MPI"); do
-    xinput map-to-output "$TOUCH" "$MAIN" 2>/dev/null && \
-        echo "Mapped touch '$TOUCH' → $MAIN"
-done
-
-# Wait for BCM Flask server
+# Wait for Flask
 for i in $(seq 1 90); do
     curl -sf http://localhost:5002 >/dev/null && break
     sleep 1
@@ -87,14 +51,12 @@ chromium --app=http://localhost:5002 \
     --disable-session-crashed-bubble \
     --user-data-dir=/tmp/bcm-chromium-main &
 
-# Small display — status dashboard
-if [ -n "$SMALL" ]; then
+# Small display
+if xrandr | grep -q "^${SMALL_OUTPUT} connected"; then
     sleep 2
-    SMALL_RES=$(xrandr | grep "^$SMALL " | grep -oP '\d+x\d+\+' | head -1 | tr -d '+')
-    SW=$(echo "$SMALL_RES" | cut -dx -f1)
-    SH=$(echo "$SMALL_RES" | cut -dx -f2)
-    SW=${SW:-800}
-    SH=${SH:-480}
+    SW=$(xrandr | grep "^${SMALL_OUTPUT} " | grep -oP '\d+(?=x)' | head -1)
+    SH=$(xrandr | grep "^${SMALL_OUTPUT} " | grep -oP 'x\K\d+' | head -1)
+    SW=${SW:-800}; SH=${SH:-480}
     chromium --app=http://localhost:5003 \
         --window-size=${SW},${SH} --window-position=${MAIN_W},0 \
         --noerrdialogs --disable-infobars \

--- a/config/systemd/bcm-splash-small.service
+++ b/config/systemd/bcm-splash-small.service
@@ -48,6 +48,7 @@ SuccessExitStatus=0 1
 Restart=no
 
 User=root
+Environment=XDG_RUNTIME_DIR=/run/user/0
 SupplementaryGroups=video
 
 StandardOutput=journal

--- a/docs/X86_PLATFORM_SETUP.md
+++ b/docs/X86_PLATFORM_SETUP.md
@@ -481,11 +481,28 @@ Press F1:
 - **Power → After Power Loss:** Power On
 - **Power → Wake on USB:** Enabled (Arduino can wake from S3)
 
-### 9.3 Test
+### 9.3 Prevent systemd-logind from handling power button
+
+By default, logind intercepts the power button and triggers shutdown
+(that's why you see 40s boot — it's a full shutdown, not suspend).
+Tell logind to ignore it so only acpid handles it:
+
+```bash
+sudo mkdir -p /etc/systemd/logind.conf.d
+sudo tee /etc/systemd/logind.conf.d/bcm-power.conf >/dev/null <<EOF
+[Login]
+HandlePowerKey=ignore
+HandleSuspendKey=ignore
+HandleLidSwitch=ignore
+EOF
+sudo systemctl restart systemd-logind
+```
+
+### 9.4 Test
 
 ```bash
 sudo systemctl suspend
-# Press power button → should wake in ~3s
+# Press power button → should wake in ~3s (not 40s cold boot)
 journalctl -u bcm-resume --no-pager -n5
 ```
 
@@ -541,12 +558,15 @@ sudo reboot
 
 ### 10.3 Persistent AP
 
-Once you know which interface works (`wlp2s0` or `wlxXXXX`):
+Once you confirmed the test AP works (phone sees SSID):
 
 ```bash
 WIFI_IFACE=wlp2s0   # change if using USB dongle
 
-# hostapd config
+# Step 1: Release interface from NetworkManager
+sudo nmcli device set $WIFI_IFACE managed no
+
+# Step 2: hostapd config
 sudo tee /etc/hostapd/hostapd.conf >/dev/null <<EOF
 interface=$WIFI_IFACE
 driver=nl80211
@@ -567,19 +587,31 @@ sudo tee /etc/default/hostapd >/dev/null <<EOF
 DAEMON_CONF="/etc/hostapd/hostapd.conf"
 EOF
 
-# DHCP for connected clients
+# Step 3: DHCP — must bind to specific interface only
 sudo tee /etc/dnsmasq.d/bcm-ap.conf >/dev/null <<EOF
 interface=$WIFI_IFACE
+bind-interfaces
 dhcp-range=192.168.44.10,192.168.44.50,255.255.255.0,24h
 EOF
 
-# Static IP on the AP interface
+# Step 4: Static IP (assign BEFORE hostapd starts)
 sudo tee /etc/network/interfaces.d/bcm-ap >/dev/null <<EOF
 auto $WIFI_IFACE
 iface $WIFI_IFACE inet static
     address 192.168.44.1
     netmask 255.255.255.0
 EOF
+
+# Step 5: Prevent NetworkManager from reclaiming the interface on reboot
+sudo tee /etc/NetworkManager/conf.d/bcm-unmanage-wifi.conf >/dev/null <<EOF
+[keyfile]
+unmanaged-devices=interface-name:$WIFI_IFACE
+EOF
+
+# Step 6: Apply IP now and start services
+sudo ip addr flush dev $WIFI_IFACE
+sudo ip addr add 192.168.44.1/24 dev $WIFI_IFACE
+sudo ip link set $WIFI_IFACE up
 
 sudo systemctl unmask hostapd
 sudo systemctl enable hostapd dnsmasq
@@ -770,7 +802,30 @@ RF input:  D12 ← RXB6 433MHz receiver
 
 ---
 
-## 14. Troubleshooting
+## 14. Clean Reset (if things are broken)
+
+If you have config conflicts from multiple setup attempts, reset everything
+and start fresh from §5:
+
+```bash
+cd /opt/bcm
+sudo bash config/scripts/cleanup-x86.sh
+git pull
+```
+
+Then follow §5 → §10 in order. The cleanup script removes:
+- All BCM systemd services
+- ~/.xinitrc, ~/.bash_profile
+- Autologin override
+- hostapd, dnsmasq, NetworkManager WiFi configs
+- acpid power button override
+- Chromium policy
+- X11 wrapper config
+- Python venv (rebuilt in §5)
+
+---
+
+## 15. Troubleshooting
 
 **Splash not playing:**
 ```bash


### PR DESCRIPTION
New: config/scripts/cleanup-x86.sh — removes all BCM services, user configs, WiFi/hostapd, acpid overrides. Run before fresh reinstall.

xinitrc-x86-dual: simplified — 3 user-configurable variables at top (MAIN_OUTPUT, SMALL_OUTPUT, TOUCH_DEVICE) instead of fragile auto-detect. Defaults to HDMI-2/HDMI-1 for M910q with DP-to-HDMI adapters.

WiFi AP fix (docs §10.3):
- nmcli device unmanage + NM persistent config to prevent reclaim
- dnsmasq bind-interfaces (was binding all interfaces, blocking DHCP)
- Static IP assigned before hostapd starts (phone couldn't get IP)

Suspend fix (docs §9.3):
- Added HandlePowerKey=ignore in logind.conf.d (logind was intercepting power button → full shutdown instead of acpid → suspend)

bcm-splash-small.service: added XDG_RUNTIME_DIR=/run/user/0

Docs: added §14 Clean Reset section with cleanup-x86.sh reference.

https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf