### PR TITLE
Drop splash audio, add AA deps, keyboard hide, enable BT

### DIFF
--- a/config/scripts/setup-x86.sh
+++ b/config/scripts/setup-x86.sh
@@ -119,7 +119,8 @@ apt-get update -qq
 apt-get install -y -qq \
     python3 python3-venv python3-full python3-dev python3-serial \
     git curl wget \
-    xserver-xorg xinit x11-xserver-utils xinput \
+    xserver-xorg xinit x11-xserver-utils xinput xdotool \
+    xvfb matchbox-window-manager \
     unclutter chromium \
     intel-media-va-driver vainfo libva-drm2 \
     pipewire pipewire-pulse wireplumber alsa-utils mpv \
@@ -575,7 +576,19 @@ step 11 "Setting permissions..."
 usermod -aG dialout "$BCM_USER" 2>/dev/null || true
 usermod -aG video "$BCM_USER" 2>/dev/null || true
 usermod -aG audio "$BCM_USER" 2>/dev/null || true
+usermod -aG bluetooth "$BCM_USER" 2>/dev/null || true
 chown -R "$BCM_USER:$BCM_USER" "$BCM_DIR"
+
+# Enable Bluetooth (needed for AA wireless pairing)
+systemctl enable bluetooth 2>/dev/null || true
+systemctl start bluetooth 2>/dev/null || true
+
+# Make BT adapter discoverable and pairable
+if command -v bluetoothctl >/dev/null 2>&1; then
+    bluetoothctl power on 2>/dev/null || true
+    bluetoothctl discoverable on 2>/dev/null || true
+    bluetoothctl pairable on 2>/dev/null || true
+fi
 ok
 
 # ─── Phase 11: Quick test ────────────────────────────────────────

--- a/config/systemd/bcm-splash-main.service
+++ b/config/systemd/bcm-splash-main.service
@@ -27,7 +27,7 @@ ExecStart=/bin/bash -c '\
         --vo=drm,gpu,sdl \
         --hwdec=auto \
         $DRM_ARG \
-        --ao=alsa,pipewire,pulse \
+        --no-audio \
         --input-conf=/dev/null \
         /opt/bcm/assets/splash/main.mp4 & \
     MPV_PID=$!; \

--- a/src/dashboard/web/js/components/keyboard.js
+++ b/src/dashboard/web/js/components/keyboard.js
@@ -93,9 +93,11 @@ const OnScreenKeyboard = (() => {
 
         let html = `<div class="flex flex-col gap-1.5 max-w-[800px] mx-auto">`;
 
-        // Display current value
         html += `<div class="flex items-center gap-2 px-2 mb-1">
             <span id="osk-display" class="text-sm font-mono opacity-60 truncate flex-1">${_escHtml(_value)}</span>
+            <button class="${keyBg} rounded-lg px-2 py-1 text-xs transition-colors" onclick="OnScreenKeyboard.close()" title="Hide keyboard">
+                <span class="material-symbols-outlined" style="font-size:18px;">keyboard_hide</span>
+            </button>
         </div>`;
 
         for (const row of ROWS) {
@@ -141,9 +143,16 @@ const OnScreenKeyboard = (() => {
     return { attach, key, close: _close };
 })();
 
-// Auto-attach to all text inputs on focus (global handler)
 document.addEventListener("focusin", (e) => {
     if (e.target && e.target.tagName === "INPUT" && e.target.type === "text") {
         OnScreenKeyboard.attach(e.target);
+    }
+});
+
+document.addEventListener("click", (e) => {
+    const overlay = document.getElementById("osk-overlay");
+    if (overlay && !overlay.contains(e.target) &&
+        !(e.target.tagName === "INPUT" && e.target.type === "text")) {
+        OnScreenKeyboard.close();
     }
 });


### PR DESCRIPTION
Splash: changed --ao=alsa,pipewire,pulse to --no-audio. ALSA errors at early boot were blocking video from rendering. User sees nothing on either display — just Lenovo logo → GRUB → X logs. With --no-audio, mpv plays video immediately without waiting for sound cards.

AA touch: added xdotool + xvfb + matchbox-window-manager to apt packages. Android Auto uses Xvfb virtual framebuffer (:99) for rendering and xdotool for touch forwarding from browser to AA window. Without these packages, AA displays but touch events don't reach it.

Keyboard: added hide button (keyboard_hide icon) in top-right of on-screen keyboard. Also dismiss keyboard when tapping outside it. Previously only "OK" button could close the keyboard.

Bluetooth: enable bluetooth.service and set adapter discoverable/ pairable in setup script. BCM's BluetoothManager needs the adapter powered on for AA wireless pairing.

https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf