### PR TITLE
Fix WiFi (2.4GHz), simulation mode, splash debug, suspend wake

### DIFF
--- a/config/scripts/bcm-power-toggle.sh
+++ b/config/scripts/bcm-power-toggle.sh
@@ -8,7 +8,11 @@
 if systemctl is-active --quiet bcm-headunit.service; then
     systemctl stop bcm-headunit.service
     sleep 1
-    systemctl suspend
-else
-    systemctl suspend
 fi
+
+# Disable USB wake sources (touchscreens, hubs send spurious wake events)
+for f in /sys/bus/usb/devices/*/power/wakeup; do
+    echo disabled > "$f" 2>/dev/null
+done
+
+systemctl suspend

--- a/config/scripts/setup-x86.sh
+++ b/config/scripts/setup-x86.sh
@@ -33,7 +33,7 @@ SMALL_H=480
 WIFI_IFACE="wlp2s0"
 WIFI_SSID="ALFA_AA"
 WIFI_PASS="AlfaRomeo156"
-WIFI_CHANNEL="36"
+WIFI_CHANNEL="6"
 WIFI_COUNTRY="PL"
 # ─────────────────────────────────────────────────────────────────
 
@@ -469,16 +469,16 @@ EOF
 interface=$WIFI_IFACE
 driver=nl80211
 ssid=$WIFI_SSID
-hw_mode=a
+hw_mode=g
 channel=$WIFI_CHANNEL
 ieee80211n=1
-ieee80211ac=1
 wpa=2
 wpa_passphrase=$WIFI_PASS
 wpa_key_mgmt=WPA-PSK
 rsn_pairwise=CCMP
 wpa_pairwise=CCMP
 country_code=$WIFI_COUNTRY
+wmm_enabled=1
 EOF
 
     mkdir -p /etc/default
@@ -534,9 +534,18 @@ RestartSec=3
 EOF
 
     # Disable BCM's internal WiFi AP manager (conflicts with system hostapd)
+    # Disable simulation mode (no fake OBD/BT/GPS data on real hardware)
     if [ -f "$BCM_DIR/config/bcm_config.yaml" ]; then
         sed -i '/^wifi:/,/^[^ ]/{s/^\(  enabled:\) true/\1 false/}' \
             "$BCM_DIR/config/bcm_config.yaml"
+        # Add simulation: false under system: section
+        if ! grep -q "simulation:" "$BCM_DIR/config/bcm_config.yaml"; then
+            sed -i '/^system:/,/^[^ ]/{/log_file:/a\  simulation: false}' \
+                "$BCM_DIR/config/bcm_config.yaml"
+        else
+            sed -i 's/^\(  simulation:\).*/\1 false/' \
+                "$BCM_DIR/config/bcm_config.yaml"
+        fi
         if grep -A1 "^wifi:" "$BCM_DIR/config/bcm_config.yaml" | grep -q "enabled: true"; then
             warn "Could not patch wifi.enabled — edit bcm_config.yaml manually: set wifi.enabled to false"
         else
@@ -557,8 +566,8 @@ EOF
     if systemctl is-active --quiet hostapd; then
         echo -e "  ${GREEN}hostapd running${NC}"
     else
-        warn "hostapd failed — trying channel 36 fallback..."
-        sed -i 's/^channel=.*/channel=36/' /etc/hostapd/hostapd.conf
+        warn "hostapd failed — trying channel 1 fallback..."
+        sed -i 's/^channel=.*/channel=1/' /etc/hostapd/hostapd.conf
         systemctl restart hostapd 2>/dev/null || true
         sleep 2
         if systemctl is-active --quiet hostapd; then

--- a/config/systemd/bcm-splash-main.service
+++ b/config/systemd/bcm-splash-main.service
@@ -23,14 +23,21 @@ ExecStart=/bin/bash -c '\
     if [ -z "$MPV" ]; then exit 0; fi; \
     DRM_ARG=""; \
     [ -n "$BCM_SPLASH_DRM_MAIN" ] && DRM_ARG="--drm-connector=$BCM_SPLASH_DRM_MAIN"; \
-    "$MPV" --fs --loop-file=inf --really-quiet \
-        --vo=drm,gpu,sdl \
+    echo "Splash starting: vo=drm drm_arg=$DRM_ARG file=/opt/bcm/assets/splash/main.mp4"; \
+    "$MPV" --fs --loop-file=inf \
+        --vo=drm \
         --hwdec=auto \
         $DRM_ARG \
         --no-audio \
         --input-conf=/dev/null \
+        --msg-level=all=warn \
         /opt/bcm/assets/splash/main.mp4 & \
     MPV_PID=$!; \
+    sleep 1; \
+    if ! kill -0 $MPV_PID 2>/dev/null; then \
+        echo "WARN: mpv exited immediately — DRM may not be available"; \
+        exit 0; \
+    fi; \
     for i in $(seq 1 120); do \
         if curl -sf http://localhost:5002 >/dev/null 2>&1; then \
             sleep 5; \

--- a/main.py
+++ b/main.py
@@ -281,10 +281,9 @@ def main() -> None:
     # In --frontend mode: start web server + demo data, block main thread.
     # In Pygame mode: start Pygame renderer which blocks main thread.
     if dashboard_enabled:
-        # Always start demo data generators on x86
         demo = None
         demo_media = None
-        if config.platform == "x86":
+        if config.platform == "x86" and config.get("system.simulation", True):
             from src.dashboard.renderer import DemoDataGenerator
             from src.multimedia.bluetooth import DemoMediaGenerator
             demo = DemoDataGenerator(event_bus)


### PR DESCRIPTION
WiFi: Intel 8265 firmware blocks ALL 5GHz channels with NO-IR flag regardless of regulatory domain. Switched to 2.4GHz (hw_mode=g, channel 6) which works universally. Removed ieee80211ac (not applicable to 2.4GHz). Fallback to channel 1 if 6 fails.

Simulation: added system.simulation config key. When false, demo data generators (fake OBD, fake BT media, fake GPS) are skipped even on x86 platform. Setup script patches bcm_config.yaml to set simulation: false. MockGPIO remains (x86 has no real GPIO) but all fake sensor/vehicle data is disabled.

Splash: changed --vo=drm,gpu,sdl to --vo=drm only. The gpu/sdl fallbacks silently swallow the video at early boot (no X/Wayland). With drm-only, mpv either renders to the framebuffer or fails visibly. Added logging and early-exit detection so splash failures show up in journalctl.

Suspend: USB devices were sending spurious wake events causing immediate resume. Power toggle script now disables USB wakeup on all USB devices before suspending.

https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf