### PR TITLE
Fix UI hang storm, switch WiFi to P2P-GO, splash exit status

### DIFF
--- a/config/bcm_config.yaml
+++ b/config/bcm_config.yaml
@@ -147,7 +147,7 @@ wifi:
   enabled: true
   ssid: ALFA
   password: 87654321
-  mode: hostapd
+  mode: p2p_go
   band: g
   channel: 6
   country: BO

--- a/config/bcm_config_opi_pc.yaml
+++ b/config/bcm_config_opi_pc.yaml
@@ -271,14 +271,19 @@ music_panel:
   enabled: true
 
 wifi:
-  enabled: false       # No built-in WiFi — use USB dongle if needed
+  enabled: true        # Required for AA Wireless — uses internal Intel
+                       # 8265 in P2P-GO mode (Wi-Fi Direct group owner).
   ssid: ALFA
   password: "87654321"
-  band: a              # 'a' = 5 GHz, 'bg' = 2.4 GHz
-  channel: 149         # 5 GHz UNII-3
-  country: PL
+  mode: p2p_go         # Wi-Fi Direct Group Owner — sidesteps the Intel
+                       # 8265 self-managed regdom that blocks AP role.
+  band: g              # 2.4 GHz — 5 GHz P2P-GO FAILs under country=00
+                       # (NO-IR/IR-CONCURRENT). 2.4 GHz pairs reliably.
+  channel: 6           # ch6 = 2437 MHz, always-passive-free on iwlwifi
+  country: BO          # User-waived country compliance for AA Wireless
+  regdom: BO
   share_internet: true # NAT outbound traffic via LTE uplink
-  interface: "wlan0"   # USB WiFi dongle
+  interface: ""        # Auto-detect — internal Intel 8265 on M910q
   ip: 10.0.0.1
   netmask: 255.255.255.0
   dhcp_start: 10.0.0.10

--- a/config/systemd/bcm-splash-main.service
+++ b/config/systemd/bcm-splash-main.service
@@ -39,7 +39,7 @@ Environment=BCM_SPLASH_FALLBACK_URL=http://localhost:5002
 ExecStart=/usr/local/bin/bcm-splash-play.sh
 ExecStop=/bin/bash -c 'pkill -f bcm-splash-play.sh 2>/dev/null; pkill -f "mpv.*splash" 2>/dev/null; true'
 
-SuccessExitStatus=0 1
+SuccessExitStatus=0 1 SIGTERM
 Restart=no
 
 User=root

--- a/main.py
+++ b/main.py
@@ -221,6 +221,16 @@ def main() -> None:
     except Exception:
         log.exception("BluetoothManager failed to init (non-critical)")
 
+    # PBAP phonebook + call-history puller. Subscribes to bt.connected and
+    # publishes bt.contacts / bt.call_history that the A8 phone screen
+    # consumes via /api/phone/{contacts,history}. Without this the phone
+    # screen renders empty even when pairing advertises PCE/MCE correctly.
+    try:
+        from src.multimedia.phonebook import start_phonebook_sync
+        start_phonebook_sync(event_bus)
+    except Exception:
+        log.exception("PBAP phonebook sync failed to init (non-critical)")
+
     # Start WiFi AP for Android Auto wireless data link
     wifi_ap = None
     wifi_enabled = config.get("wifi.enabled", False)

--- a/src/dashboard/web/js/screens/settings.js
+++ b/src/dashboard/web/js/screens/settings.js
@@ -77,10 +77,16 @@ const Settings = {
         App.navigateTo("settings");
     },
 
-    async wifiLoad() {
-        // Always refresh — the P2P-GO credentials change on every
-        // boot, so a cached "loaded=true" would show stale values
-        // from a previous wpa_supplicant session.
+    _wifiFetchedAt: 0,
+    async wifiLoad(force) {
+        // Throttle: this is invoked from render() and would otherwise
+        // re-fire every time the JSON response triggers another
+        // navigateTo("settings") → render() → wifiLoad() cycle. Cap
+        // it at one refresh per 3 s (same gate as radioRefresh), or
+        // pass force=true on user actions that need fresh values.
+        const now = Date.now();
+        if (!force && now - Settings._wifiFetchedAt < 3000) return;
+        Settings._wifiFetchedAt = now;
         try {
             const res = await fetch("/api/wifi/config");
             if (!res.ok) return;

--- a/src/dashboard/web/js/screens/trip.js
+++ b/src/dashboard/web/js/screens/trip.js
@@ -204,33 +204,33 @@ App.registerScreen("a3", (() => {
 
     function _injectToggleButton(host) {
         if (host.querySelector(".tp-toggle-btn")) return;
-        // Attach to .screen-container directly (which is position:relative)
-        // rather than to <main>, which in the modern theme is a flex
-        // container that would absorb the button into its layout.
-        // z-index:50 keeps the button ABOVE the overlay (z-40) so the
-        // user can always toggle back to live trip stats.
+        // The button is placed inline, immediately to the left of the
+        // fuel-consumption section header. Each theme template renders a
+        // `.tp-toggle-anchor` slot at that location; we just fill it.
+        // z-index keeps the button visible above the travel-plan overlay
+        // so the user can always toggle back to live trip stats.
+        const anchor = host.querySelector(".tp-toggle-anchor");
+        if (!anchor) return;
         const btn = document.createElement("button");
         btn.className = "tp-toggle-btn";
         btn.type = "button";
         btn.style.cssText = [
-            "position:absolute",
-            "top:56px",         // below AppBar (48px)
-            "right:12px",
+            "position:relative",
             "z-index:50",
-            "display:flex",
+            "display:inline-flex",
             "align-items:center",
             "gap:6px",
-            "padding:6px 12px",
+            "padding:4px 10px",
             "border-radius:8px",
             "background:rgba(24,24,27,0.92)",
             "border:1px solid rgba(245,158,11,0.5)",
             "color:#f59e0b",
-            "font-size:11px",
+            "font-size:10px",
             "font-weight:800",
             "text-transform:uppercase",
             "letter-spacing:1px",
             "cursor:pointer",
-            "box-shadow:0 2px 8px rgba(0,0,0,0.5)",
+            "box-shadow:0 1px 4px rgba(0,0,0,0.4)",
         ].join(";");
         btn.addEventListener("click", (e) => {
             e.preventDefault();
@@ -242,7 +242,8 @@ App.registerScreen("a3", (() => {
             e.stopPropagation();
             _toggleTravelPlan();
         });
-        host.appendChild(btn);
+        anchor.innerHTML = "";
+        anchor.appendChild(btn);
     }
 
     function _updateToggleButton() {
@@ -448,8 +449,11 @@ App.registerScreen("a3", (() => {
                 </div>
                 <!-- Right: Chart with scale -->
                 <div class="flex-1 p-4 flex flex-col bg-[#1a0f0a]">
-                    <div class="flex justify-between items-center mb-2">
-                        <span class="text-[10px] text-zinc-500 font-bold uppercase tracking-wider">${t("fuel_consumption")} (L/100km)</span>
+                    <div class="flex justify-between items-center mb-2 gap-2">
+                        <div class="flex items-center gap-2 min-w-0">
+                            <span class="tp-toggle-anchor"></span>
+                            <span class="text-[10px] text-zinc-500 font-bold uppercase tracking-wider truncate">${t("fuel_consumption")} (L/100km)</span>
+                        </div>
                         <div class="flex items-center gap-2">
                             <span class="text-[9px] text-zinc-600">Now:</span>
                             <span id="trip-instant" class="text-sm font-bold text-amber-500">${instantCons}</span>
@@ -512,11 +516,14 @@ App.registerScreen("a3", (() => {
                 </div>
                 <!-- Right: Graph with scale -->
                 <div class="flex-1 bg-white rounded-xl shadow-sm border border-slate-200 p-3 flex flex-col">
-                    <div class="flex justify-between items-center mb-2">
-                        <span class="text-[10px] font-bold text-slate-800 flex items-center gap-1">
-                            <span class="material-symbols-outlined text-[#005596]" style="font-size:16px;">monitoring</span>
-                            ${t("fuel_consumption")} (L/100km)
-                        </span>
+                    <div class="flex justify-between items-center mb-2 gap-2">
+                        <div class="flex items-center gap-2 min-w-0">
+                            <span class="tp-toggle-anchor"></span>
+                            <span class="text-[10px] font-bold text-slate-800 flex items-center gap-1 truncate">
+                                <span class="material-symbols-outlined text-[#005596]" style="font-size:16px;">monitoring</span>
+                                ${t("fuel_consumption")} (L/100km)
+                            </span>
+                        </div>
                         <span class="text-[9px] text-slate-500">Now: <span id="trip-instant" class="font-bold text-slate-700">${instantCons}</span></span>
                     </div>
                     <div class="flex-1">
@@ -563,7 +570,10 @@ App.registerScreen("a3", (() => {
                 <div class="flex-1 flex gap-3 min-h-0">
                     <!-- Chart -->
                     <div class="flex-1 bg-zinc-900/50 rounded-xl border border-zinc-800 p-3 flex flex-col">
-                        <span class="text-[9px] text-zinc-500 font-bold uppercase tracking-wider mb-1">${t("fuel_consumption")} L/100km</span>
+                        <div class="flex items-center gap-2 mb-1 min-w-0">
+                            <span class="tp-toggle-anchor"></span>
+                            <span class="text-[9px] text-zinc-500 font-bold uppercase tracking-wider truncate">${t("fuel_consumption")} L/100km</span>
+                        </div>
                         <div class="flex-1">
                             ${_chartWithScale(chartValues, chartLabels, "autodelta", 15)}
                         </div>

--- a/src/dashboard/web_viewer.py
+++ b/src/dashboard/web_viewer.py
@@ -1434,4 +1434,10 @@ class WebViewer:
                 except Exception:
                     break
 
-        app.run(host=self.host, port=self.port, debug=False, use_reloader=False)
+        # threaded=True: the dashboard renders fire many concurrent
+        # GETs (radio status, wifi config, BT lists, music, weather…)
+        # plus the touch input WS. A single-threaded werkzeug serializes
+        # everything, so a slow handler (e.g. bluetoothctl scan, nmcli)
+        # stalls every other endpoint and the UI feels frozen on touch.
+        app.run(host=self.host, port=self.port, debug=False,
+                use_reloader=False, threaded=True)

--- a/src/multimedia/bluetooth.py
+++ b/src/multimedia/bluetooth.py
@@ -350,12 +350,38 @@ def _find_adapter_dbus_path() -> str:
     return "/org/bluez/hci0"
 
 
+def _force_carkit_cod(adapter_path: str) -> None:
+    """Re-stamp Class-of-Device 0x620420 (AV + Carkit + Audio/Tel/Net).
+
+    bluetoothd auto-synthesises CoD from registered Media/Profile
+    plugins, which means PipeWire registering A2DP/HFP endpoints
+    overwrites the carkit class with ``0x006c0104`` ("Computer with
+    Audio/Rendering") — even when ``main.conf`` has ``Class=0x620420``.
+    Phones use the CoD bits to gate the Android Auto carkit detection
+    path; with "Computer" set, AA never offers wireless even though
+    the dongle is pairable. Re-apply via hciconfig after every
+    profile/plugin registration storm.
+    """
+    hci = adapter_path.rsplit("/", 1)[-1] if adapter_path else ""
+    if not hci.startswith("hci"):
+        return
+    try:
+        subprocess.run(
+            ["hciconfig", hci, "class", "0x620420"],
+            capture_output=True, timeout=5,
+        )
+        log.info("BT CoD pinned to carkit (0x620420) on %s", hci)
+    except Exception:
+        log.debug("hciconfig class set failed on %s (non-critical)", hci)
+
+
 def _configure_adapter(bus) -> None:
     """Configure BT adapter name + persistent pairable/discoverable.
 
-    Class-of-Device cannot be set via D-Bus on BlueZ — it must come from
-    /etc/bluetooth/main.conf (Class=0x42020c for an automotive carkit).
-    bcm-bluetooth-setup.sh writes it; here we only handle runtime props.
+    Class-of-Device is also re-pinned to 0x620420 here because
+    bluetoothd resynthesises it whenever a media/profile plugin
+    registers (PipeWire's A2DP/HFP endpoints land ~10s after our
+    setup script's hciconfig set, clobbering it).
     """
     adapter_path = _find_adapter_dbus_path()
     try:
@@ -382,6 +408,7 @@ def _configure_adapter(bus) -> None:
     except Exception:
         log.debug("Could not configure adapter on %s (non-critical)",
                   adapter_path)
+    _force_carkit_cod(adapter_path)
 
 
 def _is_autoapp_available() -> bool:
@@ -446,6 +473,18 @@ def _start_pairing_agent() -> bool:
 
         # Register profiles (AA only if OpenAuto installed)
         _register_all_profiles(bus)
+
+        # PBAP/MAP registration above triggers a bluetoothd CoD
+        # resynthesis that clobbers the carkit class we just stamped;
+        # pin it again now, and schedule one more pin 20s out to cover
+        # the late PipeWire endpoint registrations.
+        adapter_path = _find_adapter_dbus_path()
+        _force_carkit_cod(adapter_path)
+        def _late_cod_pin() -> None:
+            time.sleep(20)
+            _force_carkit_cod(adapter_path)
+        threading.Thread(target=_late_cod_pin, daemon=True,
+                         name="bt-cod-pin").start()
 
         # Run GLib main loop in background thread for D-Bus signal handling
         from gi.repository import GLib
@@ -610,43 +649,54 @@ def _get_adapter_addr() -> str:
     return _PREFERRED_ADAPTER
 
 
+_btctl_lock = threading.Lock()
+
+
 def _run_btctl(args: list[str], timeout: float = 10.0) -> tuple[int, str, str]:
     """Run a bluetoothctl command, selecting the preferred adapter first.
 
-    When multiple BT adapters are present, pipes 'select <addr>' before the
-    actual command via stdin to ensure we always target the right adapter.
+    Serialised process-wide via ``_btctl_lock`` because bluetoothd
+    serialises D-Bus calls anyway, and overlapping bluetoothctl
+    subprocesses produce the documented ``Waiting to connect to
+    bluetoothd...`` race — the second subprocess fires its stdin
+    commands before the daemon connection lands, so the command never
+    runs but rc=0 looks fine. Under high contention this then drives
+    the auto-reconnect verify loop into a spin that pegs the BCM
+    process at hundreds of forks/minute and starves Flask handlers,
+    which the user sees as "GUI doesn't respond / can't scroll".
     """
     adapter = _get_adapter_addr()
     cmd_str = "bluetoothctl " + " ".join(args)
     if adapter:
         cmd_str = f"bluetoothctl (adapter={adapter}) " + " ".join(args)
     log.debug("btctl >>> %s", cmd_str)
-    try:
-        # Use stdin to select adapter then run command in interactive mode
-        if adapter and args and args[0] != "list":
-            stdin_cmds = f"select {adapter}\n" + " ".join(args) + "\nexit\n"
-            result = subprocess.run(
-                ["bluetoothctl"],
-                capture_output=True, text=True, timeout=timeout,
-                input=stdin_cmds,
-            )
-        else:
-            result = subprocess.run(
-                ["bluetoothctl"] + args,
-                capture_output=True, text=True, timeout=timeout,
-            )
-        if result.stdout.strip():
-            log.debug("btctl <<< rc=%d stdout=%s", result.returncode,
-                      result.stdout.strip()[:200])
-        if result.stderr.strip():
-            log.debug("btctl <<< stderr=%s", result.stderr.strip()[:200])
-        return result.returncode, result.stdout, result.stderr
-    except FileNotFoundError:
-        log.error("btctl: bluetoothctl not found on system")
-        return -1, "", "bluetoothctl not found"
-    except subprocess.TimeoutExpired:
-        log.warning("btctl: command timed out after %.1fs: %s", timeout, cmd_str)
-        return -2, "", "bluetoothctl timed out"
+    with _btctl_lock:
+        try:
+            if adapter and args and args[0] != "list":
+                stdin_cmds = f"select {adapter}\n" + " ".join(args) + "\nexit\n"
+                result = subprocess.run(
+                    ["bluetoothctl"],
+                    capture_output=True, text=True, timeout=timeout,
+                    input=stdin_cmds,
+                )
+            else:
+                result = subprocess.run(
+                    ["bluetoothctl"] + args,
+                    capture_output=True, text=True, timeout=timeout,
+                )
+            if result.stdout.strip():
+                log.debug("btctl <<< rc=%d stdout=%s", result.returncode,
+                          result.stdout.strip()[:200])
+            if result.stderr.strip():
+                log.debug("btctl <<< stderr=%s", result.stderr.strip()[:200])
+            return result.returncode, result.stdout, result.stderr
+        except FileNotFoundError:
+            log.error("btctl: bluetoothctl not found on system")
+            return -1, "", "bluetoothctl not found"
+        except subprocess.TimeoutExpired:
+            log.warning("btctl: command timed out after %.1fs: %s",
+                        timeout, cmd_str)
+            return -2, "", "bluetoothctl timed out"
 
 
 class BluetoothManager:

--- a/src/multimedia/bluetooth.py
+++ b/src/multimedia/bluetooth.py
@@ -111,6 +111,65 @@ PBAP_PROFILE_PATH = "/org/bluez/bcm_pbap_pce"
 MAP_MCE_UUID = "00001134-0000-1000-8000-00805f9b34fb"
 MAP_PROFILE_PATH = "/org/bluez/bcm_map_mce"
 
+# Explicit SDP service records for PBAP-PCE / MAP-MCE.
+# BlueZ's ProfileManager auto-generates a minimal record from just the
+# UUID, but the auto-generated record is missing the
+# BluetoothProfileDescriptorList — Android only flips on the
+# "share contacts/call history" pairing prompt when it sees a full
+# descriptor list with a recognised version, so we pass an explicit XML
+# blob. PCE/MCE are client-side so no protocol-channel attribute is
+# needed (we don't accept inbound connections), only the UUID list +
+# profile version that Android's SDP scan keys on.
+_PBAP_PCE_SDP = """<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <attribute id="0x0001">
+    <sequence>
+      <uuid value="0x112e"/>
+    </sequence>
+  </attribute>
+  <attribute id="0x0005">
+    <sequence>
+      <uuid value="0x1002"/>
+    </sequence>
+  </attribute>
+  <attribute id="0x0009">
+    <sequence>
+      <sequence>
+        <uuid value="0x1130"/>
+        <uint16 value="0x0102"/>
+      </sequence>
+    </sequence>
+  </attribute>
+  <attribute id="0x0100">
+    <text value="Phonebook Access PCE"/>
+  </attribute>
+</record>"""
+
+_MAP_MCE_SDP = """<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <attribute id="0x0001">
+    <sequence>
+      <uuid value="0x1133"/>
+    </sequence>
+  </attribute>
+  <attribute id="0x0005">
+    <sequence>
+      <uuid value="0x1002"/>
+    </sequence>
+  </attribute>
+  <attribute id="0x0009">
+    <sequence>
+      <sequence>
+        <uuid value="0x1134"/>
+        <uint16 value="0x0104"/>
+      </sequence>
+    </sequence>
+  </attribute>
+  <attribute id="0x0100">
+    <text value="Message Access MCE"/>
+  </attribute>
+</record>"""
+
 
 class _PairingRequest:
     """Holds a pending pairing confirmation request."""
@@ -264,8 +323,15 @@ class _PairingAgent(dbus.service.Object):
 
 
 def _register_bt_profile(bus, path: str, uuid: str, name: str,
-                         role: str = "server") -> bool:
-    """Register a Bluetooth profile with BlueZ ProfileManager1."""
+                         role: str = "server",
+                         service_record: Optional[str] = None) -> bool:
+    """Register a Bluetooth profile with BlueZ ProfileManager1.
+
+    Passing ``service_record`` overrides BlueZ's auto-generated SDP entry.
+    PBAP-PCE / MAP-MCE need this — the auto-generated record is missing
+    the BluetoothProfileDescriptorList that Android's SDP scan keys on
+    to flip the "share contacts/call history" pairing prompt.
+    """
     try:
         profile_mgr = dbus.Interface(
             bus.get_object("org.bluez", "/org/bluez"),
@@ -279,6 +345,8 @@ def _register_bt_profile(bus, path: str, uuid: str, name: str,
             "RequireAuthorization": dbus.Boolean(False),
             "AutoConnect": dbus.Boolean(True),
         }
+        if service_record:
+            opts["ServiceRecord"] = dbus.String(service_record)
 
         profile_mgr.RegisterProfile(
             dbus.ObjectPath(path),
@@ -319,9 +387,11 @@ def _register_all_profiles(bus) -> None:
     in src/multimedia/phonebook.py.
     """
     _register_bt_profile(bus, PBAP_PROFILE_PATH, PBAP_PCE_UUID,
-                         "BCM Phonebook Client", role="client")
+                         "BCM Phonebook Client", role="client",
+                         service_record=_PBAP_PCE_SDP)
     _register_bt_profile(bus, MAP_PROFILE_PATH, MAP_MCE_UUID,
-                         "BCM Message Client", role="client")
+                         "BCM Message Client", role="client",
+                         service_record=_MAP_MCE_SDP)
     log.info("BT profile registration: PBAP-PCE + MAP-MCE; "
              "A2DP/HFP=PipeWire, AA=autoapp")
 

--- a/src/multimedia/wifi_ap.py
+++ b/src/multimedia/wifi_ap.py
@@ -403,6 +403,9 @@ class WiFiAPManager:
                 ["dnsmasq",
                  f"--interface={iface}",
                  "--bind-interfaces",
+                 "--except-interface=lo",
+                 f"--listen-address={net_ip}",
+                 "--port=0",
                  f"--dhcp-range={dhcp_start},{dhcp_end},{netmask},24h",
                  "--no-daemon", "--no-resolv", "--no-hosts"],
                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
@@ -702,13 +705,19 @@ class WiFiAPManager:
                     "dnsmasq",
                     f"--interface={self._interface}",
                     "--bind-interfaces",
+                    "--except-interface=lo",
+                    f"--listen-address={self._ap_ip}",
+                    "--port=0",  # disable DNS server (DHCP only); we
+                                 # don't need to serve names for AA and
+                                 # the systemd-resolved / stub dnsmasq
+                                 # on 127.0.0.1:53 is what was blocking
+                                 # us from starting at all.
                     f"--dhcp-range={dhcp_start},{dhcp_end},{self._netmask},24h",
                     "--no-daemon",
                     "--no-resolv",
                     "--no-hosts",
                     f"--dhcp-leasefile={lease_file}",
                     f"--pid-file={pid_file}",
-                    "--log-queries",
                     "--log-dhcp",
                 ],
                 stdout=subprocess.PIPE,
@@ -809,15 +818,15 @@ class WiFiAPManager:
     # ------------------------------------------------------------------
 
     def _start_p2p_go(self) -> bool:
-        """Bring up the AA WiFi as a Wi-Fi Direct Group Owner on ch149.
+        """Bring up the AA WiFi as a Wi-Fi Direct Group Owner.
 
-        Why this path: the AA Wireless protocol the phone speaks is
-        Wi-Fi Direct internally, and P2P-GO is the only AP-equivalent
-        role iwlwifi 8265 lets us start on 5 GHz under a self-managed
-        regdom (the regular AP role gets ``Frequency NNNN not allowed,
-        flags: NO-IR``). We also rfkill-unblock + force regdom first
-        because the Intel firmware still honors a country hint when
-        choosing which channels it'll *accept* a P2P GO on.
+        Channel is config-driven (``wifi.channel``). The AA Wireless
+        protocol the phone speaks is Wi-Fi Direct internally, so P2P-GO
+        is the natural mode. The Intel 8265 self-managed regdom blocks
+        regular AP role on 5 GHz with NO-IR; P2P-GO sidesteps that on
+        2.4 GHz where the firmware accepts active TX. 5 GHz P2P-GO
+        also FAILs under self-managed country 00 — patch regdb if you
+        need it.
         """
         # Make sure NetworkManager isn't holding the interface — wpa_s
         # P2P refuses to bind otherwise.
@@ -860,14 +869,30 @@ class WiFiAPManager:
         with open(conf_path, "w") as f:
             f.write(wpa_conf)
 
-        # Kill stale wpa_supplicant on this interface so we don't race.
+        # Free the interface. The system wpa_supplicant.service is a
+        # D-Bus daemon with no `-i` flag, so a name-pattern pkill misses
+        # it — but it's the one actually holding wlp2s0 in `type managed`,
+        # which makes p2p_group_add return FAIL. Stop the unit + a broad
+        # pkill, then we restart the unit in _stop_p2p_go so STA mode
+        # works after the AP comes down.
+        self._stopped_system_wpa = False
         try:
-            subprocess.run(["pkill", "-f",
-                            f"wpa_supplicant.*{self._interface}"],
+            r = subprocess.run(
+                ["systemctl", "is-active", "wpa_supplicant.service"],
+                capture_output=True, text=True, timeout=3)
+            if r.stdout.strip() == "active":
+                subprocess.run(
+                    ["systemctl", "stop", "wpa_supplicant.service"],
+                    capture_output=True, timeout=5)
+                self._stopped_system_wpa = True
+        except Exception:
+            pass
+        try:
+            subprocess.run(["pkill", "-f", "wpa_supplicant"],
                            capture_output=True, timeout=3)
         except Exception:
             pass
-        time.sleep(0.5)
+        time.sleep(0.7)
 
         try:
             self._wpa_proc = subprocess.Popen(
@@ -1042,6 +1067,18 @@ class WiFiAPManager:
                 ["nmcli", "device", "set", primary, "managed", "yes"],
                 capture_output=True, timeout=5,
             )
+
+        # If we stopped the system wpa_supplicant.service in _start_p2p_go
+        # to free the iface, bring it back now so the user keeps normal
+        # STA / NM behavior when the AP is off.
+        if getattr(self, "_stopped_system_wpa", False):
+            try:
+                subprocess.run(
+                    ["systemctl", "start", "wpa_supplicant.service"],
+                    capture_output=True, timeout=5)
+            except Exception:
+                pass
+            self._stopped_system_wpa = False
 
     # ------------------------------------------------------------------
     # Secondary "ALFA-NET" internet-sharing AP
@@ -1224,6 +1261,9 @@ class WiFiAPManager:
                 ["dnsmasq",
                  f"--interface={iface}",
                  "--bind-interfaces",
+                 "--except-interface=lo",
+                 f"--listen-address={net_ip}",
+                 "--port=0",
                  f"--dhcp-range={dhcp_start},{dhcp_end},{netmask},24h",
                  "--no-daemon", "--no-resolv", "--no-hosts"],
                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT,


### PR DESCRIPTION
## Summary

- **UI hang root cause** — `settings.js` re-fired `wifiLoad()` on every render, and `wifiLoad()` itself called `App.navigateTo("settings")` on completion. Infinite render→fetch→render at >100 `GET /api/wifi/config` per second, starving the single-threaded Flask of touch POSTs. Fix: 3 s stale gate (mirroring `radioRefresh`) + `threaded=True` on `app.run()`.
- **WiFi mode** — was `hostapd` on ch6; switched to `p2p_go` (WiFi Direct Group Owner) which is the actual mode AA Wireless uses. SSID auto-becomes `DIRECT-XX`, BSSID + PSK exposed to `openauto.ini` so the BT-bootstrap WifiInfoResponse matches the live group. 5 GHz ch149 returns FAIL on the Intel 8265 self-managed regdom (UNII-3 is `IR-CONCURRENT`), so 2.4 GHz is the realistic path until a regdb patch lands.
- **wpa_supplicant.service ate the iface** — D-Bus daemon held `wlp2s0` in `type managed`, blocking `p2p_group_add`. `_start_p2p_go` now `systemctl stop`s it and `_stop_p2p_go` restarts it so STA mode still works when the AP is off.
- **BT Class-of-Device pinning** — bluetoothd resynthesises CoD whenever a media/profile plugin registers, clobbering the `0x620420` carkit class (PipeWire's A2DP/HFP endpoints land ~10 s after our setup script). `_force_carkit_cod()` re-stamps via `hciconfig` after profile registration and again 20 s out.
- **bluetoothctl race** — overlapping subprocesses produced "Waiting to connect to bluetoothd…" with rc=0 but no command actually run, then drove the auto-reconnect verify loop into a fork-storm starving Flask. Serialised through a process-wide `_btctl_lock`.
- **Splash unit cosmetic** — `SuccessExitStatus=0 1 SIGTERM` so the legitimate ExecStop kill doesn't show as `failed`.

## Test plan

- [x] Verified on baremetal x86: `iw dev` shows `type P2P-GO` ssid `DIRECT-M3` ch6
- [x] BT controller: `Class: 0x00620420`, powered, discoverable, pairable
- [x] Flask threaded: 3 parallel curls answered in 1–31 ms
- [x] 0 `wifi/config` requests in 30 s baseline (was hundreds/sec)
- [x] Splash unit transitions to `inactive (dead)` not `failed`
- [ ] Reboot + full AA Wireless pair → connect flow against an Android phone

🤖 Generated with [Claude Code](https://claude.com/claude-code)