### PR TITLE
Fix splash DRM timing, add LTE setup, fix ch1 fallback label

### DIFF
--- a/config/scripts/setup-x86.sh
+++ b/config/scripts/setup-x86.sh
@@ -47,7 +47,7 @@ warn() { echo -e "${YELLOW}  WARN: $1${NC}"; }
 fail() { echo -e "${RED}  FAIL: $1${NC}"; exit 1; }
 ok()   { echo -e "${GREEN}  OK${NC}"; }
 
-TOTAL=13
+TOTAL=14
 
 if [ "$(id -u)" -ne 0 ]; then
     fail "Run with sudo: sudo bash $0"
@@ -579,9 +579,63 @@ EOF
     ok
 fi
 
-# ─── Phase 9: GRUB (silent boot) ─────────────────────────────────
+# ─── Phase 9b: LTE modem (Huawei E3372) ──────────────────────────
 
-step 10 "Configuring silent boot (GRUB)..."
+step 10 "Configuring LTE modem..."
+
+LTE_IFACE=""
+for iface in /sys/class/net/ww*; do
+    [ -e "$iface" ] && LTE_IFACE=$(basename "$iface") && break
+done
+
+if [ -n "$LTE_IFACE" ]; then
+    echo "  Found LTE interface: $LTE_IFACE"
+
+    # Don't let NetworkManager manage the LTE interface
+    # (we use simple DHCP so it doesn't conflict with WiFi AP)
+    cat >> /etc/NetworkManager/conf.d/bcm-unmanage-wifi.conf <<EOF
+
+[keyfile]
+unmanaged-devices=interface-name:$LTE_IFACE
+EOF
+
+    # Bring up with DHCP via systemd-networkd or dhclient
+    mkdir -p /etc/systemd/network
+    cat > /etc/systemd/network/50-lte.network <<EOF
+[Match]
+Name=$LTE_IFACE
+
+[Network]
+DHCP=yes
+
+[DHCPv4]
+RouteMetric=700
+UseDNS=yes
+EOF
+
+    systemctl enable systemd-networkd 2>/dev/null || true
+    systemctl restart systemd-networkd 2>/dev/null || true
+
+    # Bring up now
+    ip link set "$LTE_IFACE" up 2>/dev/null || true
+    dhclient -nw "$LTE_IFACE" 2>/dev/null || true
+
+    sleep 3
+    if ip addr show "$LTE_IFACE" 2>/dev/null | grep -q "inet "; then
+        LTE_IP=$(ip -4 addr show "$LTE_IFACE" | grep -oP 'inet \K[\d.]+')
+        echo -e "  ${GREEN}LTE online: $LTE_IP${NC}"
+    else
+        warn "LTE interface up but no IP yet — may need SIM PIN or APN config"
+    fi
+    ok
+else
+    echo "  No LTE modem found — skipping."
+    ok
+fi
+
+# ─── Phase 10: GRUB (silent boot) ────────────────────────────────
+
+step 11 "Configuring silent boot (GRUB)..."
 
 if [ -f /etc/default/grub ]; then
     cp /etc/default/grub /etc/default/grub.bak
@@ -605,7 +659,7 @@ ok
 
 # ─── Phase 10: Permissions ────────────────────────────────────────
 
-step 11 "Setting permissions..."
+step 12 "Setting permissions..."
 
 usermod -aG dialout "$BCM_USER" 2>/dev/null || true
 usermod -aG video "$BCM_USER" 2>/dev/null || true
@@ -637,7 +691,7 @@ ok
 
 # ─── Phase 11: Quick test ────────────────────────────────────────
 
-step 12 "Testing BCM (headless)..."
+step 13 "Testing BCM (headless)..."
 
 TEST_OUTPUT=$(su - "$BCM_USER" -c "cd $BCM_DIR && source .venv/bin/activate && timeout 10 python main.py --platform x86 --config config/bcm_config.yaml --frontend 2>&1" || true)
 
@@ -651,7 +705,7 @@ fi
 
 # ─── Phase 12: Summary ───────────────────────────────────────────
 
-step 13 "Done!"
+step 14 "Done!"
 
 echo ""
 echo "========================================="

--- a/config/systemd/bcm-splash-main.service
+++ b/config/systemd/bcm-splash-main.service
@@ -23,7 +23,9 @@ ExecStart=/bin/bash -c '\
     if [ -z "$MPV" ]; then exit 0; fi; \
     DRM_ARG=""; \
     [ -n "$BCM_SPLASH_DRM_MAIN" ] && DRM_ARG="--drm-connector=$BCM_SPLASH_DRM_MAIN"; \
-    echo "Splash starting: vo=drm drm_arg=$DRM_ARG file=/opt/bcm/assets/splash/main.mp4"; \
+    for w in $(seq 1 50); do [ -e /dev/dri/card0 ] && break; sleep 0.2; done; \
+    if [ ! -e /dev/dri/card0 ]; then echo "DRM device not found after 10s"; exit 0; fi; \
+    echo "Splash: DRM ready, connector=$BCM_SPLASH_DRM_MAIN"; \
     "$MPV" --fs --loop-file=inf \
         --vo=drm \
         --hwdec=auto \
@@ -35,9 +37,10 @@ ExecStart=/bin/bash -c '\
     MPV_PID=$!; \
     sleep 1; \
     if ! kill -0 $MPV_PID 2>/dev/null; then \
-        echo "WARN: mpv exited immediately — DRM may not be available"; \
+        echo "WARN: mpv exited — DRM output failed"; \
         exit 0; \
     fi; \
+    echo "Splash playing (pid=$MPV_PID)"; \
     for i in $(seq 1 120); do \
         if curl -sf http://localhost:5002 >/dev/null 2>&1; then \
             sleep 5; \


### PR DESCRIPTION
Splash: DRM device (/dev/dri/card0) didn't exist when service started — i915 driver not loaded yet. Added wait loop (up to 10s, 200ms intervals) for /dev/dri/card0 before launching mpv. Without DRM device, mpv fails with "drmGetDevices failed" and exits immediately.

LTE: added phase 10 for Huawei E3372 (CDC-Ether mode). Auto-detects ww* interface, creates systemd-networkd config with DHCP (metric 700 so WiFi AP routes aren't overridden), brings up interface immediately. The E3372 in HiLink mode (12d1:1506) doesn't need usb_modeswitch.

Also fixed channel fallback label (said "ch36" but actually fell back to channel 1).

https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf