### PR TITLE
Fix splash timing, WiFi channel, BT auto-power

### DIFF
--- a/config/scripts/setup-x86.sh
+++ b/config/scripts/setup-x86.sh
@@ -33,7 +33,7 @@ SMALL_H=480
 WIFI_IFACE="wlp2s0"
 WIFI_SSID="ALFA_AA"
 WIFI_PASS="AlfaRomeo156"
-WIFI_CHANNEL="149"
+WIFI_CHANNEL="36"
 WIFI_COUNTRY="PL"
 # ─────────────────────────────────────────────────────────────────
 
@@ -309,6 +309,11 @@ EOF
 # .bash_profile — start X on tty1
 cat > "$BCM_HOME/.bash_profile" <<'BASHEOF'
 if [ -z "$DISPLAY" ] && [ "$(tty)" = "/dev/tty1" ]; then
+    # Wait for splash video to finish before starting X.
+    # Splash uses DRM framebuffer — X would steal it and kill the splash.
+    while systemctl is-active --quiet bcm-splash-main.service 2>/dev/null; do
+        sleep 1
+    done
     exec startx -- -nocursor
 fi
 BASHEOF
@@ -583,7 +588,21 @@ chown -R "$BCM_USER:$BCM_USER" "$BCM_DIR"
 systemctl enable bluetooth 2>/dev/null || true
 systemctl start bluetooth 2>/dev/null || true
 
-# Make BT adapter discoverable and pairable
+# Auto-power BT adapter on boot (survives reboot)
+if [ -f /etc/bluetooth/main.conf ]; then
+    sed -i 's/^#*AutoEnable.*/AutoEnable=true/' /etc/bluetooth/main.conf
+    if ! grep -q "^AutoEnable" /etc/bluetooth/main.conf; then
+        sed -i '/^\[Policy\]/a AutoEnable=true' /etc/bluetooth/main.conf
+    fi
+else
+    mkdir -p /etc/bluetooth
+    cat > /etc/bluetooth/main.conf <<EOF
+[Policy]
+AutoEnable=true
+EOF
+fi
+
+# Power on now and set discoverable
 if command -v bluetoothctl >/dev/null 2>&1; then
     bluetoothctl power on 2>/dev/null || true
     bluetoothctl discoverable on 2>/dev/null || true

--- a/config/systemd/bcm-splash-main.service
+++ b/config/systemd/bcm-splash-main.service
@@ -3,8 +3,8 @@ Description=BCM Boot Splash — plays until dashboard is ready
 Documentation=https://github.com/geek95dg/Alfa156-headunit
 DefaultDependencies=no
 
-# Start early, before BCM stack. sound.target ensures ALSA cards are ready.
-After=systemd-vconsole-setup.service sound.target
+# Start early, before BCM stack
+After=systemd-vconsole-setup.service
 Before=multi-user.target bcm-ignition-watcher.service
 
 ConditionPathExists=/opt/bcm/assets/splash/main.mp4


### PR DESCRIPTION
Splash: X was stealing DRM framebuffer from mpv before splash could render. Root cause: autologin → startx runs at multi-user.target, same time as splash. Fix: .bash_profile now polls
systemctl is-active bcm-splash-main and waits for it to finish before calling startx. Also removed After=sound.target which was delaying splash startup (unnecessary since we use --no-audio now).

WiFi: changed default channel from 149 to 36. Channel 149 (5745 MHz, UNII-3) is blocked by Intel 8265 firmware with NO-IR flag even with PL regulatory domain set. Channel 36 (5180 MHz, UNII-1) is universally allowed for AP mode in ETSI regions.

Bluetooth: adapter wasn't powering on after reboot. Added AutoEnable=true to /etc/bluetooth/main.conf so BlueZ powers the adapter automatically at boot. BCM's BluetoothManager needs the adapter online to handle pairing and A2DP.

https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf