### PR TITLE
Drop internal Intel BT + modern theme polish + scroll/touch fixes

### DIFF
--- a/config/scripts/apply-fixes.sh
+++ b/config/scripts/apply-fixes.sh
@@ -22,9 +22,34 @@ install -m 0644 "$BCM_DIR/config/systemd/bcm-splash-small.service" /etc/systemd/
 systemctl disable bcm-splash-small.service 2>/dev/null || true
 rm -f /etc/systemd/system/multi-user.target.wants/bcm-splash-small.service
 
-echo "==> 2/6  Installing Bluetooth setup (Class=carkit + AlwaysPairable)"
+echo "==> 2/6  Installing Bluetooth setup (Class=carkit + AlwaysPairable + drop internal Intel BT)"
 install -m 0755 "$BCM_DIR/config/scripts/bcm-bluetooth-setup.sh" /usr/local/bin/bcm-bluetooth-setup.sh
 install -m 0644 "$BCM_DIR/config/systemd/bcm-bluetooth.service" /etc/systemd/system/bcm-bluetooth.service
+
+# Drop the integrated Intel 8087 controller so only the USB dongle is
+# visible to BlueZ. The script-level unbind catches it at service start;
+# the udev rule below kills it earlier, before bluetoothd ever sees it,
+# which avoids the race where bluetoothd grabs the Intel as default
+# adapter and the phone latches onto its (broken) BD_ADDR.
+mkdir -p /etc/default
+if [ ! -f /etc/default/bcm-bluetooth ] || ! grep -q "^BCM_BT_KEEP_INTERNAL=" /etc/default/bcm-bluetooth; then
+    echo "BCM_BT_KEEP_INTERNAL=0" >> /etc/default/bcm-bluetooth
+fi
+# Also flip the legacy "prefer Intel" flag off — even with the unbind
+# we don't want userspace fallback to look for the Intel first.
+if grep -q "^BCM_BT_PREFER_INTERNAL=1" /etc/default/bcm-bluetooth 2>/dev/null; then
+    sed -i 's/^BCM_BT_PREFER_INTERNAL=1/BCM_BT_PREFER_INTERNAL=0/' /etc/default/bcm-bluetooth
+fi
+cat > /etc/udev/rules.d/81-bcm-disable-intel-bt.rules <<'UDEV'
+# Disable the integrated Intel 8087:0a2b Bluetooth controller (M910q etc).
+# The kernel writes "0" to /sys/bus/usb/devices/X/authorized on attach,
+# which prevents the btusb driver from binding. Re-enable by removing
+# this rule or echoing 1 to the device's authorized sysfs entry.
+SUBSYSTEM=="usb", ATTR{idVendor}=="8087", ATTR{idProduct}=="0a2b", ATTR{authorized}="0"
+UDEV
+udevadm control --reload-rules 2>/dev/null || true
+# Trigger now so any currently-bound Intel BT goes away without a reboot.
+udevadm trigger --action=add --attr-match=idVendor=8087 2>/dev/null || true
 
 # Apply BT main.conf changes now (the setup script also does this, but
 # running it here makes the result observable before reboot).

--- a/config/scripts/bcm-bluetooth-setup.sh
+++ b/config/scripts/bcm-bluetooth-setup.sh
@@ -24,6 +24,55 @@ if command -v rfkill >/dev/null 2>&1; then
     fi
 fi
 
+# Hard-disable the integrated Intel 8087 controller.
+# Why: on the M910q (and other NUC-class boards) both the internal Intel
+# 8087:0a2b and an external CSR/Realtek dongle land on hciX simultaneously,
+# and BlueZ happily advertises both — phones then see two carkits with the
+# same alias and pairing latches onto the Intel one which mid-session
+# `tx timeout`s and drops. Preferring the dongle in userspace isn't
+# enough: the Intel still publishes the advertising RA, A2DP-Sink endpoint
+# on the wrong BD_ADDR, and HFP profile that the phone may pick first.
+#
+# Unbind it from its USB driver so the kernel removes /sys/class/bluetooth/hciN
+# entirely. BlueZ then only sees the dongle.  Can be re-enabled by setting
+# BCM_BT_KEEP_INTERNAL=1 in /etc/default/bcm-bluetooth.
+[ -f /etc/default/bcm-bluetooth ] && . /etc/default/bcm-bluetooth
+if [ "${BCM_BT_KEEP_INTERNAL:-0}" != "1" ]; then
+    for hci_dir in /sys/class/bluetooth/hci*; do
+        [ -e "$hci_dir" ] || continue
+        hci=$(basename "$hci_dir")
+        dev_real=$(readlink -f "$hci_dir/device" 2>/dev/null || true)
+        [ -n "$dev_real" ] || continue
+        # Walk up to the USB interface node (has idVendor/bInterfaceNumber).
+        cur="$dev_real"
+        vendor=""
+        usb_iface=""
+        for _ in 1 2 3 4 5; do
+            if [ -f "$cur/idVendor" ]; then
+                vendor=$(cat "$cur/idVendor" 2>/dev/null | tr A-Z a-z)
+                usb_iface="$cur"
+                break
+            fi
+            parent=$(dirname "$cur")
+            [ "$parent" = "$cur" ] && break
+            cur="$parent"
+        done
+        if [ "$vendor" = "8087" ] && [ -n "$usb_iface" ]; then
+            # The USB *device* node (one level up from interface) is what
+            # we unbind from the usb driver. dev_real for hciX usually
+            # points to interface .0 of the device, e.g.
+            #   /sys/bus/usb/devices/1-7:1.0  →  parent device 1-7
+            usb_dev=$(dirname "$usb_iface")
+            usb_name=$(basename "$usb_dev")
+            echo "BT setup: unbinding internal Intel 8087 at $usb_name ($hci)"
+            hciconfig "$hci" down 2>/dev/null || true
+            if [ -e /sys/bus/usb/drivers/usb/unbind ]; then
+                echo "$usb_name" > /sys/bus/usb/drivers/usb/unbind 2>/dev/null || true
+            fi
+        fi
+    done
+fi
+
 # NOTE: do NOT touch /etc/bluetooth/main.conf here, and do NOT restart
 # bluetooth.service from within this script. The unit has
 # Requires=bluetooth.service, so bouncing the daemon makes systemd

--- a/config/scripts/setup-x86.sh
+++ b/config/scripts/setup-x86.sh
@@ -902,15 +902,27 @@ cp "$BCM_DIR/config/scripts/bcm-bluetooth-setup.sh" /usr/local/bin/
 chmod +x /usr/local/bin/bcm-bluetooth-setup.sh
 cp "$BCM_DIR/config/systemd/bcm-bluetooth.service" /etc/systemd/system/
 
-# Tell the BT setup oneshot to prefer the integrated Intel 8087 adapter
-# on the M910q (matches bluetooth.prefer_internal=true in the YAML).
-# Remove or set to 0 to fall back to "prefer USB dongle" which is the
-# safer default on unknown hardware. The hci watchdog inside
-# BluetoothManager recovers from the documented Intel tx-timeouts.
+# Drop the integrated Intel 8087 BT entirely — its tx-timeout pattern
+# under load drops calls/AA mid-session, and when both internal and USB
+# dongle are present BlueZ advertises both with the same alias which
+# confuses phones during pairing. The udev rule below deauthorizes the
+# Intel USB device on attach so btusb never binds; the bluetooth setup
+# oneshot also unbinds it at service start as a safety net for systems
+# where udev rules aren't reloaded.
 mkdir -p /etc/default
-if ! grep -q "^BCM_BT_PREFER_INTERNAL=" /etc/default/bcm-bluetooth 2>/dev/null; then
-    echo "BCM_BT_PREFER_INTERNAL=1" >> /etc/default/bcm-bluetooth
+if ! grep -q "^BCM_BT_KEEP_INTERNAL=" /etc/default/bcm-bluetooth 2>/dev/null; then
+    echo "BCM_BT_KEEP_INTERNAL=0" >> /etc/default/bcm-bluetooth
 fi
+# Make sure any prior BCM_BT_PREFER_INTERNAL=1 from older installs is off.
+if grep -q "^BCM_BT_PREFER_INTERNAL=1" /etc/default/bcm-bluetooth 2>/dev/null; then
+    sed -i 's/^BCM_BT_PREFER_INTERNAL=1/BCM_BT_PREFER_INTERNAL=0/' /etc/default/bcm-bluetooth
+fi
+cat > /etc/udev/rules.d/81-bcm-disable-intel-bt.rules <<'UDEV'
+# Disable the integrated Intel 8087:0a2b Bluetooth controller (M910q etc).
+SUBSYSTEM=="usb", ATTR{idVendor}=="8087", ATTR{idProduct}=="0a2b", ATTR{authorized}="0"
+UDEV
+udevadm control --reload-rules 2>/dev/null || true
+udevadm trigger --action=add --attr-match=idVendor=8087 2>/dev/null || true
 
 # Persist BT rfkill unblock across boots — without this many baremetal
 # boards (M910q, OPi 5 Pro) come up with bluetooth soft-blocked even

--- a/src/dashboard/web/css/themes.css
+++ b/src/dashboard/web/css/themes.css
@@ -171,11 +171,17 @@ body[data-theme="heritage"] {
     text-shadow: 0 0 10px rgba(245, 158, 11, 0.4);
 }
 
-/* ---- MODERN THEME ---- */
+/* ---- MODERN THEME ----
+ * Palette tuned for the 7" touchscreen at indoor/dim cabin lighting.
+ * Cards used to be `#ffffff` on `#f1f5f9` — eye-piercing in the dark,
+ * and `--card-border: #e2e8f0` was a hairline at the same tone so the
+ * frames disappeared. Switched to warmer off-whites for the surfaces
+ * and a clearly visible slate-400 border so panels read as panels.
+ */
 [data-theme="modern"] {
     --color-primary: #005596;
     --color-accent: #ef4444;
-    --color-surface: #f8fafc;
+    --color-surface: #eef2f7;
     --color-on-surface: #0f172a;
     --color-on-surface-variant: #64748b;
 
@@ -187,19 +193,45 @@ body[data-theme="heritage"] {
     --nav-active-color: #ef4444;
     --nav-inactive-color: #71717a;
 
-    --card-bg: #ffffff;
-    --card-border: #e2e8f0;
+    --card-bg: #f6f8fb;
+    --card-border: #94a3b8;
     --text-primary: #0f172a;
-    --text-dim: #94a3b8;
-    --text-mid: #64748b;
-    --progress-bg: #e2e8f0;
+    --text-dim: #64748b;
+    --text-mid: #475569;
+    --progress-bg: #cbd5e1;
     --progress-fill: #3b82f6;
 }
 
 [data-theme="modern"] body,
 body[data-theme="modern"] {
-    background-color: #f1f5f9;
+    background-color: #dde3eb;
     color: #0f172a;
+}
+
+/* Modern uses Tailwind utility classes (bg-white, border-slate-200) in
+ * screen templates directly. Overriding here recolors every card/panel
+ * without touching the screen JS. The borders go from invisible
+ * hairlines (slate-200) to clearly readable slate-400, and pure white
+ * is downshifted to a warmer #f6f8fb to stop the dim-cabin glare.
+ */
+[data-theme="modern"] .bg-white {
+    background-color: #f6f8fb !important;
+}
+[data-theme="modern"] .border-slate-200,
+[data-theme="modern"] .border-slate-300 {
+    border-color: #94a3b8 !important;
+}
+[data-theme="modern"] .text-white {
+    /* Pure white text on bright/coloured backgrounds is brutal under
+     * cabin light. The blue tile (bg-[#005596]) keeps enough contrast
+     * with #f1f5f9-tinted white. */
+    color: #f1f5f9 !important;
+}
+/* Widen card outlines a touch so the new frame colour reads as a frame,
+ * not just a stroke. 1.5px reads as "deliberate" without going cartoon.
+ */
+[data-theme="modern"] .border {
+    border-width: 1.5px !important;
 }
 
 .glass-card {
@@ -294,7 +326,14 @@ body[data-theme="autodelta"] {
     -webkit-mask-image: linear-gradient(to bottom, black 70%, transparent 100%);
 }
 
-/* ---- SHARED LAYOUT ---- */
+/* ---- SHARED LAYOUT ----
+ * Screens are flex columns under a fixed AppBar; after the 7" sizing
+ * bump some panels (Settings, Service, Audio) exceed the visible area.
+ * Allow vertical scroll on the inner content-area so users can reach
+ * everything via touch flick instead of clipping the bottom rows.
+ * The screen-container itself stays clipped so the page chrome
+ * (AppBar + NavBar overlay) never moves with the scroll.
+ */
 .screen-container {
     width: 100%;
     height: 100%;
@@ -306,8 +345,37 @@ body[data-theme="autodelta"] {
 
 .content-area {
     flex: 1;
-    overflow: hidden;
+    /* Default: clip horizontal, allow vertical scroll when content
+     * overflows. Tailwind utilities applied per-screen (overflow-hidden
+     * on the AA stream / main gauges) win on source order and clip both
+     * axes where the screen really must fit-to-viewport. */
+    overflow-x: hidden;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
 }
+/* Helper for inner scrollers that aren't the .content-area itself
+ * (e.g. a settings card containing a long list of paired devices). */
+.bcm-scroll-y {
+    overflow-y: auto !important;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
+}
+/* Re-show the scrollbar (slim) inside scrollable settings/audio panes.
+ * The global `::-webkit-scrollbar { display: none }` rule hides every
+ * scrollbar, which means the user has no visual hint the page can
+ * scroll. Bring it back as a thin overlay-style bar so long pages are
+ * discoverable; the hide rule still applies to everything else. */
+main.content-area::-webkit-scrollbar {
+    display: block;
+    width: 6px;
+}
+main.content-area::-webkit-scrollbar-thumb {
+    background: rgba(127, 127, 127, 0.45);
+    border-radius: 3px;
+}
+main.content-area::-webkit-scrollbar-track { background: transparent; }
+main.content-area { scrollbar-width: thin; }
 
 /* ---- AUTOHIDING NAVBAR ----
  * NavBar is absolute-positioned over the content; hidden by default
@@ -324,16 +392,23 @@ body[data-theme="autodelta"] {
     transform: translateY(0);
     pointer-events: auto;
 }
-/* Thin invisible hot-zone at the bottom of the viewport that catches
- * swipe-up gestures even when the navbar isn't yet shown. */
+/* Thin invisible hot-zone at the bottom of the viewport. Used to be a
+ * tap-catcher; that stole touches from any fixed-bottom button after
+ * the +15% rem bump grew controls into the strip. Now `pointer-events:
+ * none` so the document-level swipe-up handler in `_initTouchSwipe()`
+ * detects bottom-edge gestures via bubbling and taps fall through to
+ * the underlying button. The element is still injected so the
+ * existing JS bindings keep their handle.
+ */
 .bcm-navbar-hotzone {
     position: absolute;
     bottom: 0;
     left: 0;
     right: 0;
-    height: 36px;   /* +30% — easier to catch swipe-up with fat fingers */
+    height: 36px;
     z-index: 49;
     background: transparent;
+    pointer-events: none;
 }
 
 /* ---- ENCODER/SWITCH NAVIGATION ---- */

--- a/src/dashboard/web/js/app.js
+++ b/src/dashboard/web/js/app.js
@@ -404,15 +404,34 @@ const App = (() => {
     }
     /** Inject a thin invisible hot-zone at the bottom of <body> so the
      *  edge-swipe detector still fires when the touch lands on a
-     *  child element with stopPropagation behavior. */
+     *  child element with stopPropagation behavior.
+     *
+     *  The hotzone tracks its OWN touch start/end and only fires the
+     *  reveal on a real swipe-up gesture; a plain tap passes through
+     *  to the underlying UI button. Earlier versions called showNavBar
+     *  on any touchstart in the bottom 36 px which stole taps from
+     *  fixed-bottom controls (the "after scaling, touch is off" bug
+     *  the user kept hitting — buttons grew into the hotzone strip). */
     function _ensureNavHotzone() {
         if (document.getElementById("bcm-nav-hotzone")) return;
         const hot = document.createElement("div");
         hot.id = "bcm-nav-hotzone";
         hot.className = "bcm-navbar-hotzone";
-        hot.addEventListener("touchstart", () => { showNavBar(); },
-                             { passive: true });
-        hot.addEventListener("click", () => { showNavBar(); });
+        let hotStartY = 0;
+        let hotStartT = 0;
+        hot.addEventListener("touchstart", (e) => {
+            hotStartY = e.touches[0].clientY;
+            hotStartT = Date.now();
+        }, { passive: true });
+        hot.addEventListener("touchend", (e) => {
+            const endY = e.changedTouches[0].clientY;
+            const dy = endY - hotStartY;
+            const dt = Date.now() - hotStartT;
+            // Real swipe-up: at least 24 px upward within 500 ms.
+            // Anything else (a tap, a long press, a horizontal drag)
+            // is left to bubble through to the element below.
+            if (dy < -24 && dt < 500) showNavBar();
+        }, { passive: true });
         document.body.appendChild(hot);
     }
 

--- a/src/dashboard/web/js/components/appbar.js
+++ b/src/dashboard/web/js/components/appbar.js
@@ -9,19 +9,28 @@
 
 const AppBar = (() => {
     function _logoImg(theme) {
-        // Single PNG, CSS-differentiated per theme
+        // The shipped logo PNG is 8-bit grayscale with no alpha — its
+        // "transparent" area is actually white pixels. Plain `filter:
+        // invert(1)` flips that white to black and produces the ugly
+        // square behind the mark.  `mix-blend-mode: screen` makes the
+        // (post-invert) black background transparent on the black appbar
+        // (screen of 0 is identity), while the white silhouette stays
+        // bright and the per-theme tint comes from sepia+hue-rotate.
+        // Result: clean cut-out logo, no visible rectangle.
         let filterStyle = "";
         if (theme === "heritage") {
-            // Invert to white, then tint amber
             filterStyle = "filter: invert(1) sepia(1) saturate(3) hue-rotate(15deg) brightness(1.1);";
         } else if (theme === "modern") {
-            // Invert to white, slight red tint
-            filterStyle = "filter: invert(1) sepia(0.3) saturate(2) hue-rotate(-20deg) brightness(1);";
+            filterStyle = "filter: invert(1) sepia(0.5) saturate(3) hue-rotate(-25deg) brightness(1.05);";
         } else if (theme === "autodelta") {
-            // Invert to white, orange tint
             filterStyle = "filter: invert(1) sepia(1) saturate(5) hue-rotate(-10deg) brightness(1.2);";
         }
-        return `<img src="/assets/alfa_logo.png" alt="Alfa Romeo" class="h-12 w-auto object-contain" style="${filterStyle}" onerror="this.parentElement.innerHTML='<span class=\\'text-base font-bold\\'>AR</span>';">`;
+        // h-16 (~64px logical → ~74px after 1.15 root-rem bump) with
+        // negative vertical margin so the larger logo can overhang the
+        // 56-logical-px (~64px) appbar without forcing a layout reflow.
+        const cls = "appbar-logo h-16 w-auto object-contain -my-2";
+        const style = `${filterStyle} mix-blend-mode: screen;`;
+        return `<img src="/assets/alfa_logo.png" alt="Alfa Romeo" class="${cls}" style="${style}" onerror="this.parentElement.innerHTML='<span class=\\'text-base font-bold\\'>AR</span>';">`;
     }
 
     function render(theme, data) {


### PR DESCRIPTION
## Summary

- **BT:** hard-disable the integrated Intel 8087 controller (M910q) via udev `authorized=0` + a script-level USB unbind fallback, so BlueZ only sees the USB dongle. Running both adapters at once was letting phones latch onto the (broken) Intel BD_ADDR even with userspace adapter preference set. Gated by `BCM_BT_KEEP_INTERNAL=1` escape hatch in `/etc/default/bcm-bluetooth`.
- **Modern theme:** cards `#ffffff → #f6f8fb`, body `#f1f5f9 → #dde3eb`, border `#e2e8f0 → #94a3b8` (slate-400), `border-width: 1.5px` on `.border`. Added `[data-theme="modern"]` overrides for the Tailwind utilities used directly in screen templates (`.bg-white`, `.border-slate-200/300`, `.text-white`) so the palette change picks up everywhere without touching screen JS.
- **Scrollability:** `.content-area` now `overflow-y: auto` by default with `overscroll-behavior: contain` and a slim visible `::-webkit-scrollbar` so long pages (Settings, Service, Audio) are reachable. Screens that explicitly add Tailwind `overflow-hidden` (AA stream, main gauges, trip, weather) still clip — source order wins.
- **Touch mismatch:** `.bcm-navbar-hotzone` is now `pointer-events: none`, and its JS listener only fires `showNavBar()` on a real upward swipe (Δy < -24 px in <500 ms). The strip used to call `showNavBar()` on every tap and was eating clicks for any fixed-bottom button — exacerbated after the +15% rem bump grew controls into the strip. Document-level swipe-up detection in `_initTouchSwipe()` covers the gesture via bubbling.
- **Navbar logo:** added `mix-blend-mode: screen` on the appbar logo so the post-invert black background blends invisibly against the black header (the shipped `alfa_logo.png` is 8-bit grayscale, no alpha — that was the source of the "ugly black square"). Size `h-12 → h-16` with `-my-2` so the larger mark overhangs the appbar cleanly.

## Test plan

- [ ] `lsusb` no longer shows `8087:0a2b` after `apply-fixes.sh` + reboot (or `udevadm trigger`)
- [ ] `/sys/class/bluetooth/` shows only the dongle's hciX
- [ ] Phone discovers + pairs the headunit on the first try, BD_ADDR matches the dongle
- [ ] Settings screen scrolls past the visible viewport on the 7" panel; thin scrollbar visible
- [ ] Tap on a fixed-bottom button (e.g., Settings save/cancel) registers without revealing the navbar
- [ ] Swipe up from the bottom edge still reveals the navbar on every screen
- [ ] Modern theme: card borders are clearly visible against the body; no eye-piercing pure white
- [ ] Appbar logo shows no rectangular background on heritage / modern / autodelta themes
- [ ] `BCM_BT_KEEP_INTERNAL=1` re-enables the Intel adapter (regression escape hatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)