### PR TITLE
Fix 5 issues from diagnostic data

### DIFF
--- a/config/scripts/bcm-power-toggle.sh
+++ b/config/scripts/bcm-power-toggle.sh
@@ -15,4 +15,9 @@ for f in /sys/bus/usb/devices/*/power/wakeup; do
     echo disabled > "$f" 2>/dev/null
 done
 
+# Unbind LTE modem — it blocks suspend with "Failed to suspend device"
+for dev in /sys/bus/usb/drivers/cdc_ether/*/; do
+    [ -e "$dev" ] && echo "$(basename "$dev")" > /sys/bus/usb/drivers/cdc_ether/unbind 2>/dev/null
+done
+
 systemctl suspend

--- a/config/scripts/setup-x86.sh
+++ b/config/scripts/setup-x86.sh
@@ -270,17 +270,28 @@ cp "$BCM_DIR/config/systemd/bcm-resume.service" /etc/systemd/system/
 
 systemctl mask bcm-kiosk.service 2>/dev/null || true
 
-# Override DRM connectors to match user's actual hardware
+# Override DRM connectors — translate xrandr names to DRM names
+# xrandr: HDMI-1 → DRM: HDMI-A-1, xrandr: DP-1 → DRM: DP-1 (same)
+drm_name() {
+    local name="$1"
+    case "$name" in
+        HDMI-[0-9]*) echo "HDMI-A-${name#HDMI-}" ;;
+        *) echo "$name" ;;
+    esac
+}
+DRM_MAIN=$(drm_name "$MAIN_OUTPUT")
+DRM_SMALL=$(drm_name "$SMALL_OUTPUT")
+
 mkdir -p /etc/systemd/system/bcm-splash-main.service.d
 cat > /etc/systemd/system/bcm-splash-main.service.d/connector.conf <<EOF
 [Service]
-Environment=BCM_SPLASH_DRM_MAIN=$MAIN_OUTPUT
+Environment=BCM_SPLASH_DRM_MAIN=$DRM_MAIN
 EOF
 
 mkdir -p /etc/systemd/system/bcm-splash-small.service.d
 cat > /etc/systemd/system/bcm-splash-small.service.d/connector.conf <<EOF
 [Service]
-Environment=BCM_SPLASH_DRM_SMALL=$SMALL_OUTPUT
+Environment=BCM_SPLASH_DRM_SMALL=$DRM_SMALL
 EOF
 
 systemctl daemon-reload
@@ -599,7 +610,7 @@ if [ -n "$LTE_IFACE" ]; then
 unmanaged-devices=interface-name:$LTE_IFACE
 EOF
 
-    # Bring up with DHCP via systemd-networkd or dhclient
+    # Bring up with DHCP via systemd-networkd
     mkdir -p /etc/systemd/network
     cat > /etc/systemd/network/50-lte.network <<EOF
 [Match]
@@ -611,7 +622,14 @@ DHCP=yes
 [DHCPv4]
 RouteMetric=700
 UseDNS=yes
+
+[Link]
+RequiredForOnline=no
 EOF
+
+    # Disable wait-online (was blocking boot for 2min waiting for LTE DHCP)
+    systemctl disable systemd-networkd-wait-online.service 2>/dev/null || true
+    systemctl mask systemd-networkd-wait-online.service 2>/dev/null || true
 
     systemctl enable systemd-networkd 2>/dev/null || true
     systemctl restart systemd-networkd 2>/dev/null || true

--- a/config/systemd/bcm-ignition-watcher.service
+++ b/config/systemd/bcm-ignition-watcher.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=BCM — Ignition Watcher (GPIO monitor, starts headunit on ignition)
 Documentation=https://github.com/geek95dg/Alfa156-headunit
-After=multi-user.target
+After=multi-user.target bluetooth.target bcm-bluetooth.service
 
 [Service]
 Type=simple

--- a/config/systemd/bcm-resume.service
+++ b/config/systemd/bcm-resume.service
@@ -4,7 +4,14 @@ After=suspend.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/bash -c 'sleep 2 && systemctl start bcm-headunit.service'
+ExecStart=/bin/bash -c '\
+    sleep 2; \
+    for dev in /sys/bus/usb/devices/*/idVendor; do \
+        dir=$(dirname "$dev"); \
+        [ "$(cat "$dir/idVendor" 2>/dev/null)" = "12d1" ] && \
+            echo "$(basename "$dir")" > /sys/bus/usb/drivers/usb/bind 2>/dev/null; \
+    done; \
+    systemctl start bcm-headunit.service'
 
 [Install]
 WantedBy=suspend.target


### PR DESCRIPTION
1. Splash: xrandr HDMI-1 != DRM HDMI-A-1. Added drm_name() translator in setup script: HDMI-N → HDMI-A-N for DRM connector drop-ins. mpv was finding DRM device but "No connector with name HDMI-1".

2. Slow boot: systemd-networkd-wait-online blocked 2min waiting for LTE DHCP. Masked the service + set RequiredForOnline=no on LTE network config.

3. Bluetooth: "No default controller available" — BCM started before bluetooth.service initialized the adapter. Added After=bluetooth.target bcm-bluetooth.service to ignition-watcher so BCM only starts after BT adapter is powered and discoverable.

4. Suspend wake: usb 1-3 (LTE modem) "Failed to suspend device" then triggered immediate resume. Power toggle now unbinds cdc_ether driver before suspend. Resume service rebinds Huawei USB on wake.

5. LTE no IPv4: RequiredForOnline=no prevents boot block. DHCP will complete in background after boot.

https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf