### PR TITLE
Fix BT retry + discoverable, small splash DRM, suspend LTE unbind

### DIFF
--- a/config/scripts/bcm-power-toggle.sh
+++ b/config/scripts/bcm-power-toggle.sh
@@ -15,11 +15,27 @@ for f in /sys/bus/usb/devices/*/power/wakeup; do
     echo disabled > "$f" 2>/dev/null
 done
 
-# Disable XHCI/EHCI/USB wake in ACPI (main culprit for instant wake)
+# Unbind Huawei LTE modem (usb 1-3) — it fails to suspend and triggers wake
+# Find by vendor ID 12d1 (Huawei) and unbind from USB driver entirely
+for dev in /sys/bus/usb/devices/*/idVendor; do
+    dir=$(dirname "$dev")
+    if [ "$(cat "$dir/idVendor" 2>/dev/null)" = "12d1" ]; then
+        devname=$(basename "$dir")
+        echo "$devname" > /sys/bus/usb/drivers/usb/unbind 2>/dev/null
+        echo "Unbound LTE modem $devname for suspend"
+    fi
+done
+
+# Disable XHCI/EHC/USB ACPI wake sources
 if [ -f /proc/acpi/wakeup ]; then
     awk '/XHC|EHC|USB/ && /enabled/ {print $1}' /proc/acpi/wakeup | while read -r dev; do
         echo "$dev" > /proc/acpi/wakeup 2>/dev/null
     done
+fi
+
+# Also disable PS2K (keyboard) wake — no PS2 keyboard in car
+if grep -q "PS2K.*enabled" /proc/acpi/wakeup 2>/dev/null; then
+    echo "PS2K" > /proc/acpi/wakeup 2>/dev/null
 fi
 
 systemctl suspend

--- a/config/systemd/bcm-bluetooth.service
+++ b/config/systemd/bcm-bluetooth.service
@@ -8,10 +8,13 @@ Type=oneshot
 ExecStart=/bin/bash -c '\
     sleep 2; \
     bluetoothctl power on; \
+    sleep 1; \
     bluetoothctl system-alias "Alfa156 Headunit"; \
-    bluetoothctl discoverable on; \
+    bluetoothctl discoverable-timeout 0; \
     bluetoothctl pairable on; \
-    bluetoothctl discoverable-timeout 0'
+    bluetoothctl discoverable on; \
+    bluetoothctl agent on; \
+    bluetoothctl default-agent'
 RemainAfterExit=yes
 
 [Install]

--- a/config/systemd/bcm-resume.service
+++ b/config/systemd/bcm-resume.service
@@ -1,16 +1,15 @@
 [Unit]
-Description=BCM — Resume from suspend (restart headunit + kiosk)
+Description=BCM — Resume from suspend (rebind LTE + restart headunit)
 After=suspend.target
 
 [Service]
 Type=oneshot
 ExecStart=/bin/bash -c '\
     sleep 2; \
-    for dev in /sys/bus/usb/devices/*/idVendor; do \
-        dir=$(dirname "$dev"); \
-        [ "$(cat "$dir/idVendor" 2>/dev/null)" = "12d1" ] && \
-            echo "$(basename "$dir")" > /sys/bus/usb/drivers/usb/bind 2>/dev/null; \
+    for port in /sys/bus/usb/devices/usb*/; do \
+        echo "$(basename "$port")" > /sys/bus/usb/drivers/usb/bind 2>/dev/null; \
     done; \
+    sleep 3; \
     systemctl start bcm-headunit.service'
 
 [Install]

--- a/config/systemd/bcm-splash-small.service
+++ b/config/systemd/bcm-splash-small.service
@@ -24,13 +24,21 @@ Environment=BCM_SPLASH_DRM_SMALL=DP-2
 ExecStart=/bin/bash -c '\
     MPV=$(command -v mpv 2>/dev/null); \
     if [ -z "$MPV" ]; then exit 0; fi; \
-    "$MPV" --fs --loop-file=inf --really-quiet --no-audio \
-        --vo=drm,gpu,sdl \
+    for w in $(seq 1 50); do [ -e /dev/dri/card0 ] && break; sleep 0.2; done; \
+    if [ ! -e /dev/dri/card0 ]; then echo "DRM device not found"; exit 0; fi; \
+    "$MPV" --fs --loop-file=inf --no-audio \
+        --vo=drm \
         --hwdec=auto \
         --drm-connector=${BCM_SPLASH_DRM_SMALL} \
         --input-conf=/dev/null \
+        --msg-level=all=warn \
         /opt/bcm/assets/splash/small.mp4 & \
     MPV_PID=$!; \
+    sleep 1; \
+    if ! kill -0 $MPV_PID 2>/dev/null; then \
+        echo "WARN: mpv exited — small DRM connector ${BCM_SPLASH_DRM_SMALL} may be wrong"; \
+        exit 0; \
+    fi; \
     for i in $(seq 1 120); do \
         if curl -sf http://localhost:5002 >/dev/null 2>&1; then \
             sleep 5; \

--- a/src/multimedia/bluetooth.py
+++ b/src/multimedia/bluetooth.py
@@ -545,33 +545,33 @@ class BluetoothManager:
         self._event_bus.subscribe("bt.call_ended", self._on_call_ended)
 
     def _check_availability(self) -> None:
-        """Check if Bluetooth is available."""
+        """Check if Bluetooth is available (retries up to 5 times)."""
         log.info("Checking Bluetooth availability...")
-        rc, out, err = _run_btctl(["show"])
-        if rc == 0 and "Controller" in out:
-            self._available = True
-            # Parse controller address for logging
-            for line in out.splitlines():
-                if line.strip().startswith("Controller"):
-                    log.info("Bluetooth controller found: %s", line.strip())
-                    break
-            rc_pwr, out_pwr, _ = _run_btctl(["power", "on"])
-            if rc_pwr == 0:
-                log.info("Bluetooth power ON")
-            else:
-                log.warning("Bluetooth power on failed: %s", out_pwr)
-            # Register D-Bus pairing agent (handles phone-initiated pairing)
-            if not _start_pairing_agent():
-                log.warning("D-Bus pairing agent failed — falling back to bluetoothctl agent")
-                # Fallback to bluetoothctl agent (limited — phone-initiated may fail)
-                _run_btctl(["agent", "DisplayYesNo"])
-                _run_btctl(["default-agent"])
-            else:
-                log.info("D-Bus pairing agent registered successfully")
-        else:
-            self._available = False
-            log.warning("Bluetooth not available (rc=%d, err=%s) — will be simulated",
-                        rc, err.strip() if err else "none")
+        for attempt in range(5):
+            rc, out, err = _run_btctl(["show"])
+            if rc == 0 and "Controller" in out:
+                self._available = True
+                for line in out.splitlines():
+                    if line.strip().startswith("Controller"):
+                        log.info("Bluetooth controller found: %s", line.strip())
+                        break
+                rc_pwr, out_pwr, _ = _run_btctl(["power", "on"])
+                if rc_pwr == 0:
+                    log.info("Bluetooth power ON")
+                else:
+                    log.warning("Bluetooth power on failed: %s", out_pwr)
+                if not _start_pairing_agent():
+                    log.warning("D-Bus pairing agent failed — falling back to bluetoothctl agent")
+                    _run_btctl(["agent", "DisplayYesNo"])
+                    _run_btctl(["default-agent"])
+                else:
+                    log.info("D-Bus pairing agent registered successfully")
+                return
+            if attempt < 4:
+                log.info("Bluetooth not ready (attempt %d/5) — retrying in 2s...", attempt + 1)
+                time.sleep(2)
+        self._available = False
+        log.warning("Bluetooth not available after 5 attempts (last rc=%d)", rc)
 
     @property
     def available(self) -> bool:


### PR DESCRIPTION
BT not connecting: bluetoothctl show returned "No default controller" from service context because adapter wasn't ready. Added 5-attempt retry loop (2s between) in BluetoothManager._check_availability(). Also fixed bcm-bluetooth.service: set discoverable-timeout 0 BEFORE discoverable on (was timing out after 120s), added agent registration.

Small splash: was missing DRM wait loop and used --vo=drm,gpu,sdl (gpu/sdl render nowhere at boot). Now matches main splash: waits for /dev/dri/card0, uses --vo=drm only.

Suspend: USB 1-3 (Huawei LTE 12d1:*) "Failed to suspend device" caused immediate wake. Now unbinds entire USB device by vendor ID before suspend (not just cdc_ether driver). Resume rebinds USB root hubs. Also disables PS2K ACPI wake source.

https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf