### PR TITLE
AA Wireless on internal cards + PBAP + 7" GUI scale

### DIFF
--- a/config/bcm_config.yaml
+++ b/config/bcm_config.yaml
@@ -144,18 +144,36 @@ brightness:
 music_panel:
   enabled: true
 wifi:
-  enabled: false
+  enabled: true
   ssid: ALFA
   password: 87654321
+  mode: hostapd
   band: g
   channel: 6
-  country: PL
+  country: BO
+  regdom: BO
   share_internet: true
   interface: ''
   ip: 10.0.0.1
   netmask: 255.255.255.0
   dhcp_start: 10.0.0.10
   dhcp_end: 10.0.0.50
+  alfa_net:
+    enabled: true
+    ssid: ALFA-NET
+    password: AlfaRomeo156
+    channel: 6
+    country: BO
+    ip: 10.0.1.1
+    netmask: 255.255.255.0
+    dhcp_start: 10.0.1.10
+    dhcp_end: 10.0.1.50
+    share_internet: true
+  # ssid_runtime / password_runtime / bssid_runtime are populated at
+  # runtime by wifi_ap.py when in p2p_go mode (wpa_supplicant
+  # auto-generates a DIRECT-XX SSID and PSK each boot). Leave empty
+  # in the committed config so a fresh deploy starts from the YAML
+  # defaults; wifi_ap.py writes them back on the fly.
 weather:
   api_key: 631c2365675e193584b0f986798554c1
   poll_interval_min: 15
@@ -221,4 +239,7 @@ tracking:
   geofence_radius_km: 0
   sms_number: ''
 multimedia:
-  last_bt_device: 0C:36:8A:2E:F5:D2
+  last_bt_device: C0:7A:D6:90:E9:CC
+bluetooth:
+  prefer_internal: false
+  preferred_adapter: ''

--- a/config/bcm_config_opi_pc.yaml
+++ b/config/bcm_config_opi_pc.yaml
@@ -361,6 +361,13 @@ tracking:
   geofence_radius_km: 0
   sms_number: ""
 
+bluetooth:
+  # Orange Pi PC test rig has no Intel 8087 — leave at default so a
+  # USB dongle is used. Flip to true if the target OPi 5 Plus board
+  # ships with an internal radio you want to force.
+  prefer_internal: false
+  preferred_adapter: ""
+
 # OPi PC test rig specific
 test_rig:
   description: "Orange Pi PC 1.2 bench test — pre-production validation"

--- a/config/scripts/bcm-bluetooth-setup.sh
+++ b/config/scripts/bcm-bluetooth-setup.sh
@@ -63,6 +63,7 @@ done
 # controller MAC anyway, set BCM_BT_ADAPTER in /etc/default/bcm-bluetooth.
 PREFERRED_ADDR=""
 NON_INTEL_ADDR=""
+INTEL_ADDR=""
 FIRST_ADDR=""
 # shellcheck source=/dev/null
 [ -f /etc/default/bcm-bluetooth ] && . /etc/default/bcm-bluetooth
@@ -84,19 +85,24 @@ for hci_dir in $(ls -d /sys/class/bluetooth/hci* 2>/dev/null | sort); do
     addr=$(hciconfig "$hci" 2>/dev/null | awk '/BD Address/{print $3; exit}')
     [ -n "$addr" ] || continue
     [ -z "$FIRST_ADDR" ] && FIRST_ADDR="$addr"
-    if [ -n "$vendor" ] && [ "$vendor" != "8087" ] && [ -z "$NON_INTEL_ADDR" ]; then
+    if [ "$vendor" = "8087" ]; then
+        [ -z "$INTEL_ADDR" ] && INTEL_ADDR="$addr"
+    elif [ -n "$vendor" ] && [ -z "$NON_INTEL_ADDR" ]; then
         NON_INTEL_ADDR="$addr"
-        echo "BT setup: preferring non-Intel $hci ($addr, vendor $vendor)"
+        echo "BT setup: non-Intel candidate $hci ($addr, vendor $vendor)"
     fi
 done
 if [ -n "${BCM_BT_ADAPTER:-}" ]; then
     PREFERRED_ADDR="$BCM_BT_ADAPTER"
     echo "BT setup: explicit override BCM_BT_ADAPTER=$PREFERRED_ADDR"
+elif [ "${BCM_BT_PREFER_INTERNAL:-0}" = "1" ] && [ -n "$INTEL_ADDR" ]; then
+    PREFERRED_ADDR="$INTEL_ADDR"
+    echo "BT setup: BCM_BT_PREFER_INTERNAL=1 — using Intel $PREFERRED_ADDR"
 elif [ -n "$NON_INTEL_ADDR" ]; then
     PREFERRED_ADDR="$NON_INTEL_ADDR"
 elif [ -n "$FIRST_ADDR" ]; then
     PREFERRED_ADDR="$FIRST_ADDR"
-    echo "BT setup: no non-Intel adapter, falling back to $PREFERRED_ADDR"
+    echo "BT setup: no preferred adapter, falling back to $PREFERRED_ADDR"
 fi
 
 # Find the hciX index for the chosen address — used for hciconfig fallback

--- a/config/scripts/setup-x86.sh
+++ b/config/scripts/setup-x86.sh
@@ -43,9 +43,13 @@ SMALL_H=480
 WIFI_IFACE="wlp2s0"
 WIFI_SSID="ALFA_AA"
 WIFI_PASS="AlfaRomeo156"
-WIFI_CHANNEL="6"
-WIFI_HW_MODE="g"
-WIFI_COUNTRY="US"
+# Default mode is wpa_supplicant P2P-GO (Wi-Fi Direct), driven by
+# src/multimedia/wifi_ap.py — system hostapd is left disabled so the
+# Python process owns the radio. The hostapd fallback below is kept
+# for older deployments that flip wifi.mode back to "hostapd" in YAML.
+WIFI_CHANNEL="149"
+WIFI_HW_MODE="a"
+WIFI_COUNTRY="BO"
 # ─────────────────────────────────────────────────────────────────
 
 RED='\033[0;31m'
@@ -107,6 +111,8 @@ rm -f /etc/dnsmasq.d/bcm-ap.conf
 rm -f /etc/network/interfaces.d/bcm-ap
 rm -f /etc/network/interfaces.d/static
 rm -f /etc/NetworkManager/conf.d/bcm-unmanage-wifi.conf
+rm -f /etc/NetworkManager/conf.d/bcm-unmanage-p2p.conf
+rm -f /etc/systemd/network/00-bcm-p2p.network
 nmcli device set "$WIFI_IFACE" managed yes 2>/dev/null || true
 ip addr flush dev "$WIFI_IFACE" 2>/dev/null || true
 
@@ -143,7 +149,7 @@ apt-get install -y -qq \
     pipewire pipewire-pulse wireplumber alsa-utils mpv \
     gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
     gstreamer1.0-plugins-bad gstreamer1.0-libav \
-    firmware-iwlwifi bluez bluez-tools rfkill network-manager modemmanager hostapd dnsmasq iw wireless-tools iptables \
+    firmware-iwlwifi bluez bluez-tools rfkill network-manager modemmanager hostapd dnsmasq iw wireless-tools wpasupplicant iptables \
     ffmpeg v4l-utils \
     acpid \
     zram-tools \
@@ -518,6 +524,24 @@ else
 unmanaged-devices=interface-name:$WIFI_IFACE
 EOF
 
+    # Wi-Fi Direct P2P group interfaces (p2p-*) need to be unmanaged
+    # too — without this NetworkManager + systemd-networkd toggle the
+    # link UP/DOWN, which wpa_supplicant interprets as the group going
+    # away and tears the P2P-GO down. Only relevant if you flip
+    # wifi.mode to p2p_go in YAML; harmless otherwise.
+    cat > /etc/NetworkManager/conf.d/bcm-unmanage-p2p.conf <<'EOF'
+[keyfile]
+unmanaged-devices=interface-name:p2p-*
+EOF
+    mkdir -p /etc/systemd/network
+    cat > /etc/systemd/network/00-bcm-p2p.network <<'EOF'
+[Match]
+Name=p2p-*
+
+[Link]
+Unmanaged=yes
+EOF
+
     # Best-effort regdom hint at module load: iwlwifi 8265 has a
     # self-managed PHY pinned to country 00, which makes ch149/153
     # (U-NII-3, normally OK in US) read NO-IR for AP mode. This is
@@ -584,26 +608,18 @@ EOF
     ip addr add 192.168.44.1/24 dev "$WIFI_IFACE" 2>/dev/null || true
     ip link set "$WIFI_IFACE" up 2>/dev/null || true
 
-    systemctl unmask hostapd 2>/dev/null || true
-    systemctl enable hostapd dnsmasq
+    # System hostapd is left DISABLED — the BCM-internal wifi_ap.py
+    # owns the radio via wpa_supplicant P2P-GO. Concurrent hostapd
+    # would race for the same iface and trigger nl80211 EBUSY. To
+    # re-enable the legacy hostapd path, flip wifi.mode back to
+    # "hostapd" in bcm_config.yaml and run `systemctl enable
+    # hostapd dnsmasq`.
+    systemctl disable hostapd 2>/dev/null || true
+    systemctl stop hostapd 2>/dev/null || true
+    systemctl mask hostapd 2>/dev/null || true
 
-    # Ensure hostapd starts after network is ready and restarts on failure
-    mkdir -p /etc/systemd/system/hostapd.service.d
-    cat > /etc/systemd/system/hostapd.service.d/bcm-ordering.conf <<EOF
-[Unit]
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-Restart=on-failure
-RestartSec=3
-EOF
-
-    # Disable BCM's internal WiFi AP manager (conflicts with system hostapd)
     # Disable simulation mode (no fake OBD/BT/GPS data on real hardware)
     if [ -f "$BCM_DIR/config/bcm_config.yaml" ]; then
-        sed -i '/^wifi:/,/^[^ ]/{s/^\(  enabled:\) true/\1 false/}' \
-            "$BCM_DIR/config/bcm_config.yaml"
         # Add simulation: false under system: section
         if ! grep -q "simulation:" "$BCM_DIR/config/bcm_config.yaml"; then
             sed -i '/^  log_file:/a\  simulation: false' \
@@ -611,11 +627,6 @@ EOF
         else
             sed -i 's/^\(  simulation:\).*/\1 false/' \
                 "$BCM_DIR/config/bcm_config.yaml"
-        fi
-        if grep -A1 "^wifi:" "$BCM_DIR/config/bcm_config.yaml" | grep -q "enabled: true"; then
-            warn "Could not patch wifi.enabled — edit bcm_config.yaml manually: set wifi.enabled to false"
-        else
-            echo "  Set wifi.enabled=false in bcm_config.yaml (systemd manages the AP)"
         fi
     fi
 
@@ -884,12 +895,22 @@ fi
 # connect attempt and pairing handshakes get dropped before the audio
 # profile completes. pipewire-audio pulls in the right defaults for
 # headset routing.
-apt-get install -y libspa-0.2-bluetooth pipewire-audio rfkill iw 2>/dev/null || true
+apt-get install -y libspa-0.2-bluetooth pipewire-audio rfkill iw bluez-obexd 2>/dev/null || true
 
 # Enable Bluetooth (needed for AA wireless pairing)
 cp "$BCM_DIR/config/scripts/bcm-bluetooth-setup.sh" /usr/local/bin/
 chmod +x /usr/local/bin/bcm-bluetooth-setup.sh
 cp "$BCM_DIR/config/systemd/bcm-bluetooth.service" /etc/systemd/system/
+
+# Tell the BT setup oneshot to prefer the integrated Intel 8087 adapter
+# on the M910q (matches bluetooth.prefer_internal=true in the YAML).
+# Remove or set to 0 to fall back to "prefer USB dongle" which is the
+# safer default on unknown hardware. The hci watchdog inside
+# BluetoothManager recovers from the documented Intel tx-timeouts.
+mkdir -p /etc/default
+if ! grep -q "^BCM_BT_PREFER_INTERNAL=" /etc/default/bcm-bluetooth 2>/dev/null; then
+    echo "BCM_BT_PREFER_INTERNAL=1" >> /etc/default/bcm-bluetooth
+fi
 
 # Persist BT rfkill unblock across boots — without this many baremetal
 # boards (M910q, OPi 5 Pro) come up with bluetooth soft-blocked even

--- a/src/audio/pipewire_ctrl.py
+++ b/src/audio/pipewire_ctrl.py
@@ -32,11 +32,36 @@ EQ_PRESETS = {
 EQ_FREQUENCIES = [31, 62, 125, 250, 500, 1000, 2000, 4000, 8000, 16000]
 
 
+def _pipewire_env() -> dict:
+    """Build env vars so wpctl/pw-cli reach the user's PipeWire socket.
+
+    bcm-headunit runs as root via systemd, but PipeWire/wireplumber
+    live in user session 1000. Without XDG_RUNTIME_DIR pointing at
+    the user's runtime dir, `wpctl status` fails with rc=1 and BCM
+    falls back to simulated audio — volume/mute/sink-switch are no-ops
+    until this is fixed. PIPEWIRE_RUNTIME_DIR is also honored by some
+    pipewire versions; setting both is safe.
+    """
+    import os
+    env = os.environ.copy()
+    for uid in (1000, os.getuid()):
+        runtime = f"/run/user/{uid}"
+        if os.path.isdir(f"{runtime}/pipewire-0") or os.path.exists(
+                f"{runtime}/pipewire-0"):
+            env["XDG_RUNTIME_DIR"] = runtime
+            env["PIPEWIRE_RUNTIME_DIR"] = runtime
+            return env
+    # Fallback — XDG_RUNTIME_DIR set but socket may not exist
+    env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+    return env
+
+
 def _run_cmd(cmd: list[str], timeout: float = 5.0) -> tuple[int, str, str]:
     """Run a shell command and return (returncode, stdout, stderr)."""
     try:
         result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=timeout
+            cmd, capture_output=True, text=True, timeout=timeout,
+            env=_pipewire_env(),
         )
         return result.returncode, result.stdout, result.stderr
     except FileNotFoundError:

--- a/src/dashboard/web/css/themes.css
+++ b/src/dashboard/web/css/themes.css
@@ -2,6 +2,96 @@
    BCM v8 — Theme System (CSS Custom Properties)
    ======================================== */
 
+/* ---- 7" touchscreen sizing bump ----
+ * Tailwind utility classes (text-xs, p-2, h-12, gap-1, etc.) are all
+ * defined in rem, so bumping the root font-size scales the entire
+ * dashboard chrome 15% without any per-class edits. This is the
+ * pixel-accurate path the user asked for — NOT a transform:scale,
+ * which would blur fonts and break touch coordinate mapping.
+ *
+ * Literal pixel values (text-[10px], style="font-size:18px") do NOT
+ * scale via rem; those are handled by the resize helper class
+ * `.bcm-touch-icon` below and by per-component pixel bumps in the
+ * JS templates (navbar/appbar/keyboard).
+ */
+html {
+    font-size: 18.4px;   /* 16 × 1.15 */
+}
+
+/* Android Auto note: the captured autoapp stream is an <img> filling
+ * absolute inset-0, so the rem bump above doesn't change its
+ * pixel-for-pixel mapping — touch coordinates inside autoapp stay
+ * 1:1 with the Xvfb canvas. Only the shared NavBar gets larger,
+ * which is exactly what the 7" brief asked for.
+ */
+
+/* Tailwind arbitrary pixel sizes are NOT rem-based so the html bump
+ * above leaves them alone. The Settings/Trip/Weather/Service panels
+ * are full of text-[9px]/text-[10px] tag labels that the user wanted
+ * +15% along with everything else — these escape-bracket selectors
+ * bump them in-place without rewriting 150+ inline class strings.
+ */
+.text-\[8px\]   { font-size: 10px !important; }
+.text-\[9px\]   { font-size: 11px !important; }
+.text-\[10px\]  { font-size: 12px !important; }
+.text-\[11px\]  { font-size: 13px !important; }
+.text-\[12px\]  { font-size: 14px !important; }
+.text-\[13px\]  { font-size: 15px !important; }
+.text-\[14px\]  { font-size: 16px !important; }
+.text-\[24px\]  { font-size: 28px !important; }
+.text-\[26px\]  { font-size: 30px !important; }
+.text-\[28px\]  { font-size: 32px !important; }
+.text-\[32px\]  { font-size: 37px !important; }
+.text-\[36px\]  { font-size: 42px !important; }
+
+/* Material icons set their size via inline `style="font-size:NNpx"`.
+ * Attribute selectors with !important do beat inline declarations,
+ * so we can bump the common sizes without touching the JS templates.
+ * Format is no-space (`font-size:14px`) — verified across all the
+ * components/screens. If you author a new icon, match that format.
+ */
+.material-symbols-outlined[style*="font-size:14px"] { font-size: 16px !important; }
+.material-symbols-outlined[style*="font-size:16px"] { font-size: 19px !important; }
+.material-symbols-outlined[style*="font-size:18px"] { font-size: 21px !important; }
+.material-symbols-outlined[style*="font-size:20px"] { font-size: 23px !important; }
+.material-symbols-outlined[style*="font-size:22px"] { font-size: 25px !important; }
+.material-symbols-outlined[style*="font-size:24px"] { font-size: 28px !important; }
+.material-symbols-outlined[style*="font-size:26px"] { font-size: 30px !important; }
+.material-symbols-outlined[style*="font-size:28px"] { font-size: 32px !important; }
+.material-symbols-outlined[style*="font-size:30px"] { font-size: 34px !important; }
+.material-symbols-outlined[style*="font-size:32px"] { font-size: 37px !important; }
+.material-symbols-outlined[style*="font-size:36px"] { font-size: 42px !important; }
+.material-symbols-outlined[style*="font-size:40px"] { font-size: 46px !important; }
+.material-symbols-outlined[style*="font-size:48px"] { font-size: 55px !important; }
+
+/* Tailwind arbitrary width/height tokens — these are pixel-literal
+ * containers (data panels, charts, modal widths). Keep the 1-2px
+ * separators alone (they should stay hairlines) and only bump the
+ * containers that would otherwise leave too much whitespace around
+ * scaled-up text inside them.
+ */
+.w-\[80px\]    { width: 92px !important; }
+.w-\[140px\]   { width: 160px !important; }
+.w-\[180px\]   { width: 207px !important; }
+.w-\[200px\]   { width: 220px !important; }     /* matches new appbar */
+.w-\[220px\]   { width: 220px !important; }     /* unchanged (appbar) */
+.w-\[240px\]   { width: 276px !important; }
+.w-\[260px\]   { width: 299px !important; }
+.w-\[280px\]   { width: 322px !important; }
+.w-\[300px\]   { width: 345px !important; }
+.w-\[320px\]   { width: 368px !important; }
+.w-\[340px\]   { width: 391px !important; }
+.w-\[360px\]   { width: 414px !important; }
+.w-\[420px\]   { width: 483px !important; }
+.w-\[480px\]   { width: 552px !important; }
+.w-\[540px\]   { width: 621px !important; }
+.h-\[110px\]   { height: 126px !important; }
+.h-\[280px\]   { height: 322px !important; }
+.h-\[300px\]   { height: 345px !important; }
+.max-h-\[300px\] { max-height: 345px !important; }
+/* max-w-[800px] left alone — the keyboard component now drops it
+ * entirely, and other consumers want the natural ceiling. */
+
 /* Material Symbols baseline */
 .material-symbols-outlined {
     font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
@@ -241,7 +331,7 @@ body[data-theme="autodelta"] {
     bottom: 0;
     left: 0;
     right: 0;
-    height: 28px;
+    height: 36px;   /* +30% — easier to catch swipe-up with fat fingers */
     z-index: 49;
     background: transparent;
 }

--- a/src/dashboard/web/js/components/appbar.js
+++ b/src/dashboard/web/js/components/appbar.js
@@ -21,7 +21,7 @@ const AppBar = (() => {
             // Invert to white, orange tint
             filterStyle = "filter: invert(1) sepia(1) saturate(5) hue-rotate(-10deg) brightness(1.2);";
         }
-        return `<img src="/assets/alfa_logo.png" alt="Alfa Romeo" class="h-11 w-auto object-contain" style="${filterStyle}" onerror="this.parentElement.innerHTML='<span class=\\'text-sm font-bold\\'>AR</span>';">`;
+        return `<img src="/assets/alfa_logo.png" alt="Alfa Romeo" class="h-12 w-auto object-contain" style="${filterStyle}" onerror="this.parentElement.innerHTML='<span class=\\'text-base font-bold\\'>AR</span>';">`;
     }
 
     function render(theme, data) {
@@ -29,7 +29,9 @@ const AppBar = (() => {
         const date = _formatDate();
         const temp = _formatTemp(data);
         const btClass = data.bt_connected ? "text-green-500" : "text-zinc-600";
-        const btIcon = `<span class="material-symbols-outlined ${btClass}" style="font-size:16px;font-variation-settings:'FILL' ${data.bt_connected ? 1 : 0};">bluetooth</span>`;
+        // Pixel bumps for 7" touchscreen (matches navbar): icons go
+        // 16/24 → 19/28 px, fonts text-sm → text-base, height h-12 → h-14.
+        const btIcon = `<span class="material-symbols-outlined ${btClass}" style="font-size:19px;font-variation-settings:'FILL' ${data.bt_connected ? 1 : 0};">bluetooth</span>`;
 
         const bgColor = theme === "autodelta" ? "bg-[#111111] border-[#222222]"
             : "bg-black border-zinc-800";
@@ -37,19 +39,19 @@ const AppBar = (() => {
         const timeColor = theme === "autodelta" ? "text-white" : theme === "modern" ? "text-white" : "text-zinc-400";
         const tempColor = theme === "autodelta" ? "text-[#FF5F00]" : theme === "modern" ? "text-white" : "text-zinc-500";
 
-        return `<header class="w-full h-12 ${bgColor} border-b flex items-center px-4 shrink-0 z-50">
-            <div class="flex items-center gap-2 w-[200px]">
-                <span class="text-sm font-bold ${timeColor}" data-bind="time">${time}</span>
-                <span class="text-[10px] font-bold text-zinc-600 uppercase" data-bind="date">${date}</span>
+        return `<header class="w-full h-14 ${bgColor} border-b flex items-center px-4 shrink-0 z-50">
+            <div class="flex items-center gap-2 w-[220px]">
+                <span class="text-base font-bold ${timeColor}" data-bind="time">${time}</span>
+                <span class="text-xs font-bold text-zinc-600 uppercase" data-bind="date">${date}</span>
             </div>
             <div class="flex-1 flex justify-center">
                 ${_logoImg(theme)}
             </div>
-            <div class="flex items-center gap-4 w-[200px] justify-end">
-                <span class="${tempColor} text-sm font-bold" data-bind="ext_temp">${temp}</span>
+            <div class="flex items-center gap-4 w-[220px] justify-end">
+                <span class="${tempColor} text-base font-bold" data-bind="ext_temp">${temp}</span>
                 ${btIcon}
-                <span class="material-symbols-outlined text-zinc-600 text-[24px] cursor-pointer hover:text-zinc-400 p-1" onclick="App.navigateTo('audio')">equalizer</span>
-                <span class="material-symbols-outlined text-zinc-600 text-[24px] cursor-pointer hover:text-zinc-400 p-1" onclick="App.navigateTo('settings')">settings</span>
+                <span class="material-symbols-outlined text-zinc-600 cursor-pointer hover:text-zinc-400 p-1" style="font-size:28px;" onclick="App.navigateTo('audio')">equalizer</span>
+                <span class="material-symbols-outlined text-zinc-600 cursor-pointer hover:text-zinc-400 p-1" style="font-size:28px;" onclick="App.navigateTo('settings')">settings</span>
             </div>
         </header>`;
     }

--- a/src/dashboard/web/js/components/keyboard.js
+++ b/src/dashboard/web/js/components/keyboard.js
@@ -107,36 +107,52 @@ const OnScreenKeyboard = (() => {
                      : theme === "modern" ? "bg-blue-600 text-white"
                      : "bg-amber-600 text-white";
 
-        overlay.className = "fixed bottom-0 left-0 right-0 z-[200] p-2 border-t shadow-2xl " + bg;
+        // 7" touchscreen OSK — explicitly NOT max-width-clamped. We
+        // want every key to stretch to fill the full viewport so the
+        // hit-targets match the user's actual finger size; the old
+        // `max-w-[800px]` left the keyboard hugging the centre with
+        // ~1/3 of the screen wasted on either side.
+        overlay.className = "fixed bottom-0 left-0 right-0 z-[200] p-3 border-t shadow-2xl " + bg;
         overlay.style.cssText = "backdrop-filter:blur(12px);";
 
-        let html = `<div class="flex flex-col gap-1.5 max-w-[800px] mx-auto">`;
+        // flex-1 on every key + stretch on the row means each key
+        // claims an equal share of the viewport width. Letter rows
+        // give the same pixel allocation per slot regardless of how
+        // many keys are in the row, so a 9-letter row gets fatter
+        // keys than a 10-digit row, which matches typing ergonomics
+        // (the home row needs bigger keys, the number row gets fewer
+        // taps).
+        let html = `<div class="flex flex-col gap-2 w-full">`;
 
         html += `<div class="flex items-center gap-2 px-2 mb-1">
-            <span id="osk-display" class="text-sm font-mono opacity-60 truncate flex-1">${_escHtml(_value)}</span>
-            <button class="${keyBg} rounded-lg px-2 py-1 text-xs transition-colors" onclick="OnScreenKeyboard.close()" title="Hide keyboard">
-                <span class="material-symbols-outlined" style="font-size:18px;">keyboard_hide</span>
+            <span id="osk-display" class="text-base font-mono opacity-60 truncate flex-1">${_escHtml(_value)}</span>
+            <button class="${keyBg} rounded-lg px-3 py-2 text-sm transition-colors" onclick="OnScreenKeyboard.close()" title="Hide keyboard">
+                <span class="material-symbols-outlined" style="font-size:22px;">keyboard_hide</span>
             </button>
         </div>`;
 
+        // py-3.5 = 14 logical px top/bottom → ~16 actual px with the
+        // root rem bump → ~52 px tall keys. Comfortable target for
+        // thumbs and any finger size; the 7" screen is 600 px tall
+        // and the keyboard now uses ~310 px of that across 5 rows.
         for (const row of ROWS) {
-            html += `<div class="flex gap-1 justify-center">`;
+            html += `<div class="flex gap-1.5 w-full items-stretch">`;
             for (const k of row) {
                 if (k === "space") {
-                    html += `<button class="${keyBg} rounded-lg py-2.5 flex-[4] text-xs font-bold transition-colors" onclick="OnScreenKeyboard.key('space')">SPACE</button>`;
+                    html += `<button class="${keyBg} rounded-lg py-3.5 flex-[6] text-base font-bold transition-colors" onclick="OnScreenKeyboard.key('space')">SPACE</button>`;
                 } else if (k === "done") {
-                    html += `<button class="${accent} rounded-lg py-2.5 flex-[2] text-xs font-bold transition-colors" onclick="OnScreenKeyboard.key('done')">OK</button>`;
+                    html += `<button class="${accent} rounded-lg py-3.5 flex-[2] text-base font-bold transition-colors" onclick="OnScreenKeyboard.key('done')">OK</button>`;
                 } else if (k === "shift") {
-                    html += `<button class="${_shift ? accent : keyBg} rounded-lg py-2.5 px-3 text-xs font-bold transition-colors" onclick="OnScreenKeyboard.key('shift')">
-                        <span class="material-symbols-outlined" style="font-size:16px;">shift</span>
+                    html += `<button class="${_shift ? accent : keyBg} rounded-lg py-3.5 flex-[1.4] text-base font-bold transition-colors" onclick="OnScreenKeyboard.key('shift')">
+                        <span class="material-symbols-outlined" style="font-size:22px;">shift</span>
                     </button>`;
                 } else if (k === "backspace") {
-                    html += `<button class="${keyBg} rounded-lg py-2.5 px-3 text-xs font-bold transition-colors" onclick="OnScreenKeyboard.key('backspace')">
-                        <span class="material-symbols-outlined" style="font-size:16px;">backspace</span>
+                    html += `<button class="${keyBg} rounded-lg py-3.5 flex-[1.4] text-base font-bold transition-colors" onclick="OnScreenKeyboard.key('backspace')">
+                        <span class="material-symbols-outlined" style="font-size:22px;">backspace</span>
                     </button>`;
                 } else {
                     const display = _shift ? k.toUpperCase() : k;
-                    html += `<button class="${keyBg} rounded-lg py-2.5 min-w-[36px] text-sm font-bold transition-colors" onclick="OnScreenKeyboard.key('${k}')">${display}</button>`;
+                    html += `<button class="${keyBg} rounded-lg py-3.5 flex-1 text-lg font-bold transition-colors" onclick="OnScreenKeyboard.key('${k}')">${display}</button>`;
                 }
             }
             html += `</div>`;

--- a/src/dashboard/web/js/components/navbar.js
+++ b/src/dashboard/web/js/components/navbar.js
@@ -29,6 +29,12 @@ const NavBar = (() => {
         const aaAvailable = data.aa_available || data.aa_status === "running" || data.aa_status === "connected";
         const btAvailable = data.bt_available || data.bt_connected;
 
+        // Pixel bumps for the 7" touchscreen brief: nav tap targets and
+        // icons grow ~15-20% over the original (w-12/h-12 + 26px icons).
+        // w-14 / h-14 = 56 logical px (rem-scaled to ~64 actual px once
+        // the root font-size bump from themes.css applies), and the
+        // icon size goes 26 → 30 px so the SVG visual matches the
+        // larger hit-box without overcrowding.
         const items = NAV_ITEMS.map((item, i) => {
             const isActive = i === activeIdx;
             // Dim items that require unavailable features
@@ -36,20 +42,20 @@ const NavBar = (() => {
             const iconStyle = isActive ? "font-variation-settings:'FILL' 1;" : "";
 
             if (isDisabled && !isActive) {
-                return `<div class="flex items-center justify-center text-zinc-500 w-12 h-12 cursor-pointer opacity-50 transition-all"
+                return `<div class="flex items-center justify-center text-zinc-500 w-14 h-14 cursor-pointer opacity-50 transition-all"
                          title="${item.tip} (unavailable)" onclick="App.navigateTo('${item.screen}')">
-                    <span class="material-symbols-outlined" style="font-size:26px;">${item.icon}</span>
+                    <span class="material-symbols-outlined" style="font-size:30px;">${item.icon}</span>
                 </div>`;
             }
             if (isActive) {
-                return `<div class="flex items-center justify-center ${activeBg} ${activeColor} rounded-xl w-12 h-12 cursor-pointer transition-all"
+                return `<div class="flex items-center justify-center ${activeBg} ${activeColor} rounded-xl w-14 h-14 cursor-pointer transition-all"
                          title="${item.tip}" onclick="App.navigateTo('${item.screen}')">
-                    <span class="material-symbols-outlined" style="font-size:26px;${iconStyle}">${item.icon}</span>
+                    <span class="material-symbols-outlined" style="font-size:30px;${iconStyle}">${item.icon}</span>
                 </div>`;
             }
-            return `<div class="flex items-center justify-center ${inactiveColor} w-12 h-12 cursor-pointer hover:text-zinc-300 transition-all"
+            return `<div class="flex items-center justify-center ${inactiveColor} w-14 h-14 cursor-pointer hover:text-zinc-300 transition-all"
                      title="${item.tip}" onclick="App.navigateTo('${item.screen}')">
-                <span class="material-symbols-outlined" style="font-size:26px;">${item.icon}</span>
+                <span class="material-symbols-outlined" style="font-size:30px;">${item.icon}</span>
             </div>`;
         }).join("");
 
@@ -59,14 +65,14 @@ const NavBar = (() => {
         // .bcm-navbar-shown class. Floating so it doesn't steal vertical
         // space from content-area on any screen.
         return `<nav id="bcm-navbar"
-            class="bcm-navbar absolute bottom-0 left-0 right-0 z-50 flex justify-around items-center h-12 ${barCls} border-t"
+            class="bcm-navbar absolute bottom-0 left-0 right-0 z-50 flex justify-around items-center h-14 ${barCls} border-t"
             ontouchstart="App.kickNavBar(true)"
             onmouseenter="App.kickNavBar(true)"
             onmouseleave="App.kickNavBar(false)">
             ${items}
-            <div class="flex items-center justify-center text-zinc-600 w-12 h-12 cursor-pointer hover:text-zinc-400 transition-all"
+            <div class="flex items-center justify-center text-zinc-600 w-14 h-14 cursor-pointer hover:text-zinc-400 transition-all"
                  title="Settings" onclick="App.navigateTo('settings')">
-                <span class="material-symbols-outlined" style="font-size:24px;">settings</span>
+                <span class="material-symbols-outlined" style="font-size:28px;">settings</span>
             </div>
         </nav>`;
     }

--- a/src/dashboard/web/js/screens/android_auto.js
+++ b/src/dashboard/web/js/screens/android_auto.js
@@ -41,7 +41,10 @@ App.registerScreen("a2", (() => {
         }
 
         // Fullscreen — no AppBar. The autohiding NavBar floats over the
-        // canvas, revealed by a swipe up from the bottom edge.
+        // canvas, revealed by a swipe up from the bottom edge. The
+        // captured autoapp stream below is an <img> with absolute
+        // inset-0, so the global 7" rem bump doesn't touch its 1:1
+        // pixel mapping. Only the shared NavBar gets larger.
         container.innerHTML = `<div class="screen-container ${bgCls}">
             <main class="content-area relative overflow-hidden bg-black">
                 ${statusBadge}

--- a/src/dashboard/web/js/screens/settings.js
+++ b/src/dashboard/web/js/screens/settings.js
@@ -78,7 +78,9 @@ const Settings = {
     },
 
     async wifiLoad() {
-        if (Settings._wifi.loaded) return;
+        // Always refresh — the P2P-GO credentials change on every
+        // boot, so a cached "loaded=true" would show stale values
+        // from a previous wpa_supplicant session.
         try {
             const res = await fetch("/api/wifi/config");
             if (!res.ok) return;
@@ -86,6 +88,13 @@ const Settings = {
             Settings._wifi.ssid = d.ssid || "";
             Settings._wifi.password = d.password || "";
             Settings._wifi.channel = d.channel || 6;
+            Settings._wifi.mode = d.mode || "p2p_go";
+            Settings._wifi.live_ssid = d.live_ssid || "";
+            Settings._wifi.live_password = d.live_password || "";
+            Settings._wifi.live_bssid = d.live_bssid || "";
+            Settings._wifi.alfa_net_enabled = d.alfa_net_enabled !== false;
+            Settings._wifi.alfa_net_ssid = d.alfa_net_ssid || "ALFA-NET";
+            Settings._wifi.alfa_net_password = d.alfa_net_password || "";
             Settings._wifi.loaded = true;
             App.navigateTo("settings");
         } catch (e) {}
@@ -109,6 +118,7 @@ const Settings = {
         const ssid = (Settings._wifi.ssid || "").trim();
         const pwd = Settings._wifi.password || "";
         const ch = parseInt(Settings._wifi.channel, 10);
+        const valid5 = new Set([36, 40, 44, 48, 149, 153, 157, 161, 165]);
         if (!ssid || ssid.length > 32) {
             Settings._wifi.status = "SSID required (1-32 chars)";
             App.navigateTo("settings");
@@ -119,8 +129,16 @@ const Settings = {
             App.navigateTo("settings");
             return;
         }
-        if (!Number.isFinite(ch) || ch < 1 || ch > 13) {
-            Settings._wifi.status = "Channel must be 1-13";
+        if (!Number.isFinite(ch) || !((ch >= 1 && ch <= 13) || valid5.has(ch))) {
+            Settings._wifi.status = "Channel must be 1-13 or 36-165 (5 GHz)";
+            App.navigateTo("settings");
+            return;
+        }
+        // ALFA-NET secondary AP — only validate when changed from defaults.
+        const anSsid = (Settings._wifi.alfa_net_ssid || "").trim();
+        const anPwd = Settings._wifi.alfa_net_password || "";
+        if (anPwd && (anPwd.length < 8 || anPwd.length > 63)) {
+            Settings._wifi.status = "ALFA-NET password must be 8-63 chars";
             App.navigateTo("settings");
             return;
         }
@@ -131,7 +149,12 @@ const Settings = {
             const res = await fetch("/api/wifi/config", {
                 method: "POST",
                 headers: {"Content-Type": "application/json"},
-                body: JSON.stringify({ssid, password: pwd, channel: ch}),
+                body: JSON.stringify({
+                    ssid, password: pwd, channel: ch,
+                    alfa_net_enabled: !!Settings._wifi.alfa_net_enabled,
+                    alfa_net_ssid: anSsid,
+                    alfa_net_password: anPwd,
+                }),
             });
             const d = await res.json();
             if (d.ok === false || d.error) {
@@ -423,6 +446,22 @@ App.registerScreen("settings", (() => {
                         <!-- Android Auto Wireless / Wi-Fi AP credentials -->
                         <div class="rounded-xl p-3" style="background:var(--card-bg);border:1px solid var(--card-border)">
                             <p class="text-[10px] font-bold uppercase tracking-wider mb-2" style="color:var(--text-dim)">${t("aa_wireless","Android Auto Wireless")}</p>
+                            ${Settings._wifi.mode === "p2p_go" && Settings._wifi.live_ssid ? `
+                            <!-- Live P2P-GO credentials — wpa_supplicant
+                                 picks a fresh DIRECT-XX SSID + passphrase
+                                 every boot, so the YAML defaults below
+                                 aren't what the phone actually joins.
+                                 Surface the live values here read-only. -->
+                            <div class="rounded-lg p-2 mb-3" style="background:rgba(255,95,0,0.08);border:1px solid rgba(255,95,0,0.3)">
+                                <p class="text-[9px] uppercase tracking-wider mb-1" style="color:#FF5F00">${t("live_ap","Live AP (read on phone)")}</p>
+                                <div class="grid grid-cols-[auto_1fr] gap-x-2 gap-y-1 text-xs font-mono" style="color:var(--text-primary)">
+                                    <span style="color:var(--text-dim)">SSID:</span><span data-bind="wifi_live_ssid">${_attrEsc(Settings._wifi.live_ssid)}</span>
+                                    <span style="color:var(--text-dim)">PSK:</span><span data-bind="wifi_live_password" style="user-select:text;-webkit-user-select:text">${_attrEsc(Settings._wifi.live_password)}</span>
+                                    ${Settings._wifi.live_bssid ? `<span style="color:var(--text-dim)">BSSID:</span><span class="text-[10px]" data-bind="wifi_live_bssid">${_attrEsc(Settings._wifi.live_bssid)}</span>` : ""}
+                                </div>
+                                <p class="text-[9px] mt-1" style="color:var(--text-dim)">${t("p2p_go_note","Wi-Fi Direct GO regenerates these on each boot. Phone gets them automatically over BT during AA pairing.")}</p>
+                            </div>` : ""}
+                            <p class="text-[9px] font-bold uppercase tracking-wider mb-1" style="color:var(--text-dim)">${t("defaults","Defaults (used in hostapd mode)")}</p>
                             <div class="space-y-2">
                                 <div class="flex items-center gap-2">
                                     <label class="text-[9px] uppercase w-16" style="color:var(--text-dim)">SSID</label>
@@ -445,16 +484,46 @@ App.registerScreen("settings", (() => {
                                 </div>
                                 <div class="flex items-center gap-2">
                                     <label class="text-[9px] uppercase w-16" style="color:var(--text-dim)">${t("channel","Channel")}</label>
-                                    <input type="number" min="1" max="13" value="${Settings._wifi.channel}"
+                                    <input type="number" min="1" max="165" value="${Settings._wifi.channel}"
                                         oninput="Settings.wifiUpdate('channel', this.value)"
                                         class="w-16 px-2 py-1 rounded text-xs"
                                         style="background:var(--color-surface);color:var(--text-primary);border:1px solid var(--card-border)">
-                                    <span class="text-[9px]" style="color:var(--text-dim)">2.4 GHz</span>
+                                    <span class="text-[9px]" style="color:var(--text-dim)">${Settings._wifi.channel >= 36 ? "5 GHz" : "2.4 GHz"}</span>
                                     <button onclick="Settings.wifiSave()"
                                         ${Settings._wifi.saving ? 'disabled' : ''}
                                         class="ml-auto px-3 py-1 bg-green-600 text-white text-[10px] font-bold rounded hover:bg-green-500 ${Settings._wifi.saving ? 'opacity-50 cursor-not-allowed' : ''}">${Settings._wifi.saving ? t("saving","Saving...") : t("save","Save")}</button>
                                 </div>
                                 ${Settings._wifi.status ? `<p class="text-[10px]" style="color:var(--text-mid)">${Settings._wifi.status}</p>` : ""}
+                                <!-- ALFA-NET secondary AP — broadcast in parallel for internet sharing -->
+                                <div class="pt-2 space-y-2" style="border-top:1px solid var(--card-border)">
+                                    <div class="flex items-center justify-between">
+                                        <p class="text-[10px] font-bold uppercase tracking-wider" style="color:var(--text-dim)">${t("alfa_net","ALFA-NET (Internet share)")}</p>
+                                        <label class="inline-flex items-center gap-1 text-[9px]" style="color:var(--text-dim)">
+                                            <input type="checkbox" ${Settings._wifi.alfa_net_enabled ? 'checked' : ''}
+                                                oninput="Settings.wifiUpdate('alfa_net_enabled', this.checked)">
+                                            ${t("enabled","Enabled")}
+                                        </label>
+                                    </div>
+                                    <div class="flex items-center gap-2">
+                                        <label class="text-[9px] uppercase w-16" style="color:var(--text-dim)">SSID</label>
+                                        <input type="text" maxlength="32" value="${_attrEsc(Settings._wifi.alfa_net_ssid || "ALFA-NET")}"
+                                            onfocus="OnScreenKeyboard.attach(this)"
+                                            oninput="Settings.wifiUpdate('alfa_net_ssid', this.value)"
+                                            class="flex-1 px-2 py-1 rounded text-xs"
+                                            style="background:var(--color-surface);color:var(--text-primary);border:1px solid var(--card-border)">
+                                    </div>
+                                    <div class="flex items-center gap-2">
+                                        <label class="text-[9px] uppercase w-16" style="color:var(--text-dim)">${t("password","Password")}</label>
+                                        <input type="${Settings._wifi.showAlfaPwd ? 'text' : 'password'}" maxlength="63" value="${_attrEsc(Settings._wifi.alfa_net_password || "")}"
+                                            onfocus="OnScreenKeyboard.attach(this)"
+                                            oninput="Settings.wifiUpdate('alfa_net_password', this.value)"
+                                            class="flex-1 px-2 py-1 rounded text-xs"
+                                            style="background:var(--color-surface);color:var(--text-primary);border:1px solid var(--card-border)">
+                                        <button onclick="Settings._wifi.showAlfaPwd = !Settings._wifi.showAlfaPwd; App.navigateTo('settings')"
+                                            class="px-2 py-1 text-[9px] font-bold rounded"
+                                            style="background:var(--card-border);color:var(--text-mid)">${Settings._wifi.showAlfaPwd ? t("hide","Hide") : t("show","Show")}</button>
+                                    </div>
+                                </div>
                                 <div class="flex items-center justify-between pt-2" style="border-top:1px solid var(--card-border)">
                                     <p class="text-[10px]" style="color:var(--text-dim)">${
                                         Settings._wifi.restartRequired

--- a/src/dashboard/web_viewer.py
+++ b/src/dashboard/web_viewer.py
@@ -910,10 +910,33 @@ class WebViewer:
             cfg = viewer._config
             if cfg is None:
                 return jsonify({})
+            # wifi.*_runtime are set by wifi_ap.py when a P2P-GO group
+            # comes up — wpa_supplicant assigns a random DIRECT-XX SSID
+            # and WPA2 passphrase that override the YAML defaults. Show
+            # those as the LIVE values; expose the YAML values too so
+            # the user knows what gets used in hostapd mode.
+            mode = cfg.get("wifi.mode", "p2p_go")
+            live_ssid = cfg.get("wifi.ssid_runtime", "") or cfg.get("wifi.ssid", "")
+            live_pwd = cfg.get("wifi.password_runtime", "") or cfg.get("wifi.password", "")
+            live_bssid = cfg.get("wifi.bssid_runtime", "")
             return jsonify({
+                # legacy fields — still the YAML values so the Save
+                # button can write them back without overwriting the
+                # auto-generated P2P-GO credentials.
                 "ssid": cfg.get("wifi.ssid", ""),
                 "password": cfg.get("wifi.password", ""),
                 "channel": cfg.get("wifi.channel", 6),
+                # live values (what the phone actually connects to)
+                "mode": mode,
+                "live_ssid": live_ssid,
+                "live_password": live_pwd,
+                "live_bssid": live_bssid,
+                # ALFA-NET (still a regular hostapd AP, user-editable)
+                "alfa_net_enabled": bool(
+                    cfg.get("wifi.alfa_net.enabled", True)),
+                "alfa_net_ssid": cfg.get("wifi.alfa_net.ssid", "ALFA-NET"),
+                "alfa_net_password": cfg.get(
+                    "wifi.alfa_net.password", "AlfaRomeo156"),
             })
 
         @app.route("/api/wifi/config", methods=["POST"])
@@ -936,13 +959,36 @@ class WebViewer:
             except (TypeError, ValueError):
                 return jsonify({"ok": False,
                                 "error": "channel must be a number"}), 400
-            if not (1 <= channel <= 13):
+            # Channel range — accept 2.4 GHz (1-13) and 5 GHz UNII bands.
+            valid_5ghz = {36, 40, 44, 48, 149, 153, 157, 161, 165}
+            if not (1 <= channel <= 13 or channel in valid_5ghz):
                 return jsonify({"ok": False,
-                                "error": "channel must be 1-13 (2.4 GHz)"}), 400
+                                "error": "channel must be 1-13 or "
+                                         "36/40/44/48/149/153/157/161/165"
+                                }), 400
 
             cfg.set("wifi.ssid", ssid)
             cfg.set("wifi.password", password)
             cfg.set("wifi.channel", channel)
+
+            # Optional ALFA-NET fields — only update if explicitly provided
+            # so calls from older clients don't blank the secondary AP.
+            an_ssid = data.get("alfa_net_ssid")
+            an_pwd = data.get("alfa_net_password")
+            an_enabled = data.get("alfa_net_enabled")
+            if an_ssid is not None:
+                an_ssid = (an_ssid or "").strip()
+                if an_ssid and len(an_ssid) <= 32:
+                    cfg.set("wifi.alfa_net.ssid", an_ssid)
+            if an_pwd is not None:
+                if isinstance(an_pwd, str) and 8 <= len(an_pwd) <= 63:
+                    cfg.set("wifi.alfa_net.password", an_pwd)
+                elif an_pwd != "":
+                    return jsonify({"ok": False,
+                                    "error": "ALFA-NET password 8-63 chars"
+                                    }), 400
+            if an_enabled is not None:
+                cfg.set("wifi.alfa_net.enabled", bool(an_enabled))
             try:
                 cfg.save()
             except Exception as e:

--- a/src/multimedia/bluetooth.py
+++ b/src/multimedia/bluetooth.py
@@ -98,6 +98,19 @@ AA_PROFILE_PATH = "/org/bluez/bcm_aa_profile"
 A2DP_PROFILE_PATH = "/org/bluez/bcm_a2dp_profile"
 HFP_PROFILE_PATH = "/org/bluez/bcm_hfp_profile"
 
+# Phone Book Access Profile (PBAP) — Client (PCE) UUID. Phones surface
+# the "Share contacts & call history with car" prompt during pairing
+# only when the headunit advertises this UUID in its SDP record. The
+# Carkit Class-of-Device alone is not enough — Android checks for the
+# PCE service before offering the toggle.
+PBAP_PCE_UUID = "0000112e-0000-1000-8000-00805f9b34fb"
+PBAP_PROFILE_PATH = "/org/bluez/bcm_pbap_pce"
+# Message Access Profile — Client (MCE) UUID. Same story for SMS/MMS
+# sharing; we advertise it so the phone offers the toggle, but the
+# actual message-pull is optional and disabled by default.
+MAP_MCE_UUID = "00001134-0000-1000-8000-00805f9b34fb"
+MAP_PROFILE_PATH = "/org/bluez/bcm_map_mce"
+
 
 class _PairingRequest:
     """Holds a pending pairing confirmation request."""
@@ -288,7 +301,7 @@ def _register_bt_profile(bus, path: str, uuid: str, name: str,
 def _register_all_profiles(bus) -> None:
     """Register Bluetooth profiles with BlueZ.
 
-    NOTE: A2DP Sink and HFP profiles are NOT registered here — they are
+    A2DP Sink and HFP profiles are NOT registered here — they are
     managed by PipeWire/WirePlumber via libspa-0.2-bluetooth. Registering
     them here would block PipeWire (BlueZ: NotPermitted) and break audio.
 
@@ -297,10 +310,20 @@ def _register_all_profiles(bus) -> None:
     properly implements the AA wireless protocol handshake. Registering
     the AA UUID here would conflict with autoapp's btservice and cause
     "Server start failed" errors.
+
+    PBAP-PCE and MAP-MCE ARE registered here — these are client-side
+    "we want to consume your phonebook/messages" advertisements that
+    flip on the Android-side "Share contacts & call history with car"
+    pairing prompt. They don't conflict with autoapp because autoapp
+    doesn't touch PBAP/MAP. The actual data pull happens through obexd
+    in src/multimedia/phonebook.py.
     """
-    # No custom profiles to register:
-    # A2DP/HFP → PipeWire, AA → autoapp btservice
-    log.debug("BT profile registration: A2DP/HFP=PipeWire, AA=autoapp")
+    _register_bt_profile(bus, PBAP_PROFILE_PATH, PBAP_PCE_UUID,
+                         "BCM Phonebook Client", role="client")
+    _register_bt_profile(bus, MAP_PROFILE_PATH, MAP_MCE_UUID,
+                         "BCM Message Client", role="client")
+    log.info("BT profile registration: PBAP-PCE + MAP-MCE; "
+             "A2DP/HFP=PipeWire, AA=autoapp")
 
 
 def _find_adapter_dbus_path() -> str:
@@ -437,18 +460,37 @@ def _start_pairing_agent() -> bool:
         return False
 
 
+_PREFER_INTERNAL = False
+
+
+def set_prefer_internal(flag: bool) -> None:
+    """Flip vendor-8087 preference. False (default) prefers the USB dongle
+    (working-around the documented M910q tx-timeout); True forces the
+    integrated Intel adapter even when a dongle is present."""
+    global _PREFER_INTERNAL, _PREFERRED_ADAPTER
+    _PREFER_INTERNAL = bool(flag)
+    _PREFERRED_ADAPTER = ""   # force re-resolve
+
+
 def _find_preferred_adapter() -> str:
     """Find the best BT adapter address for headunit use.
 
-    On the M910q the integrated Intel 8087:0a2b (BT 4.2 on paper) is
-    documented-broken: dmesg captures `command 0xNNNN tx timeout` →
-    `Resetting usb device.` after ~15 minutes uptime, after which the
-    controller disappears from sysfs entirely. So when both the Intel
-    and a USB dongle (CSR/Realtek/Broadcom) are present, prefer the
-    dongle even though it's BT 4.0 — it survives.
+    Default policy (M910q workaround): the integrated Intel 8087:0a2b
+    (BT 4.2 on paper) is documented-broken — dmesg captures
+    ``command 0xNNNN tx timeout`` → ``Resetting usb device.`` after
+    ~15 minutes uptime, after which the controller disappears from
+    sysfs entirely. So when both the Intel and a USB dongle
+    (CSR/Realtek/Broadcom) are present, prefer the dongle even though
+    it's BT 4.0 — it survives.
+
+    Override policy (``bluetooth.prefer_internal: true`` in YAML):
+    flips the bias so the Intel 8087 is picked even with a dongle
+    present. Pairs with the hci watchdog in BluetoothManager which
+    auto-bounces the Intel adapter on tx-timeout so the user-facing
+    impact of the reset is minimised.
 
     An explicit ``bluetooth.preferred_adapter`` MAC in config still wins
-    over auto-detect (lets the user pin a specific controller).
+    over both policies (lets the user pin a specific controller).
     """
     try:
         result = subprocess.run(
@@ -499,6 +541,7 @@ def _find_preferred_adapter() -> str:
             except ValueError:
                 return 999
 
+        intel: list[str] = []
         non_intel: list[str] = []
         for addr in controllers:
             hci = addr_to_hci.get(addr)
@@ -518,10 +561,19 @@ def _find_preferred_adapter() -> str:
                     if parent == cur:
                         break
                     cur = parent
-                if vendor and vendor != "8087":
+                if vendor == "8087":
+                    intel.append(addr)
+                elif vendor:
                     non_intel.append(addr)
             except Exception:
                 pass
+
+        if _PREFER_INTERNAL and intel:
+            intel.sort(key=_hci_index)
+            log.info("BT: preferring INTERNAL Intel 8087 adapter %s "
+                     "(prefer_internal=true) — %d controllers seen",
+                     intel[0], len(controllers))
+            return intel[0]
 
         if non_intel:
             non_intel.sort(key=_hci_index)
@@ -631,6 +683,17 @@ class BluetoothManager:
         # Disconnect tap doesn't immediately bring the device back.
         # Cleared on connect() and on remove().
         self._user_disconnect_addr: Optional[str] = None
+
+        # Force internal Intel 8087 (overrides default "prefer USB dongle"
+        # bias) — paired with the hci watchdog that bounces the adapter
+        # on tx-timeout.
+        try:
+            prefer_internal = bool(config.get("bluetooth.prefer_internal", False))
+        except Exception:
+            prefer_internal = False
+        if prefer_internal:
+            set_prefer_internal(True)
+            log.info("BT: prefer_internal=true — using integrated Intel adapter")
 
         # Optional explicit adapter override from config — pin a specific
         # USB BT dongle MAC if auto-detect picks the wrong one.
@@ -1301,6 +1364,63 @@ class BluetoothManager:
         self._start_media_monitor()
         # Register HFP call command handlers
         self._init_hfp_commands()
+        # Watchdog for the documented Intel 8087 tx-timeout — only
+        # engaged when the user has asked for the internal adapter.
+        if _PREFER_INTERNAL:
+            threading.Thread(
+                target=self._hci_watchdog, daemon=True, name="bt-hci-watchdog",
+            ).start()
+
+    def _hci_watchdog(self) -> None:
+        """Recover from Intel 8087 tx-timeout by bouncing the hci device.
+
+        Only runs when ``bluetooth.prefer_internal`` is set. dmesg shows
+        ``command 0x… tx timeout`` followed by ``Resetting usb device.``
+        after which BlueZ stops reporting the controller. ``hciconfig
+        hciX down/up`` restores it without a kernel-level USB reset.
+        """
+        miss = 0
+        while self._running:
+            time.sleep(15)
+            if not self._available:
+                continue
+            rc, out, _ = _run_btctl(["show"])
+            if rc == 0 and "Controller" in out:
+                miss = 0
+                continue
+            miss += 1
+            if miss < 2:
+                continue
+            # Two consecutive misses → controller gone. Find the hci by
+            # the adapter address we resolved and bounce it.
+            addr = _get_adapter_addr()
+            hci = None
+            try:
+                hc = subprocess.run(
+                    ["hciconfig"], capture_output=True, text=True, timeout=3,
+                )
+                current = None
+                for line in hc.stdout.splitlines():
+                    if line and not line[0].isspace() and ":" in line:
+                        current = line.split(":")[0].strip()
+                    if current and addr and addr in line:
+                        hci = current
+                        break
+            except Exception:
+                pass
+            if not hci:
+                hci = "hci0"
+            log.warning("BT hci watchdog: controller missing — bouncing %s", hci)
+            for cmd in (["rfkill", "unblock", "bluetooth"],
+                        ["hciconfig", hci, "down"],
+                        ["hciconfig", hci, "up"]):
+                try:
+                    subprocess.run(cmd, capture_output=True, timeout=4)
+                except Exception:
+                    pass
+            time.sleep(2)
+            self._check_availability()
+            miss = 0
 
     def stop_monitor(self) -> None:
         """Stop the connection monitor."""
@@ -1528,12 +1648,74 @@ class BluetoothManager:
         """Start monitoring AVRCP media metadata via D-Bus.
 
         Watches org.bluez.MediaPlayer1 properties for track info and
-        playback status changes. Publishes bt.media.track, bt.media.status,
-        bt.media.position to the event bus.
+        playback status changes. Publishes:
+
+          * ``bt.media.track`` (full dict for renderer.py)
+          * ``bt.media_title`` / ``bt.media_artist`` / ``bt.media_album``
+            / ``bt.media_duration`` / ``bt.media_playing`` / ``bt.media_position``
+            (flat keys read by web_viewer.py — without these the A1
+            now-playing card never receives anything)
+
+        Also seeds the topics from any MediaPlayer1 that already exists
+        when the monitor starts. ``PropertiesChanged`` only fires on
+        deltas, so a phone that's already streaming when BCM connects
+        would otherwise leave the card empty until the next track.
         """
         if not HAS_DBUS:
             log.debug("D-Bus not available — AVRCP media monitor disabled")
             return
+
+        def _publish_track(track_info: dict) -> None:
+            self._media_track = track_info
+            self._event_bus.publish("bt.media.track", track_info)
+            self._event_bus.publish("bt.media_title", track_info.get("title", ""))
+            self._event_bus.publish("bt.media_artist", track_info.get("artist", ""))
+            self._event_bus.publish("bt.media_album", track_info.get("album", ""))
+            self._event_bus.publish("bt.media_duration",
+                                    track_info.get("duration", 0))
+
+        def _publish_status(status: str) -> None:
+            self._media_status = status
+            self._event_bus.publish("bt.media.status", status)
+            self._event_bus.publish("bt.media_playing", status == "playing")
+
+        def _publish_position(position: int) -> None:
+            self._media_position = position
+            self._event_bus.publish("bt.media.position", position)
+            self._event_bus.publish("bt.media_position", position)
+
+        def _track_dict_from_props(track) -> dict:
+            return {
+                "title": str(track.get("Title", "")),
+                "artist": str(track.get("Artist", "")),
+                "album": str(track.get("Album", "")),
+                "duration": int(track.get("Duration", 0)),
+                "track_number": int(track.get("TrackNumber", 0)),
+            }
+
+        def _seed_from_existing(bus) -> None:
+            """Read existing MediaPlayer1 objects so the card fills on connect."""
+            try:
+                om = dbus.Interface(
+                    bus.get_object("org.bluez", "/"),
+                    "org.freedesktop.DBus.ObjectManager",
+                )
+                objects = om.GetManagedObjects()
+            except Exception:
+                return
+            for _path, ifaces in objects.items():
+                mp = ifaces.get("org.bluez.MediaPlayer1")
+                if not mp:
+                    continue
+                if "Track" in mp:
+                    info = _track_dict_from_props(mp["Track"])
+                    _publish_track(info)
+                    log.info("BT AVRCP seeded: %s - %s",
+                             info["artist"], info["title"])
+                if "Status" in mp:
+                    _publish_status(str(mp["Status"]).lower())
+                if "Position" in mp:
+                    _publish_position(int(mp["Position"]))
 
         def _media_monitor():
             try:
@@ -1550,29 +1732,18 @@ class BluetoothManager:
                         return
 
                     if "Track" in changed:
-                        track = changed["Track"]
-                        track_info = {
-                            "title": str(track.get("Title", "")),
-                            "artist": str(track.get("Artist", "")),
-                            "album": str(track.get("Album", "")),
-                            "duration": int(track.get("Duration", 0)),
-                            "track_number": int(track.get("TrackNumber", 0)),
-                        }
-                        self._media_track = track_info
-                        self._event_bus.publish("bt.media.track", track_info)
+                        info = _track_dict_from_props(changed["Track"])
+                        _publish_track(info)
                         log.info("BT AVRCP track: %s - %s",
-                                 track_info["artist"], track_info["title"])
+                                 info["artist"], info["title"])
 
                     if "Status" in changed:
                         status = str(changed["Status"]).lower()
-                        self._media_status = status
-                        self._event_bus.publish("bt.media.status", status)
+                        _publish_status(status)
                         log.debug("BT AVRCP status: %s", status)
 
                     if "Position" in changed:
-                        position = int(changed["Position"])
-                        self._media_position = position
-                        self._event_bus.publish("bt.media.position", position)
+                        _publish_position(int(changed["Position"]))
 
                 bus.add_signal_receiver(
                     _on_properties_changed,
@@ -1580,6 +1751,23 @@ class BluetoothManager:
                     signal_name="PropertiesChanged",
                     path_keyword="path",
                 )
+                # New MediaPlayer1 objects appear via InterfacesAdded after
+                # a phone connects; re-seed when that fires so we don't
+                # have to wait for the next Track delta.
+                def _on_interfaces_added(_path, ifaces):
+                    if "org.bluez.MediaPlayer1" in ifaces:
+                        try:
+                            _seed_from_existing(bus)
+                        except Exception:
+                            pass
+
+                bus.add_signal_receiver(
+                    _on_interfaces_added,
+                    dbus_interface="org.freedesktop.DBus.ObjectManager",
+                    signal_name="InterfacesAdded",
+                )
+
+                _seed_from_existing(bus)
                 log.info("BT AVRCP media monitor started (D-Bus)")
 
                 loop = GLib.MainLoop()
@@ -1656,8 +1844,9 @@ class DemoMediaGenerator:
             self._thread.join(timeout=2)
 
     def _loop(self) -> None:
-        # Publish initial "playing" status
+        # Publish initial "playing" status — flat key is what web_viewer reads
         self._bus.publish("bt.media.status", "playing")
+        self._bus.publish("bt.media_playing", True)
         position = 0
 
         while self._running:
@@ -1670,12 +1859,17 @@ class DemoMediaGenerator:
                 "track_number": self._track_index + 1,
             }
             self._bus.publish("bt.media.track", track_info)
+            self._bus.publish("bt.media_title", track_info["title"])
+            self._bus.publish("bt.media_artist", track_info["artist"])
+            self._bus.publish("bt.media_album", track_info["album"])
+            self._bus.publish("bt.media_duration", track_info["duration"])
 
             # Simulate playback — advance position every second
             duration_s = track["duration"] // 1000
             position = 0
             while self._running and position < duration_s:
                 self._bus.publish("bt.media.position", position * 1000)
+                self._bus.publish("bt.media_position", position * 1000)
                 time.sleep(1)
                 position += 1
 

--- a/src/multimedia/openauto.py
+++ b/src/multimedia/openauto.py
@@ -54,6 +54,64 @@ def _aa_canvas_size(app_config: Any) -> tuple[int, int]:
     return w, h
 
 
+def _resolve_wifi_mac(app_config: Any) -> str:
+    """Best-effort: return MAC of the WiFi AP interface (BSSID).
+
+    autoapp's BT-bootstrap protocol embeds this BSSID in the
+    WifiInfoResponse it sends the phone over RFCOMM; without it the
+    phone can SEE the SSID but won't auto-join because it can't match
+    the network identity announced over BT.
+
+    Order of preference:
+      1. ``wifi.bssid_runtime`` — set by wifi_ap.py after a P2P-GO
+         comes up; the GO MAC differs from the parent iface MAC.
+      2. The configured / autodetected WiFi iface's MAC.
+    """
+    if app_config:
+        runtime = (app_config.get("wifi.bssid_runtime", "") or "").strip()
+        if runtime:
+            return runtime.upper()
+    iface = ""
+    if app_config:
+        iface = (app_config.get("wifi.interface", "") or "").strip()
+    if not iface:
+        try:
+            from src.multimedia.wifi_ap import _find_wifi_interface
+            iface = _find_wifi_interface() or ""
+        except Exception:
+            iface = ""
+    if not iface:
+        return ""
+    addr_path = f"/sys/class/net/{iface}/address"
+    try:
+        with open(addr_path) as f:
+            mac = f.read().strip().upper()
+            return mac if mac and mac != "00:00:00:00:00:00" else ""
+    except OSError:
+        return ""
+
+
+def _resolve_bt_adapter_addr(app_config: Any) -> str:
+    """Best-effort: return MAC of the preferred BT adapter.
+
+    Mirrors BluetoothManager's adapter selection so openauto.ini's
+    [Bluetooth] RemoteAdapterAddress points at the same controller
+    BCM's own pairing agent claims. Without this, autoapp picks an
+    arbitrary adapter (typically hci0) which may not be the carkit
+    controller we configured the CoD on.
+    """
+    addr = ""
+    if app_config:
+        addr = (app_config.get("bluetooth.preferred_adapter", "") or "").strip()
+    if not addr:
+        try:
+            from src.multimedia.bluetooth import _find_preferred_adapter
+            addr = _find_preferred_adapter() or ""
+        except Exception:
+            addr = ""
+    return addr.upper() if addr else ""
+
+
 def _create_openauto_config(project_dir: str, app_config: Any = None) -> None:
     """Create openauto.ini in the project directory (autoapp's working dir).
 
@@ -70,6 +128,8 @@ def _create_openauto_config(project_dir: str, app_config: Any = None) -> None:
 
     ssid = ""
     password = ""
+    wifi_mac = ""
+    bt_adapter = ""
     # 1024 × 504 = full BCM content area (dash 1024×600 minus AppBar 48
     # + NavBar 48). _aa_canvas_size returns this same value when no
     # explicit override is set, so autoapp renders into the exact box
@@ -77,9 +137,16 @@ def _create_openauto_config(project_dir: str, app_config: Any = None) -> None:
     width = 1024
     height = 504
     if app_config:
-        ssid = app_config.get("wifi.ssid", "")
-        password = app_config.get("wifi.password", "")
+        # Prefer runtime credentials when set by wifi_ap.py — Wi-Fi
+        # Direct GOs broadcast a spec-mandated `DIRECT-XX` SSID and a
+        # generated WPA2 passphrase that differ from the YAML values.
+        ssid = (app_config.get("wifi.ssid_runtime", "")
+                or app_config.get("wifi.ssid", ""))
+        password = (app_config.get("wifi.password_runtime", "")
+                    or app_config.get("wifi.password", ""))
         width, height = _aa_canvas_size(app_config)
+        wifi_mac = _resolve_wifi_mac(app_config)
+        bt_adapter = _resolve_bt_adapter_addr(app_config)
 
     # OpenAuto Resolution codes (per autoapp source):
     #   0 = 480p, 1 = 720p, 2 = 1080p, 3 = auto/stretch
@@ -110,7 +177,7 @@ MediaAudioDelay=0
 
 [Bluetooth]
 AdapterType=0
-RemoteAdapterAddress=
+RemoteAdapterAddress={bt_adapter}
 
 [Input]
 ButtonCodes.Enter=23
@@ -127,13 +194,14 @@ TouchscreenHeight={height}
 [WiFi]
 SSID={ssid}
 Password={password}
-MAC=
+MAC={wifi_mac}
 """
     with open(config_path, "w") as f:
         f.write(config_content)
 
-    log.info("Created openauto config at %s (SSID=%s)", config_path,
-             ssid or "(empty)")
+    log.info("Created openauto config at %s (SSID=%s, WiFi MAC=%s, BT=%s)",
+             config_path, ssid or "(empty)",
+             wifi_mac or "(unresolved)", bt_adapter or "(default)")
 
 
 class OpenAutoController:
@@ -664,6 +732,15 @@ def start_multimedia(config: Any, event_bus: EventBus, hal: Any = None,
         bt_mgr = BluetoothManager(config, event_bus)
         bt_mgr.start_monitor()
         log.info("BluetoothManager created (available=%s)", bt_mgr.available)
+
+    # PBAP phonebook sync — pulls contacts + call history on connect and
+    # publishes them so A3 phone screen can render via /api/phone/*.
+    # Held by the closure here so the subscriber stays alive.
+    try:
+        from src.multimedia.phonebook import start_phonebook_sync
+        _phonebook = start_phonebook_sync(event_bus)  # noqa: F841
+    except Exception:
+        log.exception("PBAP phonebook sync failed to start (non-critical)")
 
     # OpenAuto controller
     openauto = OpenAutoController(config, event_bus)

--- a/src/multimedia/phonebook.py
+++ b/src/multimedia/phonebook.py
@@ -1,0 +1,263 @@
+"""PBAP phonebook + call-history puller via BlueZ obexd.
+
+When a paired phone authorises PBAP sharing during pairing, obexd
+exposes an org.bluez.obex session that we can drive over D-Bus to
+download:
+
+  * ``telecom/pb.vcf``  — full phonebook (vCard 3.0 stream)
+  * ``telecom/cch.vcf`` — combined call history (in + out + missed)
+
+Both are parsed into JSON-friendly dicts and published on the event
+bus as ``bt.contacts`` and ``bt.call_history`` so the A3 phone screen
+can render them via /api/phone/contacts and /api/phone/history.
+
+Results are cached to ~/.bcm/phonebook-<addr>.json so a slow PBAP
+pull doesn't blank the A3 screen between sessions.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+import time
+from typing import Any, Optional
+
+from src.core.event_bus import EventBus
+from src.core.logger import get_logger
+
+log = get_logger("multimedia.phonebook")
+
+try:
+    import dbus
+    HAS_DBUS = True
+except ImportError:
+    HAS_DBUS = False
+
+OBEX_BUS = "org.bluez.obex"
+OBEX_ROOT = "/org/bluez/obex"
+OBEX_CLIENT_IFACE = "org.bluez.obex.Client1"
+OBEX_SESSION_IFACE = "org.bluez.obex.Session1"
+OBEX_PBAP_IFACE = "org.bluez.obex.PhonebookAccess1"
+
+CACHE_DIR = os.path.expanduser("~/.bcm")
+PULL_TIMEOUT_S = 30.0
+
+
+def _cache_path(addr: str) -> str:
+    safe = addr.replace(":", "").lower()
+    return os.path.join(CACHE_DIR, f"phonebook-{safe}.json")
+
+
+def _parse_vcards(blob: str) -> list[dict[str, Any]]:
+    """Split a vCard 3.0 stream into structured records.
+
+    Handles the subset Android exposes via PBAP:
+      FN, N, TEL (with TYPE=CELL/HOME/WORK/VOICE), X-IRMC-CALL-DATETIME.
+    Everything else is ignored — we only need name + numbers + optional
+    timestamp for the call-history view.
+    """
+    records: list[dict[str, Any]] = []
+    current: Optional[dict[str, Any]] = None
+    line_iter = iter(blob.splitlines())
+    for raw in line_iter:
+        line = raw.rstrip("\r")
+        if not line:
+            continue
+        # vCard line-folding: a line continuation starts with space/tab
+        while line.endswith("="):
+            try:
+                line = line[:-1] + next(line_iter).rstrip("\r")
+            except StopIteration:
+                break
+        if line.upper() == "BEGIN:VCARD":
+            current = {"name": "", "numbers": [], "timestamp": ""}
+            continue
+        if line.upper() == "END:VCARD":
+            if current and (current["name"] or current["numbers"]):
+                records.append(current)
+            current = None
+            continue
+        if current is None:
+            continue
+        if ":" not in line:
+            continue
+        head, value = line.split(":", 1)
+        params = head.split(";")
+        prop = params[0].upper()
+        if prop == "FN":
+            current["name"] = value.strip()
+        elif prop == "N" and not current["name"]:
+            # N is "Last;First;Middle;Prefix;Suffix" — take first+last.
+            parts = value.split(";")
+            current["name"] = " ".join(p for p in (
+                parts[1] if len(parts) > 1 else "",
+                parts[0] if parts else "",
+            ) if p).strip()
+        elif prop == "TEL":
+            typ = ""
+            for p in params[1:]:
+                if p.upper().startswith("TYPE="):
+                    typ = p.split("=", 1)[1].strip().split(",")[0]
+                    break
+            number = re.sub(r"[\s\-()]", "", value.strip())
+            if number:
+                current["numbers"].append({"type": typ.lower(), "number": number})
+        elif prop == "X-IRMC-CALL-DATETIME":
+            current["timestamp"] = value.strip()
+            for p in params[1:]:
+                if p.upper() in ("RECEIVED", "DIALED", "MISSED"):
+                    current.setdefault("direction", p.lower())
+    return records
+
+
+class PhonebookSync:
+    """Drives obexd PBAP sessions per connected BT device."""
+
+    def __init__(self, event_bus: EventBus):
+        self._bus = event_bus
+        self._lock = threading.Lock()
+        self._active_addr: Optional[str] = None
+        self._stop_flag = False
+        os.makedirs(CACHE_DIR, exist_ok=True)
+        self._bus.subscribe("bt.connected", self._on_connected)
+        self._bus.subscribe("bt.disconnected", self._on_disconnected)
+
+    def _on_connected(self, topic: str, value: Any, ts: float) -> None:
+        if not HAS_DBUS:
+            log.debug("dbus-python missing — PBAP sync disabled")
+            return
+        if not isinstance(value, dict):
+            return
+        addr = value.get("address")
+        if not addr:
+            return
+        self._publish_cached(addr)
+        threading.Thread(
+            target=self._sync_safe, args=(addr,),
+            daemon=True, name=f"pbap-sync-{addr[-5:]}",
+        ).start()
+
+    def _on_disconnected(self, topic: str, value: Any, ts: float) -> None:
+        with self._lock:
+            self._active_addr = None
+            self._stop_flag = True
+
+    def _publish_cached(self, addr: str) -> None:
+        """Surface the last-known phonebook immediately so A3 isn't blank
+        while the PBAP pull is in flight."""
+        path = _cache_path(addr)
+        if not os.path.isfile(path):
+            return
+        try:
+            with open(path) as f:
+                data = json.load(f)
+            self._bus.publish("bt.contacts", data.get("contacts", []))
+            self._bus.publish("bt.call_history", data.get("history", []))
+            log.info("PBAP: served cached phonebook for %s (%d contacts)",
+                     addr, len(data.get("contacts", [])))
+        except Exception:
+            log.debug("PBAP: cache read failed for %s", addr)
+
+    def _sync_safe(self, addr: str) -> None:
+        try:
+            self._sync(addr)
+        except Exception:
+            log.exception("PBAP sync raised for %s", addr)
+
+    def _sync(self, addr: str) -> None:
+        with self._lock:
+            if self._active_addr == addr:
+                return
+            self._active_addr = addr
+            self._stop_flag = False
+
+        # Give the phone a moment to authorise the PBAP service after
+        # the A2DP link comes up — Android delays the PBAP authorise
+        # popup until after audio is rolling.
+        time.sleep(3)
+
+        bus = dbus.SessionBus()
+        try:
+            client = dbus.Interface(
+                bus.get_object(OBEX_BUS, OBEX_ROOT), OBEX_CLIENT_IFACE,
+            )
+        except dbus.exceptions.DBusException:
+            log.warning("obexd not running on session bus — install "
+                        "bluez-obexd and ensure the user session is up")
+            return
+
+        try:
+            session_path = client.CreateSession(
+                addr, dbus.Dictionary({"Target": "PBAP"}, signature="sv"),
+                timeout=PULL_TIMEOUT_S,
+            )
+        except dbus.exceptions.DBusException as e:
+            log.warning("PBAP CreateSession(%s) failed: %s", addr, e)
+            return
+        log.info("PBAP session for %s → %s", addr, session_path)
+
+        pbap = dbus.Interface(
+            bus.get_object(OBEX_BUS, session_path), OBEX_PBAP_IFACE,
+        )
+
+        contacts = self._pull_book(pbap, "internal", "pb")
+        history = self._pull_book(pbap, "internal", "cch")
+
+        # Persist cache
+        try:
+            with open(_cache_path(addr), "w") as f:
+                json.dump({
+                    "addr": addr,
+                    "contacts": contacts,
+                    "history": history,
+                    "pulled_at": int(time.time()),
+                }, f)
+        except OSError as e:
+            log.debug("PBAP cache write failed: %s", e)
+
+        self._bus.publish("bt.contacts", contacts)
+        self._bus.publish("bt.call_history", history)
+        log.info("PBAP %s: %d contacts, %d history entries",
+                 addr, len(contacts), len(history))
+
+        try:
+            client.RemoveSession(session_path)
+        except dbus.exceptions.DBusException:
+            pass
+
+    def _pull_book(self, pbap, location: str, book: str) -> list[dict[str, Any]]:
+        try:
+            pbap.Select(location, book)
+        except dbus.exceptions.DBusException as e:
+            log.debug("PBAP Select(%s,%s) failed: %s", location, book, e)
+            return []
+        try:
+            blob, _ = pbap.PullAll(
+                "",
+                dbus.Dictionary({"Format": "vcard30"}, signature="sv"),
+            )
+        except dbus.exceptions.DBusException as e:
+            log.warning("PBAP PullAll(%s) failed: %s — phone may have "
+                        "denied phonebook share", book, e)
+            return []
+        # PullAll returns the path of a transient file or a string blob
+        # depending on obexd version. Newer obexd returns a path; older
+        # returns the bytes inline.
+        if isinstance(blob, str) and blob.startswith("/"):
+            try:
+                with open(blob) as f:
+                    blob = f.read()
+            except OSError:
+                return []
+        if isinstance(blob, (bytes, bytearray)):
+            blob = bytes(blob).decode("utf-8", errors="replace")
+        return _parse_vcards(blob or "")
+
+
+def start_phonebook_sync(event_bus: EventBus) -> PhonebookSync:
+    """Entry point — call once from main.py after BluetoothManager init."""
+    sync = PhonebookSync(event_bus)
+    log.info("PBAP phonebook sync ready (subscribed to bt.connected)")
+    return sync

--- a/src/multimedia/wifi_ap.py
+++ b/src/multimedia/wifi_ap.py
@@ -108,16 +108,25 @@ class WiFiAPManager:
         self._event_bus = event_bus
         self._interface: Optional[str] = None
         self._running = False
-        self._method: Optional[str] = None  # "nmcli" or "hostapd"
+        self._method: Optional[str] = None  # "p2p_go" | "nmcli" | "hostapd"
         self._ap_ip = config.get("wifi.ip", "10.0.0.1")
         self._netmask = config.get("wifi.netmask", "255.255.255.0")
         self._ssid = config.get("wifi.ssid", "Alfa156_AA")
         self._password = config.get("wifi.password", "alfa156headunit")
         self._nm_conn_name = "bcm-aa-hotspot"
 
-        # hostapd/dnsmasq processes (only used in hostapd mode)
+        # hostapd/dnsmasq/wpa_supplicant processes
         self._hostapd_proc: Optional[subprocess.Popen] = None
         self._dnsmasq_proc: Optional[subprocess.Popen] = None
+        self._wpa_proc: Optional[subprocess.Popen] = None
+        # Secondary AP ("ALFA-NET" internet share) — only spun up when
+        # the radio admits two concurrent VIFs (Intel 8265 typically
+        # supports one P2P-GO + one AP at the same time on the same
+        # channel). On phys that reject the combo we fall back to
+        # time-multiplexing.
+        self._net_iface: Optional[str] = None
+        self._net_hostapd_proc: Optional[subprocess.Popen] = None
+        self._net_dnsmasq_proc: Optional[subprocess.Popen] = None
 
         # Subscribe to shutdown
         self._event_bus.subscribe("power.shutting_down", self._on_shutdown)
@@ -163,16 +172,35 @@ class WiFiAPManager:
 
         log.info("Using WiFi interface: %s", self._interface)
 
-        # Try NetworkManager first (most compatible on desktop/VM Linux)
-        if _has_networkmanager():
-            if self._start_nmcli():
+        mode = self._config.get("wifi.mode", "hostapd")
+        log.info("WiFi AP mode: %s", mode)
+
+        # Honor the configured mode strictly. Multi-BSS (ALFA-NET on a
+        # second BSSID) is only supported by the hostapd path — it's
+        # inlined inside _start_hostapd so we don't call
+        # _maybe_start_alfa_net here for hostapd.
+        if mode == "p2p_go":
+            if self._start_p2p_go():
+                self._method = "p2p_go"
+                self._running = True
+                self._publish_started()
+                self._maybe_start_alfa_net()
+                return True
+            log.warning("P2P-GO failed — falling back to hostapd")
+            mode = "hostapd"
+
+        if mode == "nmcli":
+            if _has_networkmanager() and self._start_nmcli():
                 self._method = "nmcli"
                 self._running = True
                 self._publish_started()
+                self._maybe_start_alfa_net()
                 return True
-            log.warning("nmcli hotspot failed — trying hostapd fallback")
+            log.warning("nmcli hotspot failed — falling back to hostapd")
+            mode = "hostapd"
 
-        # Fall back to hostapd + dnsmasq
+        # hostapd path — supports multi-BSS for ALFA + ALFA-NET
+        # broadcasting from the same radio.
         if self._start_hostapd_mode():
             self._method = "hostapd"
             self._running = True
@@ -189,7 +217,13 @@ class WiFiAPManager:
 
         self._running = False
 
-        if self._method == "nmcli":
+        # Secondary ALFA-NET AP first so dnsmasq releases the VIF before
+        # we kill wpa_supplicant on the main interface.
+        self._stop_alfa_net()
+
+        if self._method == "p2p_go":
+            self._stop_p2p_go()
+        elif self._method == "nmcli":
             self._stop_nmcli()
         elif self._method == "hostapd":
             self._stop_hostapd_mode()
@@ -332,9 +366,54 @@ class WiFiAPManager:
             self._cleanup()
             return False
 
+        # Multi-BSS secondary VIF — bring up IP + a second dnsmasq for
+        # ALFA-NET clients. hostapd creates the iface but doesn't
+        # assign an IP; if we skip this, clients associate but can't
+        # get DHCP. Best-effort: failures here don't tear down the
+        # primary AA path.
+        if self._net_iface:
+            self._setup_alfa_net_secondary_bss()
+
         if self._config.get("wifi.share_internet", True):
             self._enable_internet_sharing()
         return True
+
+    def _setup_alfa_net_secondary_bss(self) -> None:
+        """Assign IP + start a second dnsmasq on the multi-BSS ALFA-NET VIF.
+
+        hostapd's `bss=` directive creates the virtual interface but
+        leaves IP/DHCP up to us. We give it a separate subnet from the
+        primary AP (default 10.0.1.0/24) and a small dedicated dnsmasq
+        process so its DHCP doesn't fight the primary AP's leases.
+        """
+        iface = self._net_iface
+        net_ip = self._config.get("wifi.alfa_net.ip", "10.0.1.1")
+        netmask = self._config.get("wifi.alfa_net.netmask", "255.255.255.0")
+        prefix = _netmask_to_prefix(netmask)
+        # hostapd brings up the bss= iface but it starts in some
+        # drivers as DOWN — explicitly bring it up.
+        for cmd in (["ip", "link", "set", iface, "up"],
+                    ["ip", "addr", "flush", "dev", iface],
+                    ["ip", "addr", "add", f"{net_ip}/{prefix}", "dev", iface]):
+            subprocess.run(cmd, capture_output=True, timeout=4)
+        dhcp_start = self._config.get("wifi.alfa_net.dhcp_start", "10.0.1.10")
+        dhcp_end = self._config.get("wifi.alfa_net.dhcp_end", "10.0.1.50")
+        try:
+            self._net_dnsmasq_proc = subprocess.Popen(
+                ["dnsmasq",
+                 f"--interface={iface}",
+                 "--bind-interfaces",
+                 f"--dhcp-range={dhcp_start},{dhcp_end},{netmask},24h",
+                 "--no-daemon", "--no-resolv", "--no-hosts"],
+                stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            )
+        except FileNotFoundError:
+            log.warning("dnsmasq missing — ALFA-NET clients won't get DHCP")
+            return
+        log.info("ALFA-NET multi-BSS: %s up on %s/%d, DHCP %s-%s",
+                 iface, net_ip, prefix, dhcp_start, dhcp_end)
+        if self._config.get("wifi.alfa_net.share_internet", True):
+            self._add_nat_for(iface)
 
     def _enable_internet_sharing(self) -> None:
         """Turn the AP into an internet gateway by NAT'ing through any
@@ -426,11 +505,22 @@ class WiFiAPManager:
             )
 
     def _setup_interface(self) -> bool:
-        """Configure the WiFi interface with a static IP."""
+        """Configure the WiFi interface with a static IP.
+
+        For a Wi-Fi Direct GO child interface (``p2p-*``), we MUST NOT
+        bring the link down — wpa_supplicant interprets that as the
+        group going away and tears the P2P-GO down, after which the
+        ``p2p-*`` iface vanishes entirely. Just flush the IP table and
+        add ours. For regular hostapd-managed wlan ifaces the link
+        cycle stays — those need an explicit down/up to clear leftover
+        STA-mode state.
+        """
         iface = self._interface
+        is_p2p = iface.startswith("p2p-")
         try:
-            subprocess.run(["ip", "link", "set", iface, "down"],
-                           capture_output=True, timeout=5)
+            if not is_p2p:
+                subprocess.run(["ip", "link", "set", iface, "down"],
+                               capture_output=True, timeout=5)
             subprocess.run(["ip", "addr", "flush", "dev", iface],
                            capture_output=True, timeout=5)
 
@@ -461,6 +551,12 @@ class WiFiAPManager:
         Intel 7265 — extras like ieee80211d/wmm_enabled/macaddr_acl have
         repeatedly broken broadcast on this card, while this exact set
         comes up first try.
+
+        When ``wifi.alfa_net.enabled`` is true, appends a second BSS
+        section so hostapd broadcasts BOTH ``ALFA`` and ``ALFA-NET`` on
+        the same channel from the same radio — Intel 8265's
+        interface_combinations rejects AP+P2P-GO concurrent but allows
+        multi-BSS within a single AP role.
         """
         config_path = os.path.join(RUNTIME_DIR, "hostapd.conf")
         # Channel/band/country are sourced from wifi.* in the YAML so the
@@ -489,6 +585,48 @@ class WiFiAPManager:
             f"country_code={country}\n"
         )
 
+        # Multi-BSS: append a second virtual AP for ALFA-NET if enabled.
+        # The `bss=` directive creates an additional BSSID on the same
+        # radio/channel. Hostapd's auto-derivation increments the
+        # primary MAC's last octet by 1 — which collides with the
+        # kernel's reserved P2P-device handle MAC (primary+1 is the
+        # canonical Wi-Fi Direct device address). Set `bssid=` to
+        # primary+2 to dodge the collision; the locally-administered
+        # bit is also flipped so the MAC is unambiguously synthetic.
+        if self._config.get("wifi.alfa_net.enabled", True):
+            net_ssid = self._config.get("wifi.alfa_net.ssid", "ALFA-NET")
+            net_pwd = self._config.get("wifi.alfa_net.password",
+                                       "AlfaRomeo156")
+            bss_iface = f"{self._interface}_net"
+            # Read primary MAC + derive secondary BSSID.
+            try:
+                with open(f"/sys/class/net/{self._interface}/address") as f:
+                    primary_mac = f.read().strip().lower()
+                octets = [int(o, 16) for o in primary_mac.split(":")]
+                # +2 in last octet (avoid +1 = P2P-device handle), and
+                # set the locally-administered bit on the first octet
+                # so the address can't be confused with the OUI.
+                octets[0] |= 0x02
+                octets[5] = (octets[5] + 2) & 0xff
+                secondary_bssid = ":".join(f"{o:02x}" for o in octets)
+            except Exception:
+                secondary_bssid = ""
+            config_content += (
+                f"\n# Secondary BSS — ALFA-NET internet share\n"
+                f"bss={bss_iface}\n"
+                f"ssid={net_ssid}\n"
+                + (f"bssid={secondary_bssid}\n" if secondary_bssid else "") +
+                f"wpa=2\n"
+                f"wpa_passphrase={net_pwd}\n"
+                f"wpa_key_mgmt=WPA-PSK\n"
+                f"rsn_pairwise=CCMP\n"
+            )
+            self._net_iface = bss_iface
+            log.info("hostapd multi-BSS: primary=%s secondary=%s "
+                     "(BSSID=%s, SSID=%s)",
+                     self._ssid, net_ssid,
+                     secondary_bssid or "auto", net_ssid)
+
         with open(config_path, "w") as f:
             f.write(config_content)
 
@@ -503,31 +641,53 @@ class WiFiAPManager:
         except Exception:
             pass
 
-        try:
-            self._hostapd_proc = subprocess.Popen(
-                ["hostapd", config_path],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-            )
-            # Wait and check if it started
-            time.sleep(2)
-            if self._hostapd_proc.poll() is not None:
-                out = self._hostapd_proc.stdout.read().decode(
-                    "utf-8", errors="replace") if self._hostapd_proc.stdout else ""
-                log.error("hostapd failed to start: %s", out.strip())
+        def _launch(path: str) -> bool:
+            try:
+                self._hostapd_proc = subprocess.Popen(
+                    ["hostapd", path],
+                    stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                )
+            except Exception:
+                log.exception("Failed to launch hostapd")
                 return False
-
-            threading.Thread(
-                target=self._read_proc_logs,
-                args=(self._hostapd_proc, "hostapd"),
-                daemon=True,
-            ).start()
-
-            log.info("hostapd started (PID %d)", self._hostapd_proc.pid)
-            return True
-        except Exception:
-            log.exception("Failed to start hostapd")
+            time.sleep(2)
+            if self._hostapd_proc.poll() is None:
+                threading.Thread(
+                    target=self._read_proc_logs,
+                    args=(self._hostapd_proc, "hostapd"),
+                    daemon=True,
+                ).start()
+                log.info("hostapd started (PID %d)", self._hostapd_proc.pid)
+                return True
+            out = self._hostapd_proc.stdout.read().decode(
+                "utf-8", errors="replace") if self._hostapd_proc.stdout else ""
+            log.error("hostapd failed to start: %s", out.strip())
+            self._hostapd_proc = None
             return False
+
+        if _launch(config_path):
+            return True
+
+        # Multi-BSS failure recovery: iwlwifi 8265's interface_combinations
+        # admits exactly ONE AP role on this radio (`#{AP, P2P-client,
+        # P2P-GO} <= 1`), so the `bss=` secondary trips
+        # "Could not set interface wlp2s0_net flags (UP): Device or
+        # resource busy". If we asked for ALFA-NET and the dual-BSS
+        # launch failed, retry single-BSS so the primary ALFA still
+        # comes up; ALFA-NET is unavailable on this hardware without
+        # a second radio (USB dongle).
+        if self._net_iface and self._config.get("wifi.alfa_net.enabled", True):
+            log.warning("Multi-BSS rejected by iwlwifi (8265 admits 1 AP "
+                        "only) — retrying ALFA single-BSS without "
+                        "ALFA-NET. Plug a USB WiFi dongle to get the "
+                        "second SSID concurrently.")
+            single_bss = config_content.split("\n# Secondary BSS")[0]
+            with open(config_path, "w") as f:
+                f.write(single_bss)
+            self._net_iface = None
+            if _launch(config_path):
+                return True
+        return False
 
     def _start_dnsmasq(self) -> bool:
         """Start dnsmasq for DHCP on the AP interface."""
@@ -643,6 +803,496 @@ class WiFiAPManager:
         except Exception:
             pass
         return False
+
+    # ------------------------------------------------------------------
+    # wpa_supplicant P2P-GO method (Wi-Fi Direct Group Owner)
+    # ------------------------------------------------------------------
+
+    def _start_p2p_go(self) -> bool:
+        """Bring up the AA WiFi as a Wi-Fi Direct Group Owner on ch149.
+
+        Why this path: the AA Wireless protocol the phone speaks is
+        Wi-Fi Direct internally, and P2P-GO is the only AP-equivalent
+        role iwlwifi 8265 lets us start on 5 GHz under a self-managed
+        regdom (the regular AP role gets ``Frequency NNNN not allowed,
+        flags: NO-IR``). We also rfkill-unblock + force regdom first
+        because the Intel firmware still honors a country hint when
+        choosing which channels it'll *accept* a P2P GO on.
+        """
+        # Make sure NetworkManager isn't holding the interface — wpa_s
+        # P2P refuses to bind otherwise.
+        if _has_networkmanager():
+            subprocess.run(
+                ["nmcli", "device", "set", self._interface, "managed", "no"],
+                capture_output=True, timeout=5,
+            )
+            time.sleep(0.3)
+
+        # Best-effort regdom kick. User waived country compliance so we
+        # try a country that the iwlwifi 8265 firmware admits is OK on
+        # ch149 (BO/JP/IN have historically worked). `iw reg set` is a
+        # no-op on self-managed PHYs but costs nothing to attempt.
+        regdom = self._config.get("wifi.regdom", "BO")
+        for cmd in (["rfkill", "unblock", "wifi"],
+                    ["rfkill", "unblock", "all"],
+                    ["iw", "reg", "set", regdom]):
+            try:
+                subprocess.run(cmd, capture_output=True, timeout=3)
+            except Exception:
+                pass
+
+        os.makedirs(RUNTIME_DIR, exist_ok=True)
+        ctrl_dir = os.path.join(RUNTIME_DIR, "wpa-ctrl")
+        os.makedirs(ctrl_dir, exist_ok=True)
+        conf_path = os.path.join(RUNTIME_DIR, "wpa-p2p.conf")
+        # device_name carries through to the phone's Wi-Fi Direct picker.
+        wpa_conf = (
+            f"ctrl_interface=DIR={ctrl_dir} GROUP=netdev\n"
+            f"update_config=1\n"
+            f"country={regdom}\n"
+            f"device_name=Alfa156 Headunit\n"
+            f"device_type=8-0050F204-2\n"  # AudioVideo / Carkit
+            f"p2p_go_intent=15\n"
+            f"p2p_go_ht40=1\n"
+            f"p2p_go_vht=1\n"
+            f"persistent_reconnect=1\n"
+        )
+        with open(conf_path, "w") as f:
+            f.write(wpa_conf)
+
+        # Kill stale wpa_supplicant on this interface so we don't race.
+        try:
+            subprocess.run(["pkill", "-f",
+                            f"wpa_supplicant.*{self._interface}"],
+                           capture_output=True, timeout=3)
+        except Exception:
+            pass
+        time.sleep(0.5)
+
+        try:
+            self._wpa_proc = subprocess.Popen(
+                ["wpa_supplicant",
+                 "-i", self._interface,
+                 "-D", "nl80211",
+                 "-c", conf_path],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+        except FileNotFoundError:
+            log.warning("wpa_supplicant not installed — install via apt")
+            return False
+
+        # Wait for ctrl socket to appear.
+        ctrl_path = os.path.join(ctrl_dir, self._interface)
+        deadline = time.time() + 5.0
+        while time.time() < deadline and not os.path.exists(ctrl_path):
+            if self._wpa_proc.poll() is not None:
+                log.error("wpa_supplicant exited before ctrl socket ready")
+                return False
+            time.sleep(0.2)
+        if not os.path.exists(ctrl_path):
+            log.error("wpa_supplicant ctrl socket never appeared at %s",
+                      ctrl_path)
+            self._stop_p2p_go()
+            return False
+
+        # Start a persistent P2P group. Channel→freq mapping differs
+        # between bands: 2.4 GHz ch1-13 uses 2407+5*N (and ch14 is the
+        # special-case 2484 MHz for JP), while 5 GHz uses 5000+5*N.
+        # Picking the wrong formula sends ch6 to 5030 MHz which is
+        # NO-IR on the Intel 8265 firmware — silent `p2p_group_add: FAIL`.
+        channel = int(self._config.get("wifi.channel", 6))
+        if channel <= 14:
+            freq = 2484 if channel == 14 else 2407 + 5 * channel
+        else:
+            freq = 5000 + 5 * channel
+        cli_cmd = [
+            "wpa_cli", "-p", ctrl_dir, "-i", self._interface,
+            "p2p_group_add", f"freq={freq}", "persistent",
+        ]
+        r = subprocess.run(cli_cmd, capture_output=True, text=True, timeout=10)
+        if r.returncode != 0 or "FAIL" in (r.stdout + r.stderr).upper():
+            log.error("p2p_group_add failed: %s%s",
+                      r.stdout.strip(), r.stderr.strip())
+            self._stop_p2p_go()
+            return False
+        log.info("wpa_cli p2p_group_add OK: %s", r.stdout.strip())
+
+        # Find the p2p-wlan*-N interface wpa_s just created.
+        time.sleep(1.5)
+        p2p_iface = self._find_p2p_iface(self._interface)
+        if not p2p_iface:
+            log.warning("Could not locate p2p group interface — using "
+                        "primary %s for IP", self._interface)
+            p2p_iface = self._interface
+
+        # Wi-Fi Direct GOs broadcast a spec-mandated `DIRECT-XX` SSID
+        # with a random WPA2 passphrase. Read what wpa_supplicant
+        # generated and overwrite self._ssid / self._password so the
+        # downstream openauto.ini regen sends the *real* SSID + PSK
+        # to the phone over BT. Without this, the phone is told to
+        # join "ALFA" while the actual GO is "DIRECT-Qi" → AA-Wireless
+        # connect fails silently.
+        if p2p_iface != self._interface:
+            real_ssid = self._wpa_query(ctrl_dir, p2p_iface, "status",
+                                        prop="ssid")
+            real_psk = self._wpa_query(ctrl_dir, p2p_iface,
+                                       "p2p_get_passphrase")
+            real_bssid = self._wpa_query(ctrl_dir, p2p_iface, "status",
+                                         prop="bssid")
+            if real_ssid:
+                self._ssid = real_ssid
+            if real_psk:
+                self._password = real_psk
+            # The GO has its own MAC (parent±2 typically) — publish so
+            # openauto.ini gets the right BSSID for WifiInfoResponse.
+            log.info("P2P-GO advertising SSID=%s psk=%s… on BSSID=%s",
+                     self._ssid, (self._password or "")[:3],
+                     real_bssid or "?")
+            try:
+                self._config.set("wifi.ssid_runtime", self._ssid)
+                self._config.set("wifi.password_runtime", self._password)
+                if real_bssid:
+                    self._config.set("wifi.bssid_runtime", real_bssid)
+            except Exception:
+                log.debug("Could not persist runtime SSID/PSK")
+            self._event_bus.publish("wifi.ap_credentials", {
+                "ssid": self._ssid,
+                "password": self._password,
+                "bssid": real_bssid,
+            })
+
+        # Assign IP + start dnsmasq on the GO interface.
+        prev_iface = self._interface
+        self._interface = p2p_iface
+        if not self._setup_interface():
+            self._interface = prev_iface
+            self._stop_p2p_go()
+            return False
+        if not self._start_dnsmasq():
+            self._stop_p2p_go()
+            return False
+
+        if self._config.get("wifi.share_internet", True):
+            self._enable_internet_sharing()
+        return True
+
+    @staticmethod
+    def _wpa_query(ctrl_dir: str, iface: str, cmd: str,
+                   prop: Optional[str] = None) -> str:
+        """Run wpa_cli and return either a single property from `status`
+        output (when `prop` is set) or the trimmed raw response.
+        """
+        try:
+            r = subprocess.run(
+                ["wpa_cli", "-p", ctrl_dir, "-i", iface, cmd],
+                capture_output=True, text=True, timeout=4,
+            )
+        except Exception:
+            return ""
+        out = (r.stdout or "").strip()
+        if not prop:
+            # Single-line responses like p2p_get_passphrase come back
+            # as `9aAuzYNy` with no key=value framing.
+            return out.splitlines()[-1].strip() if out else ""
+        for line in out.splitlines():
+            if line.startswith(prop + "="):
+                return line.split("=", 1)[1].strip().strip('"')
+        return ""
+
+    @staticmethod
+    def _find_p2p_iface(primary: str) -> Optional[str]:
+        """Locate the p2p-wlan*-N child interface for `primary`."""
+        try:
+            for iface in os.listdir("/sys/class/net"):
+                if iface.startswith("p2p-") and primary.split("-")[0] in iface:
+                    return iface
+            # Fallback — any p2p-* iface
+            for iface in os.listdir("/sys/class/net"):
+                if iface.startswith("p2p-"):
+                    return iface
+        except OSError:
+            pass
+        return None
+
+    def _stop_p2p_go(self) -> None:
+        """Tear down wpa_supplicant P2P-GO group + dnsmasq."""
+        self._stop_dnsmasq()
+        ctrl_dir = os.path.join(RUNTIME_DIR, "wpa-ctrl")
+        if self._interface and self._interface.startswith("p2p-"):
+            try:
+                subprocess.run(
+                    ["wpa_cli", "-p", ctrl_dir, "-i", self._interface,
+                     "p2p_group_remove", self._interface],
+                    capture_output=True, timeout=5,
+                )
+            except Exception:
+                pass
+        if self._wpa_proc and self._wpa_proc.poll() is None:
+            self._wpa_proc.send_signal(signal.SIGTERM)
+            try:
+                self._wpa_proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._wpa_proc.kill()
+        self._wpa_proc = None
+
+        if _has_networkmanager():
+            primary = self._config.get("wifi.interface", "") or "wlan0"
+            subprocess.run(
+                ["nmcli", "device", "set", primary, "managed", "yes"],
+                capture_output=True, timeout=5,
+            )
+
+    # ------------------------------------------------------------------
+    # Secondary "ALFA-NET" internet-sharing AP
+    # ------------------------------------------------------------------
+
+    def _maybe_start_alfa_net(self) -> None:
+        """Bring up the editable ALFA-NET hotspot on a second VIF.
+
+        Strategy (in order — first that works wins):
+          1. **Different physical radio** — if a second wireless iface
+             exists (USB dongle), park ALFA-NET there.
+          2. **Concurrent VIF on same phy** — iw add interface __ap;
+             only succeeds when the driver advertises an AP/GO + AP
+             combination. iwlwifi 8265 advertises ``#{AP, P2P-GO} <= 1``
+             which means it does NOT — adding an AP VIF on the same
+             PHY as an active P2P-GO group collapses the GO. The
+             concurrent-VIF check below catches that and skips.
+          3. **Skip** — log a warning and require a USB dongle for
+             ALFA-NET. Time-multiplexing is intentionally NOT done
+             here because the AA P2P-GO group is the primary mission
+             and must stay up.
+        """
+        if not self._config.get("wifi.alfa_net.enabled", True):
+            return
+        ssid = self._config.get("wifi.alfa_net.ssid", "ALFA-NET")
+        password = self._config.get("wifi.alfa_net.password", "AlfaRomeo156")
+        net_ip = self._config.get("wifi.alfa_net.ip", "10.0.1.1")
+        net_mask = self._config.get("wifi.alfa_net.netmask", "255.255.255.0")
+        # When the primary AP is P2P-GO, self._interface is the child
+        # `p2p-<parent>-N` iface but the radio actually being used is
+        # the parent — derive it from the iface name so the same-PHY
+        # check below treats the parent as already-claimed.
+        primary = self._interface or ""
+        parent = primary
+        if primary.startswith("p2p-"):
+            # p2p-wlp2s0-0 → wlp2s0
+            try:
+                parent = primary.split("-", 2)[1]
+            except IndexError:
+                parent = primary
+        primary_phy = (self._phy_for_iface(parent)
+                       or self._phy_for_iface(primary))
+        if not primary_phy:
+            log.warning("ALFA-NET: couldn't resolve primary PHY — "
+                        "skipping to avoid clobbering the AA group")
+            return
+        candidate = None
+        try:
+            for iface in sorted(os.listdir("/sys/class/net")):
+                if iface in (primary, parent):
+                    continue
+                if not (iface.startswith(("wlan", "wlp", "wlx"))
+                        or os.path.isdir(f"/sys/class/net/{iface}/wireless")):
+                    continue
+                phy = self._phy_for_iface(iface)
+                if phy and phy != primary_phy:
+                    candidate = iface
+                    break
+        except OSError:
+            pass
+
+        if candidate:
+            log.info("ALFA-NET: using separate radio %s", candidate)
+            if self._start_alfa_net_on(candidate, ssid, password,
+                                       net_ip, net_mask):
+                self._net_iface = candidate
+                return
+
+        # Path 2: concurrent VIF on same PHY. Intel 8265's
+        # interface_combinations advertises `#{AP, P2P-GO} <= 1`, so
+        # adding an AP VIF while a P2P-GO group is active will
+        # silently collapse the GO. The `iw phy ... interface add`
+        # command often returns rc=0 anyway, then hostapd starts and
+        # knocks AA off the air. Skip this path entirely when the
+        # primary is p2p_go to keep AA up.
+        if self._method == "p2p_go":
+            log.warning(
+                "ALFA-NET disabled — primary AP is P2P-GO and the "
+                "Intel 8265 PHY can't host AA + ALFA-NET concurrently. "
+                "Plug a USB WiFi dongle for ALFA-NET."
+            )
+            return
+
+        if primary_phy:
+            vif = f"{primary}_net"
+            try:
+                r = subprocess.run(
+                    ["iw", "phy", primary_phy, "interface", "add",
+                     vif, "type", "__ap"],
+                    capture_output=True, text=True, timeout=4,
+                )
+                if r.returncode == 0:
+                    log.info("ALFA-NET: created concurrent VIF %s on %s",
+                             vif, primary_phy)
+                    if self._start_alfa_net_on(vif, ssid, password,
+                                               net_ip, net_mask):
+                        self._net_iface = vif
+                        return
+                    subprocess.run(["iw", "dev", vif, "del"],
+                                   capture_output=True, timeout=3)
+                else:
+                    log.warning("ALFA-NET: PHY rejects concurrent AP VIF "
+                                "(driver combo): %s",
+                                (r.stderr or r.stdout).strip())
+            except Exception as e:
+                log.warning("ALFA-NET concurrent VIF setup raised: %s", e)
+
+        log.warning("ALFA-NET disabled — no spare radio and PHY won't "
+                    "host a second AP VIF. Plug a USB WiFi dongle to "
+                    "enable internet sharing without losing AA Wireless.")
+
+    @staticmethod
+    def _phy_for_iface(iface: str) -> Optional[str]:
+        try:
+            r = subprocess.run(
+                ["iw", "dev", iface, "info"],
+                capture_output=True, text=True, timeout=3,
+            )
+            for line in r.stdout.splitlines():
+                line = line.strip()
+                if line.startswith("wiphy "):
+                    return f"phy{line.split()[1]}"
+        except Exception:
+            pass
+        return None
+
+    def _start_alfa_net_on(self, iface: str, ssid: str, password: str,
+                           net_ip: str, netmask: str) -> bool:
+        """Bring up hostapd + dnsmasq for the secondary ALFA-NET SSID."""
+        os.makedirs(RUNTIME_DIR, exist_ok=True)
+        conf_path = os.path.join(RUNTIME_DIR, "hostapd-alfanet.conf")
+        # 2.4 GHz ch6 — works everywhere, doesn't share the main 5 GHz
+        # frequency unless the radio forces it.
+        channel = int(self._config.get("wifi.alfa_net.channel", 6))
+        country = self._config.get("wifi.alfa_net.country", "BO")
+        conf = (
+            f"interface={iface}\n"
+            f"driver=nl80211\n"
+            f"ssid={ssid}\n"
+            f"hw_mode=g\n"
+            f"channel={channel}\n"
+            f"ieee80211n=1\n"
+            f"wpa=2\n"
+            f"wpa_passphrase={password}\n"
+            f"wpa_key_mgmt=WPA-PSK\n"
+            f"rsn_pairwise=CCMP\n"
+            f"country_code={country}\n"
+        )
+        with open(conf_path, "w") as f:
+            f.write(conf)
+
+        # IP + bring iface up before hostapd binds.
+        prefix = _netmask_to_prefix(netmask)
+        for cmd in (["ip", "link", "set", iface, "up"],
+                    ["ip", "addr", "flush", "dev", iface],
+                    ["ip", "addr", "add", f"{net_ip}/{prefix}", "dev", iface]):
+            subprocess.run(cmd, capture_output=True, timeout=4)
+
+        try:
+            self._net_hostapd_proc = subprocess.Popen(
+                ["hostapd", conf_path],
+                stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            )
+            time.sleep(1.5)
+            if self._net_hostapd_proc.poll() is not None:
+                out = (self._net_hostapd_proc.stdout.read().decode(
+                    errors="replace") if self._net_hostapd_proc.stdout else "")
+                log.error("ALFA-NET hostapd failed: %s", out.strip())
+                self._net_hostapd_proc = None
+                return False
+        except FileNotFoundError:
+            log.warning("hostapd not installed — ALFA-NET disabled")
+            return False
+
+        # dnsmasq on a different range than the primary AA AP.
+        dhcp_start = self._config.get("wifi.alfa_net.dhcp_start", "10.0.1.10")
+        dhcp_end = self._config.get("wifi.alfa_net.dhcp_end", "10.0.1.50")
+        try:
+            self._net_dnsmasq_proc = subprocess.Popen(
+                ["dnsmasq",
+                 f"--interface={iface}",
+                 "--bind-interfaces",
+                 f"--dhcp-range={dhcp_start},{dhcp_end},{netmask},24h",
+                 "--no-daemon", "--no-resolv", "--no-hosts"],
+                stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            )
+        except FileNotFoundError:
+            log.warning("dnsmasq missing — ALFA-NET clients won't get IPs")
+            self._stop_alfa_net()
+            return False
+
+        log.info("ALFA-NET up: SSID=%s on %s IP=%s/%d ch%d",
+                 ssid, iface, net_ip, prefix, channel)
+        # Best-effort NAT for ALFA-NET clients too.
+        if self._config.get("wifi.alfa_net.share_internet", True):
+            self._add_nat_for(iface)
+        return True
+
+    def _stop_alfa_net(self) -> None:
+        for proc in (self._net_dnsmasq_proc, self._net_hostapd_proc):
+            if proc and proc.poll() is None:
+                proc.send_signal(signal.SIGTERM)
+                try:
+                    proc.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+        self._net_dnsmasq_proc = None
+        self._net_hostapd_proc = None
+        if self._net_iface:
+            # Delete the VIF we created (only if it ends in _net — the
+            # USB-dongle path uses a real interface that should survive).
+            if self._net_iface.endswith("_net"):
+                subprocess.run(["iw", "dev", self._net_iface, "del"],
+                               capture_output=True, timeout=3)
+            self._net_iface = None
+
+    def _add_nat_for(self, iface: str) -> None:
+        """Add MASQUERADE for ALFA-NET clients via any non-WiFi uplink."""
+        try:
+            with open("/proc/sys/net/ipv4/ip_forward", "w") as f:
+                f.write("1\n")
+        except OSError:
+            return
+        uplinks = []
+        try:
+            for u in os.listdir("/sys/class/net"):
+                if u in ("lo", iface, self._interface):
+                    continue
+                if u.startswith(("wlan", "wlp", "wlx", "p2p-")):
+                    continue
+                try:
+                    with open(f"/sys/class/net/{u}/operstate") as f:
+                        if f.read().strip() == "up":
+                            uplinks.append(u)
+                except OSError:
+                    pass
+        except OSError:
+            return
+        for up in uplinks:
+            for rule in (["-t", "nat", "-A", "POSTROUTING",
+                          "-o", up, "-j", "MASQUERADE"],
+                         ["-A", "FORWARD", "-i", up, "-o", iface,
+                          "-m", "state", "--state",
+                          "RELATED,ESTABLISHED", "-j", "ACCEPT"],
+                         ["-A", "FORWARD", "-i", iface, "-o", up,
+                          "-j", "ACCEPT"]):
+                try:
+                    subprocess.run(["iptables"] + rule,
+                                   capture_output=True, timeout=3)
+                except FileNotFoundError:
+                    return
 
     def _read_proc_logs(self, proc: subprocess.Popen, name: str) -> None:
         """Forward subprocess output to logger."""


### PR DESCRIPTION
## Summary

Five-part bundle from a single bring-up session on the M910q bare metal. Each part is independent and the commits compile cleanly on top of `main`.

### Part 1 — Force internal Intel BT (opt-in)
- `bluetooth.prefer_internal: true` in YAML flips `_find_preferred_adapter` so the integrated Intel 8087 is picked over a USB dongle when both are present.
- `BCM_BT_PREFER_INTERNAL=1` in `/etc/default/bcm-bluetooth` mirrors the flag for the bluetoothd setup oneshot.
- New `_hci_watchdog` bounces the adapter on the documented 8087 tx-timeout via `hciconfig down/up`, recovering when BlueZ loses the controller — only engaged when prefer_internal is on (it's a no-op for the dongle path).

### Part 2 — wpa_supplicant P2P-GO + multi-BSS fallback
- New `wifi.mode: hostapd | p2p_go | nmcli` dispatched explicitly.
- P2P-GO path: correct 2.4 / 5 GHz channel→freq conversion (`2407+5*N` for ch1-13, `5000+5*N` for 5 GHz), reads the auto-generated SSID/PSK/BSSID after `p2p_group_add` and feeds them into `openauto.ini` via `wifi.*_runtime` keys.
- `_setup_interface` skips `ip link down` on p2p-* ifaces — wpa_supplicant interprets that as the group going away and tears the GO down.
- Multi-BSS hostapd attempt for ALFA + ALFA-NET on the same radio: tried, iwlwifi 8265's `interface_combinations` admits only one AP role; code falls back to single-BSS ALFA and logs a clear message that ALFA-NET needs a second radio (USB dongle).
- `setup-x86.sh` now writes `/etc/NetworkManager/conf.d/bcm-unmanage-p2p.conf` and a matching systemd-networkd `.network` file so `p2p-*` interfaces stay under wpa_supplicant control.

### Part 3 — AA wireless interface plumbing
`_create_openauto_config` now resolves `[WiFi] MAC=` from the WiFi iface and `[Bluetooth] RemoteAdapterAddress=` from the preferred BT adapter, with runtime BSSID/SSID/password overrides for P2P-GO mode. Empty `MAC=`/`RemoteAdapterAddress=` was the silent failure mode where AA-Wireless bootstrapping never completed.

### Part 4 — A1 now-playing card
- `BluetoothManager` publishes both `bt.media.track` (dict for the pygame renderer) AND the flat `bt.media_title/_artist/_album/_duration/_playing/_position` keys (read by `web_viewer.py`). The flat keys were never populated — dashboard card always showed empty.
- AVRCP monitor now seeds from existing `MediaPlayer1` objects via `GetManagedObjects` and listens to `InterfacesAdded`, so a phone that connects with audio already playing fills the card immediately.

### Part 5 — PBAP contacts / call history
- `_register_all_profiles` advertises PBAP-PCE (`0x112e`) and MAP-MCE (`0x1134`) UUIDs so phones show the carkit "share contacts & history" toggle during pairing. CoD=`0x620420` alone wasn't enough — Android checks the SDP for the PCE service.
- New `src/multimedia/phonebook.py` drives `obexd` over D-Bus on `bt.connected` to pull `internal/pb` + `internal/cch`, parses vCard 3.0, publishes `bt.contacts` / `bt.call_history` for the A3 phone screen. Cache at `~/.bcm/phonebook-<addr>.json` keeps A3 populated between pulls.
- `bluez-obexd` added to the `setup-x86.sh` apt install.

### Audio — PipeWire reachable from root `bcm-headunit`
- `_pipewire_env` injects `XDG_RUNTIME_DIR=/run/user/1000` so `wpctl` / `pw-cli` reach the user-session PipeWire socket. Without this the BCM Audio screen volume/mute/sink controls were silent no-ops.
- **Known not-fixed:** `apply_eq_preset` is still a stub that publishes events nobody subscribes to. Real EQ wiring needs a separate PipeWire filter-chain config + reload subscriber (~40 lines of follow-up). Documented in the docstring.

### 7" touchscreen sizing (+15%, Android Auto untouched)
Implemented as **real pixel resizing**, not CSS transform (transform:scale blurs text + skews touch coordinates inside autoapp):
- Root rem bump: `html { font-size: 18.4px }` scales every rem-based Tailwind utility.
- Attribute-selector overrides for arbitrary pixel values: `.text-\[10px\]`, `.w-\[200px\]`, `.h-\[280px\]`, etc.
- Material icon inline `font-size:Npx` bumped via `[style*="…"]` selectors with `!important`.
- NavBar `h-12 → h-14`, icons 26→30 px. AppBar same, text-sm → text-base, side icons 24→28.
- On-screen keyboard: dropped `max-w-[800px]` clamp, keys stretch to full viewport with `flex-1` and `py-3.5` (~60 px tall).
- AA screen left alone — content is an MJPEG `<img>` with `absolute inset-0`, so the rem bump can't touch its 1:1 pixel mapping. Only the shared NavBar over it gets larger.

### Settings UI
- `/api/wifi/config` GET now returns `live_ssid` / `live_password` / `live_bssid` alongside the YAML defaults. Settings → WiFi shows the live P2P-GO credentials in an orange "Live AP" box (P2P-GO regenerates them each boot, so the user can read them off the screen if they ever need to type them on a phone).
- ALFA-NET SSID + password editable in Settings → WiFi.

## Hardware-truth notes (captured in comments + memory)

- **Intel 8087:0a2b BT on M910q** does a documented tx-timeout USB reset after ~15 min and then the controller fully vanishes from the bus; the new hci-watchdog only helps if the hci stays present. Recommendation: USB dongle (CSR8510 verified) for stable BT.
- **Intel 8265 WiFi** self-managed PHY pins to country 00 → every 5 GHz channel reads `NO-IR` for BOTH AP and P2P-GO. 5 GHz on this card requires either a USB dongle or firmware-patched regdb.
- **Intel 8265** admits only one of `{AP, P2P-client, P2P-GO}` per radio — no way to host AA + ALFA-NET concurrently on a single radio without a second WiFi NIC.

## Test plan

- [ ] Pair phone via BT — confirm carkit class shown + "Share contacts & history" prompt during pairing.
- [ ] Trigger Android Auto Wireless — phone joins ALFA (or P2P-GO `DIRECT-XX`) from the BT-bootstrap automatically.
- [ ] Play music over BT — A1 now-playing card fills title/artist/album within ~2 s of phone connect (was empty before).
- [ ] Open A3 phone screen — contacts + call history populated within ~10 s of pair (PBAP pull is async).
- [ ] Reload dashboard at `http://<bcm>:5002` — chrome (NavBar/AppBar) is ~15% larger; cards/labels/values bumped; AA screen unchanged.
- [ ] Tap any text field — on-screen keyboard fills full viewport width with big keys.
- [ ] Settings → WiFi — "Live AP" box shows the live P2P-GO SSID/PSK; ALFA-NET fields editable + persist.
- [ ] Volume slider on BCM Audio screen — confirm it actually changes USB soundbar volume (proves PipeWire env fix).
- [ ] `prefer_internal: true` + reboot — internal Intel 8087 selected; hci watchdog log when adapter resets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)