### PR TITLE
Fix sed syntax error for simulation config patch

### DIFF
--- a/config/scripts/setup-x86.sh
+++ b/config/scripts/setup-x86.sh
@@ -540,7 +540,7 @@ EOF
             "$BCM_DIR/config/bcm_config.yaml"
         # Add simulation: false under system: section
         if ! grep -q "simulation:" "$BCM_DIR/config/bcm_config.yaml"; then
-            sed -i '/^system:/,/^[^ ]/{/log_file:/a\  simulation: false}' \
+            sed -i '/^  log_file:/a\  simulation: false' \
                 "$BCM_DIR/config/bcm_config.yaml"
         else
             sed -i 's/^\(  simulation:\).*/\1 false/' \


### PR DESCRIPTION
Nested {/pattern/a\text} doesn't work in GNU sed. Replaced with simple /^  log_file:/a\  simulation: false which appends after the log_file line in the system: section.

https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf