### PR TITLE
Fix BT discoverability, WiFi channel fallback, splash sound.target

### DIFF
--- a/config/scripts/setup-x86.sh
+++ b/config/scripts/setup-x86.sh
@@ -545,8 +545,27 @@ EOF
     fi
 
     systemctl daemon-reload
-    systemctl restart hostapd dnsmasq 2>/dev/null || \
-        warn "hostapd/dnsmasq failed to start now — check: journalctl -u hostapd -n 20"
+
+    # Verify config is correct
+    echo "  hostapd config: SSID=$WIFI_SSID channel=$WIFI_CHANNEL iface=$WIFI_IFACE"
+    grep "^channel=" /etc/hostapd/hostapd.conf || warn "No channel in hostapd.conf"
+
+    # Start services now
+    systemctl restart hostapd dnsmasq 2>/dev/null
+    sleep 2
+    if systemctl is-active --quiet hostapd; then
+        echo -e "  ${GREEN}hostapd running${NC}"
+    else
+        warn "hostapd failed — trying channel 36 fallback..."
+        sed -i 's/^channel=.*/channel=36/' /etc/hostapd/hostapd.conf
+        systemctl restart hostapd 2>/dev/null
+        sleep 2
+        if systemctl is-active --quiet hostapd; then
+            echo -e "  ${GREEN}hostapd running (ch36 fallback)${NC}"
+        else
+            warn "hostapd still failing — check: sudo journalctl -u hostapd -n 20"
+        fi
+    fi
     ok
 fi
 
@@ -585,10 +604,13 @@ usermod -aG bluetooth "$BCM_USER" 2>/dev/null || true
 chown -R "$BCM_USER:$BCM_USER" "$BCM_DIR"
 
 # Enable Bluetooth (needed for AA wireless pairing)
-systemctl enable bluetooth 2>/dev/null || true
+cp "$BCM_DIR/config/systemd/bcm-bluetooth.service" /etc/systemd/system/
+systemctl daemon-reload
+systemctl enable bluetooth bcm-bluetooth 2>/dev/null || true
 systemctl start bluetooth 2>/dev/null || true
+systemctl start bcm-bluetooth 2>/dev/null || true
 
-# Auto-power BT adapter on boot (survives reboot)
+# Auto-power BT adapter on boot
 if [ -f /etc/bluetooth/main.conf ]; then
     sed -i 's/^#*AutoEnable.*/AutoEnable=true/' /etc/bluetooth/main.conf
     if ! grep -q "^AutoEnable" /etc/bluetooth/main.conf; then
@@ -600,13 +622,6 @@ else
 [Policy]
 AutoEnable=true
 EOF
-fi
-
-# Power on now and set discoverable
-if command -v bluetoothctl >/dev/null 2>&1; then
-    bluetoothctl power on 2>/dev/null || true
-    bluetoothctl discoverable on 2>/dev/null || true
-    bluetoothctl pairable on 2>/dev/null || true
 fi
 ok
 

--- a/config/systemd/bcm-bluetooth.service
+++ b/config/systemd/bcm-bluetooth.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=BCM — Bluetooth adapter setup (discoverable + pairable)
+After=bluetooth.service
+Requires=bluetooth.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c '\
+    sleep 2; \
+    bluetoothctl power on; \
+    bluetoothctl system-alias "Alfa156 Headunit"; \
+    bluetoothctl discoverable on; \
+    bluetoothctl pairable on; \
+    bluetoothctl discoverable-timeout 0'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=bluetooth.target


### PR DESCRIPTION
Bluetooth: discoverable/pairable don't persist across reboots in BlueZ. Created bcm-bluetooth.service (oneshot, After=bluetooth) that runs bluetoothctl to set power on, discoverable on, pairable on, and alias "Alfa156 Headunit" at every boot. Phone can now find BCM.

WiFi: added channel fallback — if hostapd fails on configured channel, automatically retries with channel 36 (5180 MHz, UNII-1) which is universally allowed. Also prints channel verification during setup so failures are visible.

Splash: removed After=sound.target (was delaying splash startup, unnecessary since we use --no-audio). Already done in previous commit but ensuring clean state.

https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf