### PR TITLE
Add M910q x86 production guide + setup automation

### DIFF
--- a/docs/x86-production/01-bom.html
+++ b/docs/x86-production/01-bom.html
@@ -1,0 +1,842 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>01 — Bill of Materials | BCM x86 Production</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+
+  <!-- Hamburger toggle (mobile) -->
+  <button class="hamburger" aria-label="Toggle navigation" onclick="document.querySelector('.sidebar').classList.toggle('open');document.querySelector('.sidebar-overlay').classList.toggle('active');">&#9776;</button>
+  <div class="sidebar-overlay" onclick="document.querySelector('.sidebar').classList.remove('open');this.classList.remove('active');"></div>
+
+  <!-- Sidebar Navigation -->
+  <aside class="sidebar">
+    <div class="sidebar-header">
+      <div class="logo-text">BCM v8.5</div>
+      <div class="logo-sub">x86 Production Docs</div>
+    </div>
+    <nav>
+      <ul>
+        <li><a class="active" href="01-bom.html"><span class="nav-num">01</span> Bill of Materials</a></li>
+        <li><a href="02-assembly.html"><span class="nav-num">02</span> Physical Assembly</a></li>
+      </ul>
+    </nav>
+  </aside>
+
+  <!-- Main Content -->
+  <main class="content">
+    <div class="content-inner">
+
+      <h1>
+        Bill of Materials
+        <span class="subtitle">Lenovo M910q Tiny — Alfa Romeo 156 Production Build</span>
+      </h1>
+
+      <p>
+        Complete parts list for the BCM v8.5 headunit based on a <strong>used Lenovo ThinkCentre M910q Tiny</strong>
+        (i5-6400T, 8 GB DDR4, 256 GB NVMe). Prices in <strong>PLN</strong>, Q1 2026 estimates from Polish retailers
+        and Allegro/AliExpress.
+      </p>
+
+      <div class="box box-info">
+        <div class="box-title">Why M910q?</div>
+        <p>
+          A used M910q costs 200-400 PLN — cheaper than a new Orange Pi 5 Pro while offering a quad-core
+          Intel i5 with VAAPI hardware decode, 2 DisplayPort outputs, 6 USB 3.0 ports, and NVMe storage.
+          The trade-off: no GPIO (requires Arduino peripherals) and higher power draw (20V / 65W).
+        </p>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           STAGE 1
+           ============================================================ -->
+
+      <h2><span class="badge badge-stage1">Stage 1</span> Core System — Dashboard + Audio + OBD</h2>
+      <p>Estimated cost: <strong>~650 — 1 100 PLN</strong></p>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Component</th>
+              <th>Model / Spec</th>
+              <th>Qty</th>
+              <th>Price (PLN)</th>
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>1</td>
+              <td>Mini PC</td>
+              <td><strong>Lenovo M910q Tiny</strong> (i5-6400T, 8 GB DDR4, 256 GB NVMe) — used</td>
+              <td>1</td>
+              <td>200-400</td>
+              <td>2&times; DisplayPort, 6&times; USB 3.0</td>
+            </tr>
+            <tr>
+              <td>2</td>
+              <td>WiFi + BT dongle</td>
+              <td><strong>Fenvi FU-AX1800</strong> (MT7921, WiFi 6 + BT 5.2)</td>
+              <td>1</td>
+              <td>120-180</td>
+              <td>Replaces Intel 8265 for 5 GHz AP + BT</td>
+            </tr>
+            <tr>
+              <td>3</td>
+              <td>Power converter</td>
+              <td><strong>XL6019</strong> 12 V &rarr; 20 V DC-DC boost, 65 W</td>
+              <td>1</td>
+              <td>15-30</td>
+              <td>M910q uses 20 V barrel jack</td>
+            </tr>
+            <tr>
+              <td>4</td>
+              <td>AGM battery</td>
+              <td>12 V 7.2 Ah sealed lead-acid</td>
+              <td>1</td>
+              <td>50-80</td>
+              <td>Cranking protection + 36 h S3 standby</td>
+            </tr>
+            <tr>
+              <td>5</td>
+              <td>LVD cutoff</td>
+              <td>10.5 V low-voltage disconnect module</td>
+              <td>1</td>
+              <td>15-25</td>
+              <td>Protects AGM from deep discharge</td>
+            </tr>
+            <tr>
+              <td>6</td>
+              <td>Schottky diode</td>
+              <td><strong>MBR2045</strong> (20 A, 45 V)</td>
+              <td>1</td>
+              <td>5-10</td>
+              <td>Prevents AGM backfeed to car battery</td>
+            </tr>
+            <tr>
+              <td>7</td>
+              <td>Fuses</td>
+              <td>5 A blade (M910q) + 25 A blade (amps)</td>
+              <td>2</td>
+              <td>10</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>8</td>
+              <td>Main display</td>
+              <td>7" IPS 1024&times;600 HDMI + USB touch</td>
+              <td>1</td>
+              <td>200-350</td>
+              <td>QDtech MPI5001 or similar</td>
+            </tr>
+            <tr>
+              <td>9</td>
+              <td>Small display</td>
+              <td>4.3" TFT 800&times;480 HDMI (no touch)</td>
+              <td>1</td>
+              <td>150-250</td>
+              <td>Status dashboard</td>
+            </tr>
+            <tr>
+              <td>10</td>
+              <td>DP-to-HDMI adapters</td>
+              <td>Passive DisplayPort to HDMI cables</td>
+              <td>2</td>
+              <td>20-30</td>
+              <td>M910q has 2&times; DP, displays need HDMI</td>
+            </tr>
+            <tr>
+              <td>11</td>
+              <td>USB DAC</td>
+              <td><strong>ES9038Q2M</strong> module</td>
+              <td>1</td>
+              <td>45-75</td>
+              <td>32-bit audio, RCA out</td>
+            </tr>
+            <tr>
+              <td>12</td>
+              <td>Amplifier (main)</td>
+              <td><strong>TDA7388</strong> (4&times;45 W Class AB)</td>
+              <td>1</td>
+              <td>45-70</td>
+              <td>4 car speakers</td>
+            </tr>
+            <tr>
+              <td>13</td>
+              <td>Heatsink</td>
+              <td>Aluminium for TDA7388</td>
+              <td>1</td>
+              <td>10-15</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>14</td>
+              <td>K-Line adapter</td>
+              <td>CP2102 USB-UART + L9637D + 510 &Omega; resistor</td>
+              <td>1</td>
+              <td>25-40</td>
+              <td>ECU communication (Bosch EDC15C7)</td>
+            </tr>
+            <tr>
+              <td>15</td>
+              <td>USB powered hub</td>
+              <td>7-port USB 3.0 powered</td>
+              <td>1</td>
+              <td>40-60</td>
+              <td>All peripherals connect through this</td>
+            </tr>
+            <tr>
+              <td>16</td>
+              <td>Cables</td>
+              <td>2&times; DP-HDMI, USB-A, power, RCA audio</td>
+              <td>&mdash;</td>
+              <td>50-80</td>
+              <td></td>
+            </tr>
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colspan="4"><strong>Stage 1 subtotal</strong></td>
+              <td colspan="2"><strong>~650 — 1 100 PLN</strong></td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           STAGE 2
+           ============================================================ -->
+
+      <h2><span class="badge badge-stage2">Stage 2</span> Cameras (4-way) + Sensors + Dashcam</h2>
+      <p>Estimated cost: <strong>~450 — 800 PLN</strong></p>
+      <p>
+        Same components as the OPi 5 Pro BOM items 14-24. Four AHD cameras with a 4-channel
+        USB grabber, ultrasonic parking sensors, and a USB SSD for dashcam loop recording.
+      </p>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Component</th>
+              <th>Model / Spec</th>
+              <th>Qty</th>
+              <th>Price (PLN)</th>
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>17</td>
+              <td>4-camera set</td>
+              <td>Front / rear / left / right AHD 720p + cables</td>
+              <td>1</td>
+              <td>110-230</td>
+              <td>AliExpress set (promo ~125 PLN)</td>
+            </tr>
+            <tr>
+              <td>18</td>
+              <td>4-ch USB video grabber</td>
+              <td>USB 2.0/3.0 4-channel AHD capture</td>
+              <td>1</td>
+              <td>150-250</td>
+              <td>Presents as 4&times; <code>/dev/videoN</code></td>
+            </tr>
+            <tr>
+              <td>19</td>
+              <td>Parking sensors</td>
+              <td>HC-SR04 ultrasonic</td>
+              <td>4</td>
+              <td>40-60</td>
+              <td>Rear bumper</td>
+            </tr>
+            <tr>
+              <td>20</td>
+              <td>Buzzer</td>
+              <td>Piezo 5 V</td>
+              <td>1</td>
+              <td>5-10</td>
+              <td>Parking warning</td>
+            </tr>
+            <tr>
+              <td>21</td>
+              <td>Temperature sensor</td>
+              <td>DS18B20 waterproof</td>
+              <td>1</td>
+              <td>20-30</td>
+              <td>Under front bumper</td>
+            </tr>
+            <tr>
+              <td>22</td>
+              <td>Optoisolators</td>
+              <td>PC817</td>
+              <td>6</td>
+              <td>12-18</td>
+              <td>Ignition, door, rain, lock, left/right blinker</td>
+            </tr>
+            <tr>
+              <td>23</td>
+              <td>Transistors</td>
+              <td>BC547 kit</td>
+              <td>1</td>
+              <td>5-10</td>
+              <td>Buzzer + backlight drivers</td>
+            </tr>
+            <tr>
+              <td>24</td>
+              <td>MOSFETs</td>
+              <td>IRLZ44N for backlight PWM</td>
+              <td>2</td>
+              <td>5-10</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>25</td>
+              <td>Resistor kit</td>
+              <td>1 k&Omega;, 2 k&Omega;, 4.7 k&Omega;, 10 k&Omega;</td>
+              <td>1</td>
+              <td>10-15</td>
+              <td>Voltage dividers, pull-ups</td>
+            </tr>
+            <tr>
+              <td>26</td>
+              <td>Perfboard + headers</td>
+              <td>For sensor wiring</td>
+              <td>1</td>
+              <td>10-15</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>27</td>
+              <td>USB SSD (dashcam)</td>
+              <td>128 GB USB 3.0</td>
+              <td>1</td>
+              <td>80-150</td>
+              <td>~47 h of loop recording</td>
+            </tr>
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colspan="4"><strong>Stage 2 subtotal</strong></td>
+              <td colspan="2"><strong>~450 — 800 PLN</strong></td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           STAGE 3
+           ============================================================ -->
+
+      <h2><span class="badge badge-stage3">Stage 3</span> Input + Connectivity</h2>
+      <p>Estimated cost: <strong>~260 — 420 PLN</strong></p>
+      <p>Same as OPi 5 Pro BOM items 25-29.</p>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Component</th>
+              <th>Model / Spec</th>
+              <th>Qty</th>
+              <th>Price (PLN)</th>
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>28</td>
+              <td>USB microphone</td>
+              <td>Condenser, ceiling-mount</td>
+              <td>1</td>
+              <td>30-60</td>
+              <td>HFP phone calls</td>
+            </tr>
+            <tr>
+              <td>29</td>
+              <td>Input Arduino</td>
+              <td><strong>Pro Micro</strong> (ATmega32U4)</td>
+              <td>1</td>
+              <td>40-60</td>
+              <td>SWC + rotary encoder</td>
+            </tr>
+            <tr>
+              <td>29a</td>
+              <td>SWC button kits</td>
+              <td>AliExpress round pods (2&times; pods + decoder box)</td>
+              <td>2</td>
+              <td>~80</td>
+              <td>Dual-pod, 24 buttons total, resistor-ladder &rarr; Arduino A0</td>
+            </tr>
+            <tr>
+              <td>30</td>
+              <td>Rotary encoder</td>
+              <td>Panel-mount with push button</td>
+              <td>1</td>
+              <td>10-20</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>31</td>
+              <td>GPS module</td>
+              <td>u-blox NEO-M8N USB</td>
+              <td>1</td>
+              <td>40-80</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>32</td>
+              <td>LTE modem</td>
+              <td>Huawei E3372 HiLink</td>
+              <td>1</td>
+              <td>60-120</td>
+              <td>Optional (for travel planner)</td>
+            </tr>
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colspan="4"><strong>Stage 3 subtotal</strong></td>
+              <td colspan="2"><strong>~260 — 420 PLN</strong></td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           STAGE 4
+           ============================================================ -->
+
+      <h2><span class="badge badge-stage4">Stage 4</span> Subwoofer + Rain Sensor</h2>
+      <p>Estimated cost: <strong>~63 — 102 PLN</strong></p>
+      <p>Same as OPi 5 Pro BOM items 30-33.</p>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Component</th>
+              <th>Model / Spec</th>
+              <th>Qty</th>
+              <th>Price (PLN)</th>
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>33</td>
+              <td>Subwoofer amp</td>
+              <td><strong>TDA2050</strong> (40 W mono Class AB)</td>
+              <td>1</td>
+              <td>20-30</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>34</td>
+              <td>Heatsink (sub)</td>
+              <td>Aluminium</td>
+              <td>1</td>
+              <td>5-10</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>35</td>
+              <td>Rain sensor</td>
+              <td>Digital rain sensor module</td>
+              <td>1</td>
+              <td>30-50</td>
+              <td>Optoisolated input</td>
+            </tr>
+            <tr>
+              <td>36</td>
+              <td>Wiper relay</td>
+              <td>5 V relay module</td>
+              <td>1</td>
+              <td>8-12</td>
+              <td></td>
+            </tr>
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colspan="4"><strong>Stage 4 subtotal</strong></td>
+              <td colspan="2"><strong>~63 — 102 PLN</strong></td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           STAGE 5
+           ============================================================ -->
+
+      <h2><span class="badge badge-stage5">Stage 5</span> Security + Tracking</h2>
+      <p>Estimated cost: <strong>~180 — 285 PLN</strong></p>
+      <p>Same as OPi 5 Pro BOM items 34-43.</p>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Component</th>
+              <th>Model / Spec</th>
+              <th>Qty</th>
+              <th>Price (PLN)</th>
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>37</td>
+              <td>Central lock Arduino</td>
+              <td>Nano / Pro Mini</td>
+              <td>1</td>
+              <td>20-30</td>
+              <td>433 MHz RF + lock relays</td>
+            </tr>
+            <tr>
+              <td>38</td>
+              <td>Relay module</td>
+              <td>10-ch 5 V</td>
+              <td>1</td>
+              <td>40-60</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>39</td>
+              <td>RF receiver</td>
+              <td>RXB6 433 MHz</td>
+              <td>1</td>
+              <td>15-25</td>
+              <td>Key fob</td>
+            </tr>
+            <tr>
+              <td>40</td>
+              <td>Siren</td>
+              <td>12 V piezo 120 dB</td>
+              <td>1</td>
+              <td>25-40</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>41</td>
+              <td>PIR</td>
+              <td>HC-SR501 mini</td>
+              <td>1</td>
+              <td>10-15</td>
+              <td>Cabin motion</td>
+            </tr>
+            <tr>
+              <td>42</td>
+              <td>Shock sensor</td>
+              <td>Piezo vibration</td>
+              <td>1</td>
+              <td>8-12</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>43</td>
+              <td>Accelerometer</td>
+              <td>MPU6050</td>
+              <td>1</td>
+              <td>15-30</td>
+              <td>Crash / tilt detection</td>
+            </tr>
+            <tr>
+              <td>44</td>
+              <td>Backup battery</td>
+              <td>18650 Li-ion 5000 mAh</td>
+              <td>1</td>
+              <td>20-30</td>
+              <td>GPS tracking when off</td>
+            </tr>
+            <tr>
+              <td>45</td>
+              <td>Charger + boost</td>
+              <td>TP4056 + MT3608</td>
+              <td>1</td>
+              <td>18-30</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>46</td>
+              <td>Power relay</td>
+              <td>Switching</td>
+              <td>1</td>
+              <td>8-12</td>
+              <td></td>
+            </tr>
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colspan="4"><strong>Stage 5 subtotal</strong></td>
+              <td colspan="2"><strong>~180 — 285 PLN</strong></td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           COST SUMMARY
+           ============================================================ -->
+
+      <h2>Cost Summary</h2>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Stage</th>
+              <th>What You Get</th>
+              <th>Min (PLN)</th>
+              <th>Max (PLN)</th>
+              <th>Cumulative (PLN)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><span class="badge badge-stage1">1</span></td>
+              <td>Dashboard + Audio + OBD + dual DP + WiFi/BT</td>
+              <td>650</td>
+              <td>1 100</td>
+              <td>650 &ndash; 1 100</td>
+            </tr>
+            <tr>
+              <td><span class="badge badge-stage2">2</span></td>
+              <td>4-way cameras, parking sensors, DS18B20, dashcam</td>
+              <td>450</td>
+              <td>800</td>
+              <td>1 100 &ndash; 1 900</td>
+            </tr>
+            <tr>
+              <td><span class="badge badge-stage3">3</span></td>
+              <td>SWC dual-pod, GPS, LTE modem</td>
+              <td>260</td>
+              <td>420</td>
+              <td>1 360 &ndash; 2 320</td>
+            </tr>
+            <tr>
+              <td><span class="badge badge-stage4">4</span></td>
+              <td>Subwoofer amp + rain sensor</td>
+              <td>63</td>
+              <td>102</td>
+              <td>1 423 &ndash; 2 422</td>
+            </tr>
+            <tr>
+              <td><span class="badge badge-stage5">5</span></td>
+              <td>Alarm, central lock, battery backup</td>
+              <td>180</td>
+              <td>285</td>
+              <td>1 603 &ndash; 2 707</td>
+            </tr>
+          </tbody>
+          <tfoot>
+            <tr class="total-row">
+              <td colspan="2"><strong>Total (all stages)</strong></td>
+              <td><strong>1 603</strong></td>
+              <td><strong>2 707</strong></td>
+              <td><strong>~1 600 &ndash; 2 700 PLN</strong></td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           M910q vs OPi COMPARISON
+           ============================================================ -->
+
+      <h2>M910q vs OPi 5 Pro — Platform Comparison</h2>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Aspect</th>
+              <th>Lenovo M910q (x86)</th>
+              <th>Orange Pi 5 Pro (ARM)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Cost (board only)</td>
+              <td class="winner">200-400 PLN (used)</td>
+              <td class="neutral">350-450 PLN (new)</td>
+            </tr>
+            <tr>
+              <td>CPU</td>
+              <td class="winner">Intel i5-6400T (4C/4T, 2.8 GHz boost)</td>
+              <td class="neutral">RK3588S (8-core ARM, big.LITTLE)</td>
+            </tr>
+            <tr>
+              <td>RAM / Storage</td>
+              <td class="winner">8 GB DDR4 / 256 GB NVMe</td>
+              <td class="neutral">4 GB LPDDR4x / microSD or NVMe</td>
+            </tr>
+            <tr>
+              <td>GPU decode</td>
+              <td class="winner">Intel HD 530 (VAAPI H.264/H.265)</td>
+              <td class="neutral">Mali G610 (V4L2 decode)</td>
+            </tr>
+            <tr>
+              <td>H.264 encode (dashcam)</td>
+              <td class="downside">Software only (x264, CPU-bound)</td>
+              <td class="winner">Hardware H.264 encode (MPP)</td>
+            </tr>
+            <tr>
+              <td>Display outputs</td>
+              <td class="neutral">2&times; DisplayPort (need DP-to-HDMI adapters)</td>
+              <td class="winner">2&times; HDMI native (2.1 + 2.0)</td>
+            </tr>
+            <tr>
+              <td>GPIO</td>
+              <td class="downside">None — requires Arduino peripherals</td>
+              <td class="winner">40-pin header, SPI, I2C, UART</td>
+            </tr>
+            <tr>
+              <td>USB ports</td>
+              <td class="winner">6&times; USB 3.0 + 1&times; USB-C</td>
+              <td class="neutral">2&times; USB 3.0 + 1&times; USB 2.0</td>
+            </tr>
+            <tr>
+              <td>Power</td>
+              <td class="downside">20 V / 65 W (needs 12 V &rarr; 20 V boost)</td>
+              <td class="winner">5 V / 15 W (simple buck from 12 V)</td>
+            </tr>
+            <tr>
+              <td>WiFi / BT</td>
+              <td class="neutral">M.2 slot — swap Intel 8265 for Fenvi FU-AX1800</td>
+              <td class="winner">Built-in WiFi 6 + BT 5.0</td>
+            </tr>
+            <tr>
+              <td>Form factor</td>
+              <td class="neutral">179&times;36.5&times;183 mm (1 litre)</td>
+              <td class="winner">100&times;75&times;20 mm (tiny)</td>
+            </tr>
+            <tr>
+              <td>Software compatibility</td>
+              <td class="winner">Full x86 Debian, all packages</td>
+              <td class="neutral">ARM Debian, some packages need building</td>
+            </tr>
+            <tr>
+              <td>Total BOM (all stages)</td>
+              <td class="winner">~1 600 &ndash; 2 700 PLN</td>
+              <td class="downside">~1 950 &ndash; 3 165 PLN</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="box box-warning">
+        <div class="box-title">Key trade-offs</div>
+        <p>
+          The M910q is <strong>cheaper</strong> and <strong>more powerful</strong> for general compute, but
+          lacks GPIO and requires a 12 V &rarr; 20 V boost converter. It also cannot do hardware H.264 encoding
+          for the dashcam — the CPU handles encoding in software (x264), which works fine on an i5 but uses
+          more power.
+        </p>
+        <p>
+          The OPi 5 Pro is <strong>smaller</strong>, runs on <strong>5 V</strong>, has <strong>native GPIO</strong>,
+          and has <strong>hardware H.264 encode</strong>, but costs more and has fewer USB ports.
+        </p>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           WHERE TO BUY
+           ============================================================ -->
+
+      <h2>Where to Buy (Poland)</h2>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Retailer</th>
+              <th>Best For</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Allegro</td>
+              <td>Used M910q, Arduino boards, displays, used parts</td>
+            </tr>
+            <tr>
+              <td>Botland</td>
+              <td>Arduino, sensors, breakout boards</td>
+            </tr>
+            <tr>
+              <td>Kamami</td>
+              <td>ICs, resistors, transistors, PCBs</td>
+            </tr>
+            <tr>
+              <td>Nettigo</td>
+              <td>Custom kits, breakout modules</td>
+            </tr>
+            <tr>
+              <td>AliExpress</td>
+              <td>4-camera set, USB grabber, bulk sensors, Fenvi WiFi</td>
+            </tr>
+            <tr>
+              <td>Amazon.pl</td>
+              <td>Displays, USB DAC, USB hubs</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           NOT INCLUDED
+           ============================================================ -->
+
+      <h2>Not Included in Prices</h2>
+
+      <ul>
+        <li>4&times; car speakers — reuse existing or ~200-400 PLN</li>
+        <li>1&times; subwoofer driver — ~100-200 PLN</li>
+        <li>12 V automotive wiring + connectors — ~50-100 PLN</li>
+        <li>DIN bracket / 3D-printed mount — ~20-50 PLN</li>
+        <li>SIM card with data plan (for LTE)</li>
+        <li>Labour / installation time</li>
+      </ul>
+
+      <!-- Page Navigation -->
+      <div class="page-nav">
+        <span></span>
+        <a href="02-assembly.html">Physical Assembly &rarr;</a>
+      </div>
+
+      <!-- Footer -->
+      <footer class="page-footer">
+        <span>BCM v8.5 &mdash; x86 Production Documentation</span>
+        <span>Alfa Romeo 156 Headunit Project</span>
+      </footer>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/docs/x86-production/02-assembly.html
+++ b/docs/x86-production/02-assembly.html
@@ -1,0 +1,684 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>02 — Physical Assembly | BCM x86 Production</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+
+  <!-- Hamburger toggle (mobile) -->
+  <button class="hamburger" aria-label="Toggle navigation" onclick="document.querySelector('.sidebar').classList.toggle('open');document.querySelector('.sidebar-overlay').classList.toggle('active');">&#9776;</button>
+  <div class="sidebar-overlay" onclick="document.querySelector('.sidebar').classList.remove('open');this.classList.remove('active');"></div>
+
+  <!-- Sidebar Navigation -->
+  <aside class="sidebar">
+    <div class="sidebar-header">
+      <div class="logo-text">BCM v8.5</div>
+      <div class="logo-sub">x86 Production Docs</div>
+    </div>
+    <nav>
+      <ul>
+        <li><a href="01-bom.html"><span class="nav-num">01</span> Bill of Materials</a></li>
+        <li><a class="active" href="02-assembly.html"><span class="nav-num">02</span> Physical Assembly</a></li>
+      </ul>
+    </nav>
+  </aside>
+
+  <!-- Main Content -->
+  <main class="content">
+    <div class="content-inner">
+
+      <h1>
+        Physical Assembly
+        <span class="subtitle">Lenovo M910q Tiny — Mounting, Power, Cabling</span>
+      </h1>
+
+      <p>
+        Step-by-step guide to physically installing and wiring the M910q-based BCM headunit
+        in an Alfa Romeo 156. Covers dash mounting, power supply chain, USB hub layout,
+        display cabling, audio wiring, and WiFi module installation.
+      </p>
+
+      <div class="box box-warning">
+        <div class="box-title">Safety first</div>
+        <p>
+          Disconnect the car's negative battery terminal before doing any wiring. Use properly rated
+          fuses on all power lines. The M910q draws up to 65 W at 20 V — ensure your DC-DC converter
+          and wiring can handle the current.
+        </p>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           SECTION 1: DASH MOUNTING
+           ============================================================ -->
+
+      <h2 id="dash-mounting">1. Dash Mounting</h2>
+
+      <h3>1.1 M910q Dimensions</h3>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Dimension</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Width</td>
+              <td>179 mm</td>
+            </tr>
+            <tr>
+              <td>Height</td>
+              <td>36.5 mm</td>
+            </tr>
+            <tr>
+              <td>Depth</td>
+              <td>182.9 mm</td>
+            </tr>
+            <tr>
+              <td>Volume</td>
+              <td>~1 litre (Tiny form factor)</td>
+            </tr>
+            <tr>
+              <td>Weight</td>
+              <td>~1.3 kg</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3>1.2 Mount Location Options in Alfa 156</h3>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Location</th>
+              <th>Pros</th>
+              <th>Cons</th>
+              <th>Recommended</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Behind centre console</strong></td>
+              <td>Short cable runs to displays; hidden from view; accessible from cabin</td>
+              <td>Limited airflow; tight fit with HVAC ducting</td>
+              <td class="winner">Yes (primary)</td>
+            </tr>
+            <tr>
+              <td><strong>Under passenger seat</strong></td>
+              <td>Good airflow; easy access; plenty of space</td>
+              <td>Longer cable runs; visible; vulnerable to spills/feet</td>
+              <td class="neutral">Fallback</td>
+            </tr>
+            <tr>
+              <td><strong>Trunk</strong></td>
+              <td>Maximum space; easy access; cool environment</td>
+              <td>Very long cable runs (USB signal loss); latency risk</td>
+              <td class="downside">Not recommended</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3>1.3 Ventilation Requirements</h3>
+
+      <p>
+        The Intel i5-6400T has a 35 W TDP. The M910q's internal fan exhausts through the rear vent
+        grille. Ensure:
+      </p>
+
+      <ul>
+        <li><strong>Rear exhaust:</strong> Leave at least 30 mm clearance behind the unit for hot air to escape.</li>
+        <li><strong>Intake:</strong> The M910q draws air from the bottom/sides. Do not place it on foam or carpet.</li>
+        <li><strong>Ambient temperature:</strong> Summer cabin temperatures can exceed 60 &deg;C when parked.
+            The S3 suspend mode should be configured to kick in when ignition is off — the CPU does not generate
+            heat in S3.</li>
+        <li><strong>Mounting orientation:</strong> Horizontal (logo up) is preferred. Vertical mounting works but
+            may slightly reduce fan efficiency.</li>
+      </ul>
+
+      <div class="box box-info">
+        <div class="box-title">Mounting tips</div>
+        <p>
+          Use industrial Velcro strips (3M Dual Lock) or a custom 3D-printed bracket with M3 standoffs.
+          The M910q has VESA 100 mount holes on its underside. Secure all cables with zip ties to prevent
+          rattling over rough roads.
+        </p>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           SECTION 2: POWER WIRING
+           ============================================================ -->
+
+      <h2 id="power-wiring">2. Power Wiring</h2>
+
+      <h3>2.1 Power Supply Chain</h3>
+
+      <p>
+        The M910q requires <strong>20 V DC</strong> via a barrel jack (not the standard 12 V car supply).
+        An XL6019 boost converter steps up the 12 V rail. An AGM battery buffer provides cranking
+        protection and S3 standby power.
+      </p>
+
+      <pre class="ascii-art"><code>Car 12V ─[25A fuse]─┬─[Schottky diode MBR2045]─ AGM 12V 7.2Ah
+                     │                              │
+                     └───────────┬──────────────────┘
+                                 │
+                    ┌────────────┴────────────┐
+                    │ LVD cutoff (10.5V)      │
+                    └────────────┬────────────┘
+                                 │
+                   ┌─────────────┴────────────┐
+                   │                           │
+             [12V→20V boost]             [20A fuse]
+                   │                           │
+             M910q barrel jack           TDA7388 amp</code></pre>
+
+      <h3>2.2 Component Details</h3>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Component</th>
+              <th>Purpose</th>
+              <th>Rating</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>25 A blade fuse</strong></td>
+              <td>Main feed protection from car battery</td>
+              <td>25 A / 32 V</td>
+            </tr>
+            <tr>
+              <td><strong>Schottky diode MBR2045</strong></td>
+              <td>Prevents AGM backfeed to car battery during cranking</td>
+              <td>20 A / 45 V, 0.5 V drop</td>
+            </tr>
+            <tr>
+              <td><strong>AGM 12 V 7.2 Ah</strong></td>
+              <td>Cranking buffer + S3 standby (~36 h)</td>
+              <td>12 V sealed lead-acid</td>
+            </tr>
+            <tr>
+              <td><strong>LVD cutoff (10.5 V)</strong></td>
+              <td>Disconnects load when AGM drops below 10.5 V to prevent deep discharge</td>
+              <td>10.5 V threshold, 20 A</td>
+            </tr>
+            <tr>
+              <td><strong>XL6019 boost converter</strong></td>
+              <td>Steps 12 V up to 20 V for M910q barrel jack</td>
+              <td>65 W max, adjustable output</td>
+            </tr>
+            <tr>
+              <td><strong>5 A blade fuse</strong></td>
+              <td>M910q input protection (after boost converter)</td>
+              <td>5 A / 32 V</td>
+            </tr>
+            <tr>
+              <td><strong>20 A blade fuse</strong></td>
+              <td>TDA7388 amplifier protection</td>
+              <td>20 A / 32 V</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="box box-danger">
+        <div class="box-title">Boost converter tuning</div>
+        <p>
+          Before connecting the M910q, adjust the XL6019 output to exactly <strong>20.0 V</strong> using
+          a multimeter. The M910q tolerates 19-21 V but will not boot outside that range. Secure the
+          adjustment potentiometer with a drop of nail polish or thread locker to prevent vibration drift.
+        </p>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           SECTION 3: USB HUB LAYOUT
+           ============================================================ -->
+
+      <h2 id="usb-layout">3. USB Hub Layout</h2>
+
+      <p>
+        The M910q has 6&times; USB 3.0 ports and 1&times; USB-C. A powered 7-port USB hub concentrates
+        all peripherals that do not require dedicated bandwidth.
+      </p>
+
+      <pre class="ascii-art"><code>M910q USB ports
+  ├── USB Hub (powered, 7-port)
+  │     ├── Arduino Pro Micro #1 (input: SWC, buttons, doors, sensors)
+  │     ├── Arduino Nano #2 (output: relays, lock, lights, wipers)
+  │     ├── USB GPS (NEO-M8N)
+  │     ├── USB LTE modem (Huawei E3372)
+  │     └── USB microphone
+  ├── USB DAC (ES9038Q2M) → RCA → TDA7388 + TDA2050
+  └── USB 4-ch AHD grabber (cameras)</code></pre>
+
+      <h3>3.1 Port Assignment Rationale</h3>
+
+      <ul>
+        <li>
+          <strong>USB DAC — direct port:</strong> Connects directly to an M910q USB 3.0 port (not through
+          the hub) to avoid audio latency and USB bandwidth contention. The ES9038Q2M is a USB Audio
+          Class 2 device.
+        </li>
+        <li>
+          <strong>4-ch AHD grabber — direct port:</strong> Also connects directly. Four simultaneous
+          720p video streams need sustained USB bandwidth. Sharing a hub would cause frame drops.
+        </li>
+        <li>
+          <strong>Hub peripherals:</strong> Low-bandwidth devices (serial Arduinos, GPS NMEA at 9600 baud,
+          LTE via RNDIS, microphone at 16 kHz mono) share the powered hub without issues.
+        </li>
+      </ul>
+
+      <div class="box box-info">
+        <div class="box-title">USB stability</div>
+        <p>
+          Use <code>udev</code> rules to assign stable device names by USB path (not by kernel enumeration
+          order). The BCM setup script creates rules in <code>/etc/udev/rules.d/99-bcm-usb.rules</code>.
+          This ensures <code>/dev/bcm-dac</code>, <code>/dev/bcm-gps</code>, etc. survive reboots and
+          re-plugging.
+        </p>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           SECTION 4: DISPLAY CABLING
+           ============================================================ -->
+
+      <h2 id="display-cabling">4. Display Cabling</h2>
+
+      <p>
+        The M910q has <strong>2&times; DisplayPort</strong> outputs (mini-DP on some revisions, full-size
+        DP on others). Both car displays use HDMI input, so passive DP-to-HDMI adapter cables are required.
+      </p>
+
+      <h3>4.1 Connections</h3>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>M910q Output</th>
+              <th>Adapter</th>
+              <th>Display</th>
+              <th>Signal</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>DP port 1</td>
+              <td>DP-to-HDMI passive cable</td>
+              <td><strong>7" IPS touchscreen</strong> (1024&times;600)</td>
+              <td>HDMI video + USB touch (separate USB cable)</td>
+            </tr>
+            <tr>
+              <td>DP port 2</td>
+              <td>DP-to-HDMI passive cable</td>
+              <td><strong>4.3" TFT status display</strong> (800&times;480)</td>
+              <td>HDMI video only (no touch)</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3>4.2 Connector Naming</h3>
+
+      <p>
+        After the DP-to-HDMI adapters, the OS sees HDMI outputs. Connector names differ between
+        tools:
+      </p>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Tool</th>
+              <th>Main Display (7")</th>
+              <th>Status Display (4.3")</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>xrandr</code></td>
+              <td><code>HDMI-1</code></td>
+              <td><code>HDMI-2</code></td>
+            </tr>
+            <tr>
+              <td>DRM / KMS</td>
+              <td><code>HDMI-A-1</code></td>
+              <td><code>HDMI-A-2</code></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="box box-info">
+        <div class="box-title">Verify connector names</div>
+        <p>
+          After the OS is installed and both displays are connected, run:
+        </p>
+        <pre><code>for f in /sys/class/drm/card*-*/status; do echo "$f: $(cat $f)"; done</code></pre>
+        <p>
+          This shows which DRM connectors are active. Update the BCM config
+          (<code>/opt/bcm/config/displays.conf</code>) to match your actual connector names.
+        </p>
+      </div>
+
+      <h3>4.3 Touchscreen USB</h3>
+
+      <p>
+        The 7" touchscreen requires a separate USB cable for its touch digitizer. This connects to the
+        M910q via the powered USB hub. The touch input is an HID device and appears as
+        <code>/dev/input/eventN</code>. Map it to the correct display output using:
+      </p>
+
+      <pre><code>xinput map-to-output "WaveShare WaveShare" HDMI-1</code></pre>
+
+      <hr>
+
+      <!-- ============================================================
+           SECTION 5: AUDIO WIRING
+           ============================================================ -->
+
+      <h2 id="audio-wiring">5. Audio Wiring</h2>
+
+      <h3>5.1 Signal Chain</h3>
+
+      <pre class="ascii-art"><code>M910q USB 3.0 port
+       │
+  ES9038Q2M USB DAC
+       │
+   RCA stereo out
+       │
+  ┌────┴─────────────────────────┐
+  │                               │
+  │  TDA7388 (4×45W)              │  TDA2050 (40W mono)
+  │  Class AB amplifier           │  Subwoofer amplifier
+  │                               │  (optional, Stage 4)
+  ├──── FL speaker                │
+  ├──── FR speaker                └──── Subwoofer
+  ├──── RL speaker
+  └──── RR speaker</code></pre>
+
+      <h3>5.2 Wiring Details</h3>
+
+      <ul>
+        <li>
+          <strong>USB DAC &rarr; RCA:</strong> The ES9038Q2M outputs line-level stereo via RCA jacks
+          (red/white). Use shielded RCA cables to avoid alternator whine.
+        </li>
+        <li>
+          <strong>TDA7388 input:</strong> RCA stereo in. The TDA7388 has 4 channels — front pair driven
+          directly from left/right, rear pair wired in parallel (same signal) or via a balance control.
+        </li>
+        <li>
+          <strong>TDA7388 outputs:</strong> 4 pairs of speaker wires to the car's existing speaker harness.
+          Use the Alfa 156 ISO connector pinout:
+        </li>
+      </ul>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Channel</th>
+              <th>TDA7388 Output</th>
+              <th>Speaker Location</th>
+              <th>Wire Colour (Alfa 156)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>CH1</td>
+              <td>OUT1+/OUT1&minus;</td>
+              <td>Front Left</td>
+              <td>White / White-Black</td>
+            </tr>
+            <tr>
+              <td>CH2</td>
+              <td>OUT2+/OUT2&minus;</td>
+              <td>Front Right</td>
+              <td>Grey / Grey-Black</td>
+            </tr>
+            <tr>
+              <td>CH3</td>
+              <td>OUT3+/OUT3&minus;</td>
+              <td>Rear Left</td>
+              <td>Green / Green-Black</td>
+            </tr>
+            <tr>
+              <td>CH4</td>
+              <td>OUT4+/OUT4&minus;</td>
+              <td>Rear Right</td>
+              <td>Violet / Violet-Black</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3>5.3 Subwoofer (Optional — Stage 4)</h3>
+
+      <ul>
+        <li>The TDA2050 takes the same RCA input as the TDA7388 (Y-splitter).</li>
+        <li>A passive low-pass filter (capacitor + resistor) at the TDA2050 input cuts frequencies above ~120 Hz.</li>
+        <li>Output drives a single 8 &Omega; or 4 &Omega; subwoofer driver.</li>
+      </ul>
+
+      <div class="box box-warning">
+        <div class="box-title">Ground loops</div>
+        <p>
+          To avoid alternator whine in the audio, ensure the USB DAC, amplifiers, and M910q share a
+          single ground point on the car chassis. Do not use separate ground connections. Use a ground
+          loop isolator on the RCA cable if whine persists.
+        </p>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           SECTION 6: FENVI FU-AX1800 INSTALLATION
+           ============================================================ -->
+
+      <h2 id="wifi-install">6. Fenvi FU-AX1800 Installation</h2>
+
+      <p>
+        The M910q ships with an Intel 8265 WiFi/BT card in its M.2 Key E slot. For reliable 5 GHz
+        AP mode (required by wireless Android Auto), replace it with the <strong>Fenvi FU-AX1800</strong>
+        (MediaTek MT7921, WiFi 6 + BT 5.2).
+      </p>
+
+      <h3>6.1 Swap Procedure</h3>
+
+      <ol>
+        <li>Power off the M910q and unplug all cables.</li>
+        <li>Remove the top cover (slide latch at rear, lift off).</li>
+        <li>Locate the M.2 Key E slot — it is near the front-left of the motherboard, under the WiFi
+            antenna cables.</li>
+        <li>Disconnect the two IPEX/U.FL antenna pigtails from the Intel 8265 card. Use a plastic spudger
+            or fingernails — do not use metal tools on the connectors.</li>
+        <li>Remove the single M2&times;3 screw holding the Intel 8265 card.</li>
+        <li>Slide the Intel 8265 out at a 30&deg; angle.</li>
+        <li>Insert the Fenvi FU-AX1800 into the M.2 Key E slot at the same 30&deg; angle, then press
+            flat and secure with the screw.</li>
+        <li>Connect both IPEX/U.FL antenna pigtails to the Fenvi card. Press until they click.</li>
+        <li>Replace the top cover.</li>
+      </ol>
+
+      <h3>6.2 Antenna Placement</h3>
+
+      <ul>
+        <li>The M910q's built-in antennas are wired to the rear panel. These work fine for WiFi client
+            mode but may be suboptimal for AP mode with a phone in the cabin.</li>
+        <li>For better reception: route external antenna pigtails (IPEX to RP-SMA) out of the M910q case
+            and place the antennas near the <strong>windshield</strong> (best line-of-sight to phone).</li>
+        <li>Use two antennas (2&times;2 MIMO) — the Fenvi FU-AX1800 has two IPEX connectors.</li>
+        <li>Keep antennas at least 20 cm apart for spatial diversity.</li>
+      </ul>
+
+      <h3>6.3 Driver Support</h3>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Chipset</th>
+              <th>Linux Driver</th>
+              <th>Kernel Version</th>
+              <th>AP Mode</th>
+              <th>BT</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>MediaTek MT7921</td>
+              <td><code>mt7921e</code> (in-tree)</td>
+              <td>5.12+</td>
+              <td class="winner">Yes (5 GHz, non-DFS)</td>
+              <td class="winner">BT 5.2 via <code>btusb</code></td>
+            </tr>
+            <tr>
+              <td>Intel 8265 (original)</td>
+              <td><code>iwlwifi</code> (in-tree)</td>
+              <td>4.6+</td>
+              <td class="downside">Limited (single channel, some firmware issues)</td>
+              <td class="neutral">BT 4.2 via <code>btusb</code></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="box box-success">
+        <div class="box-title">Verification</div>
+        <p>After booting with the Fenvi card installed, verify detection:</p>
+        <pre><code>lspci | grep -i network
+# Expected: MediaTek Inc. MT7921 802.11ax PCI Express Wireless Network Adapter
+
+iw list | grep -A2 "Supported interface modes"
+# Should include: AP</code></pre>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           SECTION 7: ASSEMBLY CHECKLIST
+           ============================================================ -->
+
+      <h2 id="checklist">7. Assembly Checklist</h2>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Step</th>
+              <th>Task</th>
+              <th>Verify</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>1</td>
+              <td>Swap Intel 8265 for Fenvi FU-AX1800</td>
+              <td><code>lspci</code> shows MT7921</td>
+            </tr>
+            <tr>
+              <td>2</td>
+              <td>Tune XL6019 output to 20.0 V with multimeter</td>
+              <td>Measure at barrel jack connector</td>
+            </tr>
+            <tr>
+              <td>3</td>
+              <td>Wire AGM battery, Schottky diode, LVD module</td>
+              <td>12 V present after LVD at rest</td>
+            </tr>
+            <tr>
+              <td>4</td>
+              <td>Connect M910q barrel jack to boost converter output</td>
+              <td>M910q power LED lights</td>
+            </tr>
+            <tr>
+              <td>5</td>
+              <td>Connect DP port 1 &rarr; DP-to-HDMI &rarr; 7" touchscreen</td>
+              <td>Display shows BIOS/GRUB</td>
+            </tr>
+            <tr>
+              <td>6</td>
+              <td>Connect DP port 2 &rarr; DP-to-HDMI &rarr; 4.3" display</td>
+              <td>Second display mirrors or extends</td>
+            </tr>
+            <tr>
+              <td>7</td>
+              <td>Connect 7" touchscreen USB cable to hub</td>
+              <td>Touch input registers in <code>xinput list</code></td>
+            </tr>
+            <tr>
+              <td>8</td>
+              <td>Connect USB DAC to direct M910q USB port</td>
+              <td><code>aplay -l</code> shows ES9038Q2M</td>
+            </tr>
+            <tr>
+              <td>9</td>
+              <td>Wire USB DAC RCA &rarr; TDA7388 input</td>
+              <td>Test tone audible on all 4 speakers</td>
+            </tr>
+            <tr>
+              <td>10</td>
+              <td>Connect USB hub + all peripherals</td>
+              <td><code>lsusb</code> shows all devices</td>
+            </tr>
+            <tr>
+              <td>11</td>
+              <td>Connect 4-ch AHD grabber to direct M910q USB port</td>
+              <td><code>v4l2-ctl --list-devices</code> shows 4 inputs</td>
+            </tr>
+            <tr>
+              <td>12</td>
+              <td>Mount M910q in chosen location, secure cables</td>
+              <td>No rattling, rear vent unobstructed</td>
+            </tr>
+            <tr>
+              <td>13</td>
+              <td>Install fuses (5 A for M910q, 25 A for main feed)</td>
+              <td>Fuses accessible for replacement</td>
+            </tr>
+            <tr>
+              <td>14</td>
+              <td>Route antenna pigtails near windshield</td>
+              <td>WiFi signal test with phone at driver seat</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Page Navigation -->
+      <div class="page-nav">
+        <a href="01-bom.html">&larr; Bill of Materials</a>
+        <span></span>
+      </div>
+
+      <!-- Footer -->
+      <footer class="page-footer">
+        <span>BCM v8.5 &mdash; x86 Production Documentation</span>
+        <span>Alfa Romeo 156 Headunit Project</span>
+      </footer>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/docs/x86-production/03-os-install.html
+++ b/docs/x86-production/03-os-install.html
@@ -1,0 +1,510 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>03 — OS Installation | BCM x86 Production</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+
+  <!-- Hamburger toggle (mobile only) -->
+  <button class="hamburger" aria-label="Toggle navigation" onclick="toggleSidebar()">&#9776;</button>
+
+  <!-- Overlay behind sidebar on mobile -->
+  <div class="sidebar-overlay" onclick="toggleSidebar()"></div>
+
+  <!-- ======== Sidebar Navigation ======== -->
+  <aside class="sidebar">
+    <div class="sidebar-header">
+      <div class="logo-text">BCM v8.5</div>
+      <div class="logo-sub">Lenovo M910q &middot; Alfa 156</div>
+    </div>
+    <nav aria-label="Documentation pages">
+      <ul>
+        <li><a href="index.html"><span class="nav-num"></span>Overview</a></li>
+        <li><a href="01-bom.html"><span class="nav-num">01</span>Bill of Materials</a></li>
+        <li><a href="02-power.html"><span class="nav-num">02</span>Power Supply</a></li>
+        <li><a href="03-os-install.html" class="active"><span class="nav-num">03</span>OS Installation</a></li>
+        <li><a href="04-packages.html"><span class="nav-num">04</span>System Packages</a></li>
+        <li><a href="05-bcm-install.html"><span class="nav-num">05</span>BCM Installation</a></li>
+        <li><a href="06-systemd.html"><span class="nav-num">06</span>Systemd Services</a></li>
+        <li><a href="07-boot.html"><span class="nav-num">07</span>Boot &amp; Splash</a></li>
+        <li><a href="08-kiosk.html"><span class="nav-num">08</span>Kiosk Display</a></li>
+        <li><a href="09-suspend.html"><span class="nav-num">09</span>Suspend / Wake</a></li>
+        <li><a href="10-wifi.html"><span class="nav-num">10</span>WiFi &amp; Android Auto</a></li>
+        <li><a href="11-arduino.html"><span class="nav-num">11</span>Arduino Wiring</a></li>
+        <li><a href="12-verification.html"><span class="nav-num">12</span>Verification</a></li>
+      </ul>
+    </nav>
+  </aside>
+
+  <!-- ======== Main Content ======== -->
+  <div class="content">
+    <div class="content-inner">
+
+      <header>
+        <h1>
+          OS Installation
+          <span class="subtitle">Debian 13 (Trixie) on Lenovo M910q &mdash; minimal server install with driver setup</span>
+        </h1>
+      </header>
+
+      <article>
+
+        <!-- ---- BIOS Settings ---- -->
+        <section>
+          <h2>BIOS Settings</h2>
+
+          <p>
+            Before installing, configure the M910q BIOS for headless automotive operation.
+            Press <strong>F1</strong> at the Lenovo splash screen to enter BIOS Setup.
+          </p>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Menu Path</th>
+                  <th>Setting</th>
+                  <th>Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Startup &rarr; Boot Priority</td>
+                  <td>Primary Boot Sequence</td>
+                  <td><strong>USB HDD</strong> first (for installation)</td>
+                </tr>
+                <tr>
+                  <td>Security &rarr; Secure Boot</td>
+                  <td>Secure Boot</td>
+                  <td><strong>Disabled</strong></td>
+                </tr>
+                <tr>
+                  <td>Power &rarr; After Power Loss</td>
+                  <td>After Power Loss</td>
+                  <td><strong>Power On</strong></td>
+                </tr>
+                <tr>
+                  <td>Devices &rarr; USB Setup</td>
+                  <td>USB Legacy Support</td>
+                  <td><strong>Disabled</strong></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="box box-info">
+            <div class="box-title">After Power Loss = Power On</div>
+            <p>
+              This setting is critical for automotive use. When the 12 V &rarr; 20 V converter
+              supplies power (ignition on), the M910q will boot automatically without pressing
+              the power button. Combined with ACPI suspend, this gives seamless ignition-based
+              start/stop behaviour.
+            </p>
+          </div>
+
+          <div class="box box-warning">
+            <div class="box-title">Disable Secure Boot</div>
+            <p>
+              Secure Boot must be disabled to allow unsigned kernel modules (e.g. out-of-tree
+              WiFi drivers) and to avoid boot issues with the minimal Debian installation.
+              The M910q will be running in a closed automotive environment, so Secure Boot
+              provides no practical benefit.
+            </p>
+          </div>
+        </section>
+
+        <!-- ---- Install Debian 13 ---- -->
+        <section>
+          <h2>Install Debian 13 (Trixie)</h2>
+
+          <h3>Prepare Installation Media</h3>
+          <p>
+            Download the <strong>netinst amd64</strong> ISO from
+            <code>https://www.debian.org/devel/debian-installer/</code> (Trixie).
+            Write it to a USB drive:
+          </p>
+
+          <pre><code># From a Linux workstation:
+sudo dd if=debian-13-amd64-netinst.iso of=/dev/sdX bs=4M status=progress conv=fsync
+
+# Or use Rufus / Etcher on Windows/macOS</code></pre>
+
+          <p>
+            Plug the USB drive into the M910q and boot. The installer should launch
+            automatically if USB boot priority was set in BIOS.
+          </p>
+
+          <h3>Partitioning</h3>
+          <p>
+            Use <strong>manual partitioning</strong> with the following layout on the NVMe SSD:
+          </p>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Partition</th>
+                  <th>Size</th>
+                  <th>Type / Mount</th>
+                  <th>Purpose</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>ESP</td>
+                  <td>512 MB &ndash; 1 GB</td>
+                  <td>EFI System Partition (<code>/boot/efi</code>)</td>
+                  <td>UEFI bootloader, GRUB</td>
+                </tr>
+                <tr>
+                  <td>Root</td>
+                  <td>Remaining space</td>
+                  <td>ext4 (<code>/</code>)</td>
+                  <td>OS, BCM application, dashcam recordings</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="box box-info">
+            <div class="box-title">No swap partition</div>
+            <p>
+              Do not create a swap partition. The M910q has 8 GB RAM which is more than
+              sufficient. We will configure <strong>zram</strong> (compressed RAM swap)
+              post-install, which is faster than disk swap and avoids unnecessary SSD writes
+              that reduce NVMe lifespan.
+            </p>
+          </div>
+
+          <h3>Software Selection</h3>
+          <p>
+            At the <em>Software selection</em> screen (tasksel), <strong>uncheck everything</strong>
+            except:
+          </p>
+          <ul>
+            <li><strong>SSH server</strong> &mdash; for remote access during setup</li>
+            <li><strong>standard system utilities</strong> &mdash; basic CLI tools</li>
+          </ul>
+
+          <div class="box box-warning">
+            <div class="box-title">No desktop environment</div>
+            <p>
+              Do <strong>not</strong> install GNOME, KDE, Xfce, or any desktop environment.
+              BCM uses a minimal X11 session with <code>matchbox-window-manager</code> and
+              Chromium in kiosk mode. A full desktop environment wastes RAM, slows boot,
+              and interferes with the kiosk setup described in
+              <a href="08-kiosk.html">08 &mdash; Kiosk Display</a>.
+            </p>
+          </div>
+        </section>
+
+        <!-- ---- Post-install ---- -->
+        <section>
+          <h2>Post-install Setup</h2>
+
+          <p>
+            After the first boot, log in as the regular user and configure <code>sudo</code>
+            access and non-free firmware repositories.
+          </p>
+
+          <h3>Enable sudo</h3>
+          <pre><code># Switch to root
+su -
+
+# Install sudo and add user to sudo group
+apt install -y sudo
+usermod -aG sudo abner
+
+# Exit root shell
+exit
+
+# Log out and back in for group membership to take effect</code></pre>
+
+          <h3>Enable Non-free Firmware</h3>
+          <pre><code># Add contrib, non-free, and non-free-firmware to apt sources
+grep non-free /etc/apt/sources.list || \
+    sudo sed -i 's/main$/main contrib non-free non-free-firmware/' /etc/apt/sources.list
+
+sudo apt update</code></pre>
+
+          <div class="box box-info">
+            <div class="box-title">Why non-free-firmware?</div>
+            <p>
+              The Intel GPU (i915), WiFi (iwlwifi or mt7921), and Bluetooth adapters all
+              require binary firmware blobs from the <code>non-free-firmware</code> repository.
+              Without this, VAAPI hardware decode, WiFi AP mode, and Bluetooth will not function.
+            </p>
+          </div>
+        </section>
+
+        <!-- ---- Static IP ---- -->
+        <section>
+          <h2>Static IP (Optional)</h2>
+
+          <p>
+            If connecting the M910q to a workshop network for remote setup via SSH, a static
+            IP avoids DHCP lookup delays and makes the machine easier to find.
+          </p>
+
+          <pre><code>sudo tee /etc/network/interfaces.d/static >/dev/null &lt;&lt;EOF
+auto enp0s31f6
+iface enp0s31f6 inet static
+    address 192.168.1.100
+    netmask 255.255.255.0
+    gateway 192.168.1.1
+    dns-nameservers 8.8.8.8 1.1.1.1
+EOF
+
+sudo systemctl restart networking</code></pre>
+
+          <div class="box box-info">
+            <div class="box-title">Interface name</div>
+            <p>
+              The M910q's built-in Intel I219-LM Ethernet typically appears as
+              <code>enp0s31f6</code>. Verify with <code>ip link show</code> and adjust the
+              config if your interface name differs.
+            </p>
+          </div>
+        </section>
+
+        <!-- ---- System Packages ---- -->
+        <section>
+          <h2>System Packages</h2>
+
+          <p>
+            Install all required packages in a single <code>apt install</code> command.
+            This covers the display server, kiosk browser, GPU drivers, audio stack, WiFi/BT
+            firmware, camera tools, and system utilities.
+          </p>
+
+          <pre><code>sudo apt install -y \
+    python3 python3-venv python3-full python3-dev python3-serial \
+    git curl wget \
+    xserver-xorg xinit x11-xserver-utils xinput xdotool xvfb \
+    matchbox-window-manager unclutter chromium \
+    intel-media-va-driver vainfo libva-drm2 \
+    pipewire pipewire-pulse wireplumber alsa-utils mpv \
+    firmware-mediatek bluez bluez-tools network-manager \
+    hostapd dnsmasq iw wireless-tools \
+    ffmpeg v4l-utils \
+    acpid \
+    zram-tools fonts-dejavu-core</code></pre>
+
+          <h3>Package Groups Explained</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Category</th>
+                  <th>Packages</th>
+                  <th>Purpose</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Core / Python</td>
+                  <td><code>python3 python3-venv python3-full python3-dev python3-serial git curl wget</code></td>
+                  <td>BCM application runtime, serial Arduino communication, file downloads</td>
+                </tr>
+                <tr>
+                  <td>Display / Kiosk</td>
+                  <td><code>xserver-xorg xinit x11-xserver-utils xinput xdotool xvfb matchbox-window-manager unclutter chromium</code></td>
+                  <td>Minimal X11 session, kiosk browser, cursor hiding, touch input</td>
+                </tr>
+                <tr>
+                  <td>Intel GPU</td>
+                  <td><code>intel-media-va-driver vainfo libva-drm2</code></td>
+                  <td>VAAPI hardware video decode (H.264/H.265) on Intel HD 530</td>
+                </tr>
+                <tr>
+                  <td>Audio</td>
+                  <td><code>pipewire pipewire-pulse wireplumber alsa-utils mpv</code></td>
+                  <td>PipeWire audio stack, ALSA utilities, media playback</td>
+                </tr>
+                <tr>
+                  <td>WiFi / Bluetooth</td>
+                  <td><code>firmware-mediatek bluez bluez-tools network-manager hostapd dnsmasq iw wireless-tools</code></td>
+                  <td>MT7921 firmware, BT stack, WiFi AP for Android Auto</td>
+                </tr>
+                <tr>
+                  <td>Camera / Video</td>
+                  <td><code>ffmpeg v4l-utils</code></td>
+                  <td>Camera capture, video transcoding, V4L2 device management</td>
+                </tr>
+                <tr>
+                  <td>Power</td>
+                  <td><code>acpid</code></td>
+                  <td>ACPI event handling for power button and lid/suspend events</td>
+                </tr>
+                <tr>
+                  <td>Misc</td>
+                  <td><code>zram-tools fonts-dejavu-core</code></td>
+                  <td>Compressed RAM swap, fallback font for Chromium rendering</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <!-- ---- Fenvi WiFi Driver ---- -->
+        <section>
+          <h2>Fenvi FU-AX1800 Driver Setup</h2>
+
+          <p>
+            If you upgraded the M910q's WiFi card to the <strong>Fenvi FU-AX1800</strong>
+            (MediaTek MT7921 chipset), the <code>firmware-mediatek</code> package installed
+            above provides the required firmware. No out-of-tree driver compilation is needed
+            &mdash; the <code>mt7921e</code> kernel module is included in the Debian 13 kernel.
+          </p>
+
+          <h3>Verify MT7921 Detection</h3>
+          <pre><code># Check that the card is detected on the PCI bus
+lspci | grep -i mediatek
+# Expected output:
+#   Network controller: MEDIATEK Corp. MT7921 802.11ax PCI Express Wireless Network Adapter</code></pre>
+
+          <h3>Blacklist Intel WiFi (if present)</h3>
+          <p>
+            If the original Intel 8265 card is still installed in the M.2 slot alongside the
+            Fenvi (e.g. via an adapter), blacklist its driver to avoid interface conflicts:
+          </p>
+
+          <pre><code># Prevent iwlwifi from loading
+echo "blacklist iwlwifi" | sudo tee /etc/modprobe.d/blacklist-intel-wifi.conf</code></pre>
+
+          <h3>Verify WiFi Interface</h3>
+          <pre><code># Confirm the wireless interface is up
+ip link show | grep wl
+# Should show a wlp* interface (e.g. wlp1s0 or wlp2s0)</code></pre>
+
+          <div class="box box-warning">
+            <div class="box-title">Only one M.2 E-key slot</div>
+            <p>
+              The M910q has a single M.2 E-key slot for WiFi. If you install the Fenvi
+              FU-AX1800, it <strong>replaces</strong> the Intel 8265 &mdash; you cannot have
+              both installed simultaneously without an external USB adapter. Remove the Intel
+              card before inserting the Fenvi.
+            </p>
+          </div>
+        </section>
+
+        <!-- ---- zram Setup ---- -->
+        <section>
+          <h2>zram Setup</h2>
+
+          <p>
+            Configure zram to provide compressed in-memory swap. This is faster than SSD
+            swap and eliminates unnecessary NVMe write wear. With 8 GB RAM and lz4
+            compression at 50%, this provides approximately 4 GB of effective swap space.
+          </p>
+
+          <pre><code># Configure zram: lz4 compression, 50% of RAM
+echo -e 'ALGO=lz4\nPERCENT=50' | sudo tee /etc/default/zramswap
+
+# Enable zramswap service
+sudo systemctl enable zramswap</code></pre>
+
+          <div class="box box-info">
+            <div class="box-title">Why lz4?</div>
+            <p>
+              The lz4 algorithm offers the best decompression speed of any available option.
+              For swap, decompression speed matters more than compression ratio since reads
+              (page-ins) are latency-critical. With an i5-6400T, lz4 swap access is nearly
+              as fast as uncompressed RAM.
+            </p>
+          </div>
+        </section>
+
+        <!-- ---- Verify VAAPI ---- -->
+        <section>
+          <h2>Verify VAAPI</h2>
+
+          <p>
+            After installing all packages and rebooting, verify that hardware video
+            acceleration is working correctly on the Intel HD 530 GPU.
+          </p>
+
+          <pre><code># Reboot to load all drivers and firmware
+sudo reboot</code></pre>
+
+          <p>After reboot, run:</p>
+
+          <pre><code># Check VAAPI driver and supported profiles
+vainfo</code></pre>
+
+          <p>Expected output should include lines like:</p>
+
+          <pre><code>vainfo: VA-API version: 1.xx
+vainfo: Driver version: Intel iHD driver - x.x.x
+vainfo: Supported profile and entrypoints
+      VAProfileH264Main               : VAEntrypointVLD
+      VAProfileH264High               : VAEntrypointVLD
+      VAProfileH264ConstrainedBaseline: VAEntrypointVLD
+      VAProfileHEVCMain               : VAEntrypointVLD
+      ...</code></pre>
+
+          <div class="box box-info">
+            <div class="box-title">VAProfileH264 is the key entry</div>
+            <p>
+              BCM's camera feeds and dashcam recordings use H.264. As long as
+              <code>VAProfileH264Main</code> and <code>VAProfileH264High</code> appear
+              with <code>VAEntrypointVLD</code> (decode), hardware-accelerated video
+              playback will work. HEVC (H.265) support is a bonus for future use.
+            </p>
+          </div>
+
+          <div class="box box-warning">
+            <div class="box-title">vainfo fails or shows no profiles?</div>
+            <p>
+              If <code>vainfo</code> returns an error or shows no profiles, check that:
+              (1) <code>intel-media-va-driver</code> is installed,
+              (2) <code>non-free-firmware</code> is in your apt sources (the i915 firmware
+              is needed), and
+              (3) you rebooted after installation. Run
+              <code>sudo apt install --reinstall intel-media-va-driver</code> and reboot
+              if issues persist.
+            </p>
+          </div>
+        </section>
+
+      </article>
+
+      <!-- ---- Page Navigation ---- -->
+      <div class="page-nav">
+        <a href="02-power.html">&larr; 02 &mdash; Power Supply</a>
+        <a href="04-packages.html">04 &mdash; System Packages &rarr;</a>
+      </div>
+
+      <!-- ---- Footer ---- -->
+      <footer class="page-footer">
+        <span>BCM v8.5 &mdash; Alfa Romeo 156 Headunit</span>
+        <span>Lenovo M910q x86 Production Build</span>
+      </footer>
+
+    </div>
+  </div>
+
+  <!-- ======== Sidebar Toggle Script ======== -->
+  <script>
+    function toggleSidebar() {
+      document.querySelector('.sidebar').classList.toggle('open');
+      document.querySelector('.sidebar-overlay').classList.toggle('active');
+    }
+
+    // Close sidebar when a nav link is clicked (mobile)
+    document.querySelectorAll('.sidebar nav a').forEach(function(link) {
+      link.addEventListener('click', function() {
+        if (window.innerWidth < 768) {
+          document.querySelector('.sidebar').classList.remove('open');
+          document.querySelector('.sidebar-overlay').classList.remove('active');
+        }
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/docs/x86-production/04-software.html
+++ b/docs/x86-production/04-software.html
@@ -1,0 +1,513 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>04 — BCM Software | BCM x86 Production</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+
+  <!-- Hamburger toggle (mobile) -->
+  <button class="hamburger" aria-label="Toggle navigation" onclick="document.querySelector('.sidebar').classList.toggle('open');document.querySelector('.sidebar-overlay').classList.toggle('active');">&#9776;</button>
+  <div class="sidebar-overlay" onclick="document.querySelector('.sidebar').classList.remove('open');this.classList.remove('active');"></div>
+
+  <!-- Sidebar Navigation -->
+  <aside class="sidebar">
+    <div class="sidebar-header">
+      <div class="logo-text">BCM v8.5</div>
+      <div class="logo-sub">x86 Production Docs</div>
+    </div>
+    <nav aria-label="Documentation pages">
+      <ul>
+        <li><a href="index.html"><span class="nav-num"></span>Overview</a></li>
+        <li><a href="01-bom.html"><span class="nav-num">01</span>Bill of Materials</a></li>
+        <li><a href="02-power.html"><span class="nav-num">02</span>Power Supply</a></li>
+        <li><a href="03-os-install.html"><span class="nav-num">03</span>OS Installation</a></li>
+        <li><a href="04-packages.html"><span class="nav-num">04</span>System Packages</a></li>
+        <li><a href="05-bcm-install.html"><span class="nav-num">05</span>BCM Installation</a></li>
+        <li><a href="06-systemd.html"><span class="nav-num">06</span>Systemd Services</a></li>
+        <li><a href="07-boot.html"><span class="nav-num">07</span>Boot &amp; Splash</a></li>
+        <li><a href="08-kiosk.html"><span class="nav-num">08</span>Kiosk Display</a></li>
+        <li><a href="09-suspend.html"><span class="nav-num">09</span>Suspend / Wake</a></li>
+        <li><a href="10-wifi.html"><span class="nav-num">10</span>WiFi &amp; Android Auto</a></li>
+        <li><a href="11-arduino.html"><span class="nav-num">11</span>Arduino Wiring</a></li>
+        <li><a href="12-verification.html"><span class="nav-num">12</span>Verification</a></li>
+      </ul>
+    </nav>
+  </aside>
+
+  <!-- Main Content -->
+  <main class="content">
+    <div class="content-inner">
+
+      <h1>
+        BCM Software Installation
+        <span class="subtitle">Clone, configure, and deploy BCM on the Lenovo M910q</span>
+      </h1>
+
+      <p>
+        This page covers the complete software installation and configuration for
+        a production BCM deployment. The automated setup script handles 14 phases
+        of system configuration &mdash; from dependency installation through
+        systemd services to a final smoke test.
+      </p>
+
+      <div class="box box-info">
+        <div class="box-title">Prerequisites</div>
+        <p>
+          Complete the OS installation (<a href="03-os-install.html">page 03</a>)
+          and system packages (<a href="04-packages.html">page 04</a>) before
+          proceeding. You should have a working Debian 13 (Trixie) system with
+          network access and a non-root user with <code>sudo</code> privileges.
+        </p>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           CLONE & INSTALL
+           ============================================================ -->
+
+      <h2 id="clone-install">Clone &amp; Install</h2>
+
+      <p>
+        Clone the BCM repository into <code>/opt/bcm</code> and take ownership
+        so you can run the application without root:
+      </p>
+
+      <pre><code>cd /opt
+sudo git clone https://github.com/geek95dg/Alfa156-headunit.git bcm
+sudo chown -R $USER:$USER /opt/bcm
+cd /opt/bcm</code></pre>
+
+      <hr>
+
+      <!-- ============================================================
+           THE SETUP SCRIPT
+           ============================================================ -->
+
+      <h2 id="setup-script">The Setup Script</h2>
+
+      <p>
+        The primary install method is <code>setup-x86.sh</code>. It handles
+        everything &mdash; from installing system packages to configuring
+        systemd services, kiosk mode, WiFi AP, and more:
+      </p>
+
+      <pre><code>sudo bash config/scripts/setup-x86.sh</code></pre>
+
+      <div class="box box-warning">
+        <div class="box-title">Run as root</div>
+        <p>
+          The script must be run with <code>sudo</code>. It modifies systemd
+          units, GRUB configuration, udev rules, and other system-level
+          settings. Review the USER CONFIG section before running.
+        </p>
+      </div>
+
+      <h3>14 Setup Phases</h3>
+
+      <p>
+        The script executes the following phases in order. Each phase is
+        idempotent &mdash; you can re-run the script safely after making
+        configuration changes.
+      </p>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Phase</th>
+              <th>What it does</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>1</td>
+              <td><strong>Cleanup</strong></td>
+              <td>Removes old BCM services and configuration files from any previous installation</td>
+            </tr>
+            <tr>
+              <td>2</td>
+              <td><strong>System packages</strong></td>
+              <td>Installs all apt dependencies (X11, Chromium, PipeWire, ffmpeg, Python, build tools, etc.)</td>
+            </tr>
+            <tr>
+              <td>3</td>
+              <td><strong>Python venv</strong></td>
+              <td>Creates <code>.venv</code> virtual environment with versioned Python binary fallback (tries <code>python3.12</code>, <code>python3.11</code>, then <code>python3</code>)</td>
+            </tr>
+            <tr>
+              <td>4</td>
+              <td><strong>Vendor assets</strong></td>
+              <td>Downloads Tailwind CSS and Leaflet for offline operation &mdash; no CDN dependency in the car</td>
+            </tr>
+            <tr>
+              <td>5</td>
+              <td><strong>Splash videos</strong></td>
+              <td>Generates placeholder splash videos via <code>ffmpeg</code> if none exist in the splash directory</td>
+            </tr>
+            <tr>
+              <td>6</td>
+              <td><strong>Systemd services</strong></td>
+              <td>Installs and enables <code>bcm-headunit</code>, <code>ignition-watcher</code>, <code>splash</code>, and <code>resume</code> service units</td>
+            </tr>
+            <tr>
+              <td>7</td>
+              <td><strong>Kiosk</strong></td>
+              <td>Configures autologin + X11 + <code>xinitrc</code> with touch-screen input mapping for dual displays</td>
+            </tr>
+            <tr>
+              <td>8</td>
+              <td><strong>Power button</strong></td>
+              <td>Configures <code>acpid</code> for suspend on power button press + sets <code>HandlePowerKey=ignore</code> in logind</td>
+            </tr>
+            <tr>
+              <td>9</td>
+              <td><strong>WiFi AP</strong></td>
+              <td>Sets up <code>hostapd</code> + <code>dnsmasq</code> access point &mdash; 2.4 GHz channel 6 with Intel 8265, 5 GHz channel 149 with Fenvi AX200</td>
+            </tr>
+            <tr>
+              <td>10</td>
+              <td><strong>LTE modem</strong></td>
+              <td>Auto-detects Huawei E3372 HiLink USB modem and configures DHCP on its network interface</td>
+            </tr>
+            <tr>
+              <td>11</td>
+              <td><strong>GRUB</strong></td>
+              <td>Silences boot output &mdash; sets <code>quiet splash</code>, disables Plymouth, hides GRUB menu</td>
+            </tr>
+            <tr>
+              <td>12</td>
+              <td><strong>Permissions</strong></td>
+              <td>Adds user to <code>dialout</code>, <code>video</code>, <code>audio</code>, <code>bluetooth</code> groups + enables Bluetooth auto-power on boot</td>
+            </tr>
+            <tr>
+              <td>13</td>
+              <td><strong>Test</strong></td>
+              <td>Runs a quick Flask smoke test &mdash; starts the application briefly to verify it launches without errors</td>
+            </tr>
+            <tr>
+              <td>14</td>
+              <td><strong>Summary</strong></td>
+              <td>Prints a summary of all installed services, configuration paths, and next steps</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           USER CONFIGURATION
+           ============================================================ -->
+
+      <h2 id="user-config">User Configuration</h2>
+
+      <p>
+        Before running the setup script, edit the <strong>USER CONFIG</strong>
+        section at the top of the file to match your hardware:
+      </p>
+
+      <pre><code>nano config/scripts/setup-x86.sh</code></pre>
+
+      <h3>Configuration Variables</h3>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Variable</th>
+              <th>Default</th>
+              <th>Description</th>
+              <th>How to find</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>MAIN_OUTPUT</code></td>
+              <td><code>"HDMI-1"</code></td>
+              <td>7" touchscreen display output</td>
+              <td><code>xrandr</code></td>
+            </tr>
+            <tr>
+              <td><code>SMALL_OUTPUT</code></td>
+              <td><code>"HDMI-2"</code></td>
+              <td>4.3" status display output</td>
+              <td><code>xrandr</code></td>
+            </tr>
+            <tr>
+              <td><code>TOUCH_DEVICE</code></td>
+              <td><code>"QDtech MPI5001"</code></td>
+              <td>Touchscreen input device name</td>
+              <td><code>xinput list</code></td>
+            </tr>
+            <tr>
+              <td><code>WIFI_IFACE</code></td>
+              <td><code>"wlp2s0"</code></td>
+              <td>WiFi interface for AP mode</td>
+              <td><code>ip link</code></td>
+            </tr>
+            <tr>
+              <td><code>WIFI_SSID</code></td>
+              <td><code>"ALFA_AA"</code></td>
+              <td>Access point name (for Android Auto)</td>
+              <td>&mdash;</td>
+            </tr>
+            <tr>
+              <td><code>WIFI_PASS</code></td>
+              <td><code>"AlfaRomeo156"</code></td>
+              <td>AP password (WPA2)</td>
+              <td>&mdash;</td>
+            </tr>
+            <tr>
+              <td><code>WIFI_CHANNEL</code></td>
+              <td><code>"6"</code></td>
+              <td>2.4 GHz channel (use <code>149</code> for 5 GHz with Fenvi)</td>
+              <td>&mdash;</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="box box-info">
+        <div class="box-title">Display output names</div>
+        <p>
+          On the M910q with DP-to-HDMI adapters, output names are typically
+          <code>DP-1</code> and <code>DP-2</code> rather than <code>HDMI-1</code>
+          / <code>HDMI-2</code>. Always verify with <code>xrandr</code> before
+          running the script. Incorrect output names will result in a blank
+          kiosk display.
+        </p>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           PRODUCTION CONFIG
+           ============================================================ -->
+
+      <h2 id="production-config">Production Config (bcm_config.yaml)</h2>
+
+      <p>
+        The main application configuration lives in
+        <code>config/bcm_config.yaml</code>. Key settings for a production
+        deployment:
+      </p>
+
+      <pre><code>system:
+  platform: x86
+  simulation: false    # CRITICAL: disables demo/fake data
+  log_level: INFO      # reduce from DEBUG for production
+
+serial:
+  kline:
+    port_x86: /dev/ttyUSB_kline    # udev rule for stable naming
+    baudrate: 10400
+    ecu_address: 1
+
+wifi:
+  enabled: false       # systemd manages the AP, not BCM
+
+modules:
+  dashboard: true
+  obd: true            # real ECU data via K-Line
+  parking: true        # HC-SR04 via Arduino
+  environment: true    # DS18B20 via Arduino
+  audio: true
+  input: true          # Arduino Pro Micro SWC + buttons
+  camera: true         # 4-ch USB grabber
+  power: true
+  multimedia: true     # Android Auto + Bluetooth
+  location: true       # USB GPS
+  network: true        # LTE modem
+  weather: true        # OpenWeatherMap API</code></pre>
+
+      <div class="box box-warning">
+        <div class="box-title">simulation: false is critical</div>
+        <p>
+          When <code>simulation</code> is set to <code>true</code>, BCM
+          generates fake sensor data for development and testing. In a
+          production car build, this <strong>must</strong> be set to
+          <code>false</code> so the system reads real data from the K-Line
+          ECU, Arduino sensors, and GPS. Leaving simulation enabled in
+          production will mask real vehicle data and hide hardware faults.
+        </p>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           USB DEVICE NAMING
+           ============================================================ -->
+
+      <h2 id="udev-rules">USB Device Naming (udev Rules)</h2>
+
+      <p>
+        USB device paths like <code>/dev/ttyUSB0</code> can change between
+        reboots depending on enumeration order. Create stable
+        <code>/dev/</code> symlinks using udev rules so BCM always finds
+        the correct device:
+      </p>
+
+      <pre><code>sudo tee /etc/udev/rules.d/99-bcm-usb.rules &gt;/dev/null &lt;&lt;'EOF'
+# K-Line adapter (CP2102)
+SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", SYMLINK+="ttyUSB_kline"
+# GPS (u-blox)
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1546", ATTRS{idProduct}=="01a7", SYMLINK+="ttyUSB_gps"
+# Arduino Pro Micro (input)
+SUBSYSTEM=="tty", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="8037", SYMLINK+="ttyACM_input"
+# Arduino Nano (output)
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", SYMLINK+="ttyUSB_output"
+EOF
+sudo udevadm control --reload-rules
+sudo udevadm trigger</code></pre>
+
+      <div class="box box-info">
+        <div class="box-title">Finding vendor and product IDs</div>
+        <p>
+          Plug in each USB device one at a time and run
+          <code>lsusb</code> to find its <code>idVendor</code> and
+          <code>idProduct</code>. If you have two devices with the same
+          chipset (e.g., two CP2102 adapters), add
+          <code>ATTRS{serial}=="..."</code> to distinguish them. Find
+          the serial with <code>udevadm info -a /dev/ttyUSB0 | grep serial</code>.
+        </p>
+      </div>
+
+      <h3>Resulting Device Map</h3>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Symlink</th>
+              <th>Hardware</th>
+              <th>USB Chip</th>
+              <th>Used by</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>/dev/ttyUSB_kline</code></td>
+              <td>K-Line OBD-II adapter</td>
+              <td>CP2102 (10c4:ea60)</td>
+              <td>OBD module &mdash; ECU diagnostics</td>
+            </tr>
+            <tr>
+              <td><code>/dev/ttyUSB_gps</code></td>
+              <td>u-blox NEO-M8N</td>
+              <td>u-blox (1546:01a7)</td>
+              <td>Location module &mdash; GPS/GNSS</td>
+            </tr>
+            <tr>
+              <td><code>/dev/ttyACM_input</code></td>
+              <td>Arduino Pro Micro</td>
+              <td>ATmega32U4 (2341:8037)</td>
+              <td>Input module &mdash; SWC, buttons, sensors</td>
+            </tr>
+            <tr>
+              <td><code>/dev/ttyUSB_output</code></td>
+              <td>Arduino Nano</td>
+              <td>CH340 (1a86:7523)</td>
+              <td>Output module &mdash; relays, locks, lights</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           MANUAL TEST
+           ============================================================ -->
+
+      <h2 id="manual-test">Manual Test</h2>
+
+      <p>
+        Before relying on systemd auto-start, verify the application runs
+        correctly from the command line:
+      </p>
+
+      <pre><code>source /opt/bcm/.venv/bin/activate
+python3 main.py --platform x86 --config config/bcm_config.yaml --frontend
+# Open browser: http://localhost:5002
+# Ctrl+C to stop</code></pre>
+
+      <div class="box box-info">
+        <div class="box-title">What to verify</div>
+        <p>
+          Check that the Flask server starts on port 5002, the dashboard
+          loads in a browser, and there are no import errors or missing
+          dependencies in the terminal output. If serial devices are not
+          connected, those modules will log warnings but the application
+          should still start.
+        </p>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           VENDOR ASSETS
+           ============================================================ -->
+
+      <h2 id="vendor-assets">Vendor Assets (Offline Operation)</h2>
+
+      <p>
+        The car has no guaranteed internet connection. All frontend
+        dependencies must be available locally. The vendor asset script
+        downloads Tailwind CSS and Leaflet (for map tiles) into the
+        project&rsquo;s static assets directory:
+      </p>
+
+      <pre><code>bash config/scripts/download-vendor-assets.sh</code></pre>
+
+      <div class="box box-warning">
+        <div class="box-title">Run this while you have internet</div>
+        <p>
+          This script requires an active internet connection to download
+          assets. Run it during initial setup &mdash; not in the car.
+          The setup script (phase 4) calls this automatically, but you
+          can re-run it manually if assets are missing or need updating.
+        </p>
+      </div>
+
+      <hr>
+
+      <!-- Page Navigation -->
+      <div class="page-nav">
+        <a href="03-os-install.html">&larr; 03 &mdash; OS Installation</a>
+        <a href="05-bcm-install.html">05 &mdash; BCM Installation &rarr;</a>
+      </div>
+
+      <!-- Footer -->
+      <footer class="page-footer">
+        <span>BCM v8.5 &mdash; x86 Production Documentation</span>
+        <span>Alfa Romeo 156 Headunit Project</span>
+      </footer>
+
+    </div>
+  </main>
+
+  <!-- Sidebar Toggle Script -->
+  <script>
+    function toggleSidebar() {
+      document.querySelector('.sidebar').classList.toggle('open');
+      document.querySelector('.sidebar-overlay').classList.toggle('active');
+    }
+
+    // Close sidebar when a nav link is clicked (mobile)
+    document.querySelectorAll('.sidebar nav a').forEach(function(link) {
+      link.addEventListener('click', function() {
+        if (window.innerWidth < 768) {
+          document.querySelector('.sidebar').classList.remove('open');
+          document.querySelector('.sidebar-overlay').classList.remove('active');
+        }
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/docs/x86-production/05-kline-obd.html
+++ b/docs/x86-production/05-kline-obd.html
@@ -1,0 +1,919 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>05 — K-Line OBD-II | BCM x86 Production</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+
+  <!-- Hamburger toggle (mobile) -->
+  <button class="hamburger" aria-label="Toggle navigation" onclick="document.querySelector('.sidebar').classList.toggle('open');document.querySelector('.sidebar-overlay').classList.toggle('active');">&#9776;</button>
+  <div class="sidebar-overlay" onclick="document.querySelector('.sidebar').classList.remove('open');this.classList.remove('active');"></div>
+
+  <!-- Sidebar Navigation -->
+  <aside class="sidebar">
+    <div class="sidebar-header">
+      <div class="logo-text">BCM v8.5</div>
+      <div class="logo-sub">x86 Production Docs</div>
+    </div>
+    <nav aria-label="Documentation pages">
+      <ul>
+        <li><a href="index.html"><span class="nav-num"></span>Overview</a></li>
+        <li><a href="01-bom.html"><span class="nav-num">01</span>Bill of Materials</a></li>
+        <li><a href="02-power.html"><span class="nav-num">02</span>Power Supply</a></li>
+        <li><a href="03-os-install.html"><span class="nav-num">03</span>OS Installation</a></li>
+        <li><a href="04-packages.html"><span class="nav-num">04</span>System Packages</a></li>
+        <li><a href="05-kline-obd.html" class="active"><span class="nav-num">05</span>K-Line OBD-II</a></li>
+        <li><a href="06-arduino.html"><span class="nav-num">06</span>Arduino Wiring</a></li>
+        <li><a href="07-boot.html"><span class="nav-num">07</span>Boot &amp; Splash</a></li>
+        <li><a href="08-kiosk.html"><span class="nav-num">08</span>Kiosk Display</a></li>
+        <li><a href="09-suspend.html"><span class="nav-num">09</span>Suspend / Wake</a></li>
+        <li><a href="10-wifi.html"><span class="nav-num">10</span>WiFi &amp; Android Auto</a></li>
+        <li><a href="11-arduino.html"><span class="nav-num">11</span>Arduino Wiring</a></li>
+        <li><a href="12-verification.html"><span class="nav-num">12</span>Verification</a></li>
+      </ul>
+    </nav>
+  </aside>
+
+  <!-- Main Content -->
+  <main class="content">
+    <div class="content-inner">
+
+      <h1>
+        K-Line OBD-II &mdash; ECU Communication
+        <span class="subtitle">K-Line adapter build and Bosch EDC15C7 diagnostics for Alfa Romeo 156 1.9 JTD</span>
+      </h1>
+
+      <!-- ============================================================
+           SECTION 1: OVERVIEW
+           ============================================================ -->
+
+      <h2 id="overview">Overview</h2>
+
+      <p>
+        The Alfa Romeo 156 1.9 JTD (8V, 2000&ndash;2005) does <strong>not</strong>
+        have a CAN-bus OBD-II interface. Instead, the Bosch EDC15C7 engine ECU
+        communicates over a single-wire <strong>K-Line</strong> bus using the
+        <strong>ISO 14230 (KWP2000)</strong> protocol. This is a serial
+        communication line operating at 10400 baud, where a single wire carries
+        bidirectional data between the diagnostic tester and the ECU.
+      </p>
+
+      <p>
+        BCM uses K-Line to read live engine data &mdash; RPM, vehicle speed,
+        coolant temperature, fuel consumption, turbo boost pressure, and more
+        &mdash; and displays it on the dashboard gauges in real time. The
+        connection is <strong>read-only</strong>; BCM never writes to the ECU
+        or modifies any engine parameters.
+      </p>
+
+      <div class="box box-warning">
+        <div class="box-title">Read-only access &mdash; safety first</div>
+        <p>
+          BCM operates in <strong>read-only diagnostic mode</strong>. It uses
+          KWP2000 service <code>0x21</code> (readDataByLocalIdentifier) to
+          request sensor data. No write, programming, or reset commands are
+          ever sent to the ECU. Do not modify the software to send write
+          commands unless you fully understand the consequences &mdash;
+          incorrect ECU writes can cause engine damage or unsafe driving
+          conditions.
+        </p>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           SECTION 2: HARDWARE — K-LINE ADAPTER BUILD
+           ============================================================ -->
+
+      <h2 id="hardware">Hardware &mdash; K-Line Adapter Build</h2>
+
+      <p>
+        The K-Line adapter converts USB serial (3.3V/5V TTL) to the
+        12V single-wire K-Line bus. It consists of three components:
+      </p>
+
+      <h3>Components</h3>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Component</th>
+              <th>Description</th>
+              <th>Approx. Cost (PLN)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>CP2102</strong> USB-UART module</td>
+              <td>USB to 3.3V/5V TTL serial converter. Provides TX, RX, GND, and 5V output.</td>
+              <td>8&ndash;15</td>
+            </tr>
+            <tr>
+              <td><strong>L9637D</strong> transceiver IC</td>
+              <td>ISO 9141 / ISO 14230 K-Line transceiver. Converts TTL logic to 12V K-Line signalling. 8-pin DIP package.</td>
+              <td>8&ndash;15</td>
+            </tr>
+            <tr>
+              <td><strong>510&Omega; resistor</strong></td>
+              <td>Pull-up resistor between 12V battery supply and the K-Line. Keeps the line HIGH when idle.</td>
+              <td>0.50&ndash;1</td>
+            </tr>
+            <tr>
+              <td><strong>100nF ceramic capacitor</strong></td>
+              <td>Decoupling capacitor between VCC and GND on the L9637D for noise filtering.</td>
+              <td>0.50&ndash;1</td>
+            </tr>
+            <tr>
+              <td><strong>12V supply</strong></td>
+              <td>Taken from OBD-II pin 16 (permanent battery 12V).</td>
+              <td>&mdash;</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p><strong>Total cost: ~25&ndash;40 PLN</strong></p>
+
+      <h3>Wiring Diagram</h3>
+
+      <p>
+        Full schematic available at
+        <code>schematics/kline_circuit.svg</code>.
+        The essential connections:
+      </p>
+
+      <pre><code>                   ┌──────────────┐        ┌──────────────┐
+                   │   CP2102     │        │   L9637D     │
+                   │  USB-UART    │        │  Transceiver │
+                   │              │        │              │
+  M910q USB ──────►│ USB          │        │ 1  K ────────┼──── OBD-II Pin 7 (K-Line)
+  hub              │              │        │              │
+                   │ TX (out) ────┼────────┼─ 5  RX (in)  │
+                   │              │        │              │
+                   │ RX (in) ─────┼────────┼─ 6  TX (out) │
+                   │              │        │              │
+                   │ GND ─────────┼────┬───┼─ 4  GND ─────┼──── OBD-II Pin 4 (GND)
+                   │              │    │   │              │
+                   │ 5V (or VCC) ─┼────┼───┼─ 3  VCC (5V) │
+                   │              │    │   │              │        510Ω
+                   └──────────────┘    │   │ 2  VS ───────┼────┤/\/\/├──── OBD-II Pin 16 (12V)
+                                       │   │              │
+                                       │   │ 7  NC        │
+                                       │   │ 8  EN ───────┼──── VCC (tie to pin 3)
+                                       │   └──────────────┘
+                                       │
+                                     ──┴──  GND
+                                      ───
+
+  Note: 100nF ceramic capacitor between L9637D pin 3 (VCC) and pin 4 (GND)</code></pre>
+
+      <div class="box box-info">
+        <div class="box-title">TX/RX cross-over</div>
+        <p>
+          The CP2102 TX pin connects to the L9637D RX (pin 5), and CP2102 RX
+          connects to L9637D TX (pin 6). This is the standard UART cross-over
+          &mdash; transmit on one side goes to receive on the other.
+        </p>
+      </div>
+
+      <h3>L9637D Pinout (8-pin DIP)</h3>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Pin</th>
+              <th>Name</th>
+              <th>Direction</th>
+              <th>Description</th>
+              <th>Connect to</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>1</td>
+              <td>K</td>
+              <td>I/O</td>
+              <td>K-Line bus (bidirectional, 12V levels)</td>
+              <td>OBD-II Pin 7</td>
+            </tr>
+            <tr>
+              <td>2</td>
+              <td>VS</td>
+              <td>Power</td>
+              <td>Battery voltage sense / pull-up supply</td>
+              <td>12V via 510&Omega; resistor</td>
+            </tr>
+            <tr>
+              <td>3</td>
+              <td>VCC</td>
+              <td>Power</td>
+              <td>Logic supply voltage (4.5&ndash;5.5V)</td>
+              <td>CP2102 5V output</td>
+            </tr>
+            <tr>
+              <td>4</td>
+              <td>GND</td>
+              <td>Power</td>
+              <td>Ground reference</td>
+              <td>Common GND (CP2102 + OBD-II pin 4)</td>
+            </tr>
+            <tr>
+              <td>5</td>
+              <td>RX</td>
+              <td>Input</td>
+              <td>Serial data input from tester (TTL)</td>
+              <td>CP2102 TX</td>
+            </tr>
+            <tr>
+              <td>6</td>
+              <td>TX</td>
+              <td>Output</td>
+              <td>Serial data output to tester (TTL)</td>
+              <td>CP2102 RX</td>
+            </tr>
+            <tr>
+              <td>7</td>
+              <td>NC</td>
+              <td>&mdash;</td>
+              <td>Not connected</td>
+              <td>&mdash;</td>
+            </tr>
+            <tr>
+              <td>8</td>
+              <td>EN</td>
+              <td>Input</td>
+              <td>Enable (active high, tie to VCC)</td>
+              <td>VCC (pin 3)</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3>Where to Buy</h3>
+
+      <p>
+        Both the CP2102 module and L9637D IC are widely available:
+      </p>
+
+      <ul>
+        <li><strong>AliExpress</strong> &mdash; cheapest source for both components (5&ndash;15 PLN each, 2&ndash;4 week delivery)</li>
+        <li><strong>Botland.com.pl</strong> &mdash; Polish electronics shop, CP2102 modules in stock</li>
+        <li><strong>Kamami.pl</strong> &mdash; L9637D IC available, fast domestic shipping</li>
+        <li><strong>TME.eu</strong> &mdash; professional distributor, L9637D in DIP-8 package</li>
+        <li><strong>Allegro.pl</strong> &mdash; search "CP2102" or "L9637D", many Polish sellers</li>
+      </ul>
+
+      <hr>
+
+      <!-- ============================================================
+           SECTION 3: CONNECTION TO CAR
+           ============================================================ -->
+
+      <h2 id="connection">Connection to Car</h2>
+
+      <h3>OBD-II Port Location</h3>
+
+      <p>
+        In the Alfa Romeo 156, the OBD-II diagnostic port is located
+        <strong>under the steering column, on the left side</strong>, near
+        the fuse box. It faces downward and may be covered by a small plastic
+        cap. The connector is a standard 16-pin Type A (passenger car) OBD-II
+        socket.
+      </p>
+
+      <h3>OBD-II Pinout (Used Pins)</h3>
+
+      <p>
+        Only 4 of the 16 OBD-II pins are used for K-Line communication:
+      </p>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>OBD-II Pin</th>
+              <th>Signal</th>
+              <th>Description</th>
+              <th>Wire Colour (typical)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>4</strong></td>
+              <td>Chassis GND</td>
+              <td>Ground reference &mdash; connect to L9637D GND and CP2102 GND</td>
+              <td>Black / Brown</td>
+            </tr>
+            <tr>
+              <td><strong>5</strong></td>
+              <td>Signal GND</td>
+              <td>Signal ground &mdash; connect together with pin 4</td>
+              <td>Black / Brown</td>
+            </tr>
+            <tr>
+              <td><strong>7</strong></td>
+              <td>K-Line</td>
+              <td>ISO 14230 data line &mdash; connect to L9637D pin 1 (K)</td>
+              <td>White / Grey</td>
+            </tr>
+            <tr>
+              <td><strong>16</strong></td>
+              <td>Battery +12V</td>
+              <td>Permanent battery voltage &mdash; connect to L9637D pin 2 (VS) via 510&Omega;</td>
+              <td>Red</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="box box-info">
+        <div class="box-title">No L-Line needed</div>
+        <p>
+          Some older ISO 9141 implementations use both K-Line (pin 7) and
+          L-Line (pin 15). The Bosch EDC15C7 in the Alfa 156 1.9 JTD uses
+          K-Line only. Pin 15 is not connected.
+        </p>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           SECTION 4: SOFTWARE CONFIGURATION
+           ============================================================ -->
+
+      <h2 id="software-config">Software Configuration</h2>
+
+      <p>
+        The K-Line serial port is configured in <code>config/bcm_config.yaml</code>:
+      </p>
+
+      <pre><code>serial:
+  kline:
+    port_x86: /dev/ttyUSB_kline    # stable symlink via udev rule
+    baudrate: 10400                # ISO 14230 standard baud rate
+    ecu_address: 1                 # 0x01 = EDC15C7 engine ECU</code></pre>
+
+      <h3>udev Rule for Stable Device Naming</h3>
+
+      <p>
+        The CP2102 USB-UART module must have a stable <code>/dev/</code>
+        symlink so BCM can find it regardless of USB enumeration order. Create
+        or verify the udev rule (as described in
+        <a href="04-software.html#udev-rules">04 &mdash; Software &sect; USB Device Naming</a>):
+      </p>
+
+      <pre><code># /etc/udev/rules.d/99-bcm-usb.rules
+# K-Line adapter (CP2102)
+SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", SYMLINK+="ttyUSB_kline"</code></pre>
+
+      <p>
+        Reload and trigger after creating or editing the rule:
+      </p>
+
+      <pre><code>sudo udevadm control --reload-rules
+sudo udevadm trigger</code></pre>
+
+      <h3>Verify the Symlink</h3>
+
+      <pre><code>ls -la /dev/ttyUSB_kline
+# Expected output:
+# lrwxrwxrwx 1 root root 7 ... /dev/ttyUSB_kline -> ttyUSB0</code></pre>
+
+      <div class="box box-info">
+        <div class="box-title">User permissions</div>
+        <p>
+          The BCM user must be in the <code>dialout</code> group to access
+          serial ports without root. The setup script (phase 12) adds this
+          automatically, or do it manually:
+          <code>sudo usermod -aG dialout $USER</code> (log out and back in
+          to apply).
+        </p>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           SECTION 5: COMMUNICATION PROTOCOL
+           ============================================================ -->
+
+      <h2 id="protocol">Communication Protocol</h2>
+
+      <p>
+        The K-Line communication follows the ISO 14230 (KWP2000) protocol.
+        BCM implements this in two layers: <code>src/obd/kline.py</code>
+        handles the physical layer, and <code>src/obd/kwp2000.py</code>
+        handles the application-layer diagnostic services.
+      </p>
+
+      <h3>5-Baud Initialization Sequence</h3>
+
+      <p>
+        Before normal communication can begin, the tester must perform a
+        slow-init handshake at 5 baud to wake up the ECU. The full sequence:
+      </p>
+
+      <ol>
+        <li>
+          <strong>Send ECU address at 5 baud</strong> &mdash;
+          Pull the K-Line low for 200ms per bit to transmit the target ECU
+          address (<code>0x01</code> for EDC15C7). The 10-bit frame is:
+          start bit (0), 8 data bits LSB-first (<code>00000001</code> = 0x01),
+          stop bit (1). Total time: 10 &times; 200ms = 2 seconds.
+        </li>
+        <li>
+          <strong>Switch to 10400 baud</strong> &mdash;
+          After the address is sent, reconfigure the UART to 10400 baud,
+          8N1 (8 data bits, no parity, 1 stop bit).
+        </li>
+        <li>
+          <strong>Receive sync byte</strong> &mdash;
+          The ECU responds with <code>0x55</code> (01010101 binary), which
+          the tester can use to verify baud rate synchronization.
+        </li>
+        <li>
+          <strong>Receive two key bytes (KB1, KB2)</strong> &mdash;
+          The ECU sends two key bytes that identify its supported protocol
+          variant. For EDC15C7, these are typically <code>0x08 0x08</code>
+          (KWP2000 with physical addressing).
+        </li>
+        <li>
+          <strong>Send inverted KB2</strong> &mdash;
+          The tester acknowledges by sending the bitwise inverse of KB2:
+          <code>(~KB2) &amp; 0xFF</code>.
+        </li>
+        <li>
+          <strong>Receive inverted address echo</strong> &mdash;
+          The ECU confirms the handshake by sending the bitwise inverse of
+          the ECU address: <code>(~0x01) &amp; 0xFF = 0xFE</code>.
+          Communication is now established.
+        </li>
+      </ol>
+
+      <h3>KWP2000 Timing Constants</h3>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Parameter</th>
+              <th>Value</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>P1 max</td>
+              <td>20 ms</td>
+              <td>Maximum inter-byte time in ECU response</td>
+            </tr>
+            <tr>
+              <td>P2 min / max</td>
+              <td>25&ndash;50 ms</td>
+              <td>Time between tester request and ECU response</td>
+            </tr>
+            <tr>
+              <td>P3 min</td>
+              <td>55 ms</td>
+              <td>Minimum time between ECU response and next tester request</td>
+            </tr>
+            <tr>
+              <td>P4 min</td>
+              <td>5 ms</td>
+              <td>Minimum inter-byte time in tester request</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3>KWP2000 Diagnostic Session</h3>
+
+      <p>
+        After the 5-baud init handshake, BCM starts a diagnostic session and
+        begins polling data:
+      </p>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Step</th>
+              <th>Service</th>
+              <th>SID</th>
+              <th>Parameters</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>1</td>
+              <td>startDiagnosticSession</td>
+              <td><code>0x10</code></td>
+              <td>Mode <code>0x81</code> (default session)</td>
+              <td>Opens a diagnostic session with the ECU</td>
+            </tr>
+            <tr>
+              <td>2</td>
+              <td>testerPresent</td>
+              <td><code>0x3E</code></td>
+              <td>No parameters</td>
+              <td>Keepalive sent every 2 seconds to prevent session timeout</td>
+            </tr>
+            <tr>
+              <td>3</td>
+              <td>readDataByLocalIdentifier</td>
+              <td><code>0x21</code></td>
+              <td>Local ID (e.g., <code>0x01</code> for RPM)</td>
+              <td>Reads a single parameter from the ECU</td>
+            </tr>
+            <tr>
+              <td>4</td>
+              <td>stopDiagnosticSession</td>
+              <td><code>0x20</code></td>
+              <td>No parameters</td>
+              <td>Closes the session on shutdown</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3>KWP2000 Message Format</h3>
+
+      <p>
+        Each message uses physical addressing with the following structure:
+      </p>
+
+      <pre><code>[Format] [Target] [Source] [Data...] [Checksum]
+
+Format byte: 0x80 | data_length   (physical addressing, length in format byte)
+Target:      0x01                  (ECU address)
+Source:      0xF1                  (tester address)
+Checksum:    sum of all preceding bytes, masked to 8 bits
+
+Example — read RPM (local ID 0x01):
+  Request:  [0x82] [0x01] [0xF1] [0x21] [0x01] [0x96]
+  Response: [0x83] [0xF1] [0x01] [0x61] [0x01] [RPM_HI] [RPM_LO] [CS]</code></pre>
+
+      <hr>
+
+      <!-- ============================================================
+           SECTION 6: ECU DATA — PIDS
+           ============================================================ -->
+
+      <h2 id="pids">ECU Data &mdash; PID Definitions</h2>
+
+      <p>
+        The Bosch EDC15C7 exposes 9 parameters via KWP2000 local identifiers.
+        These are defined in <code>src/obd/edc15c7.py</code>:
+      </p>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Local ID</th>
+              <th>Parameter</th>
+              <th>Unit</th>
+              <th>Scale</th>
+              <th>Bytes</th>
+              <th>Dashboard Gauge</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>0x01</code></td>
+              <td>Engine RPM</td>
+              <td>rpm</td>
+              <td>&times;0.25</td>
+              <td>2</td>
+              <td>Primary (tachometer)</td>
+            </tr>
+            <tr>
+              <td><code>0x02</code></td>
+              <td>Vehicle Speed</td>
+              <td>km/h</td>
+              <td>direct</td>
+              <td>1</td>
+              <td>Primary (speedometer)</td>
+            </tr>
+            <tr>
+              <td><code>0x03</code></td>
+              <td>Coolant Temperature</td>
+              <td>&deg;C</td>
+              <td>&minus;40 offset</td>
+              <td>1</td>
+              <td>Primary (temp gauge)</td>
+            </tr>
+            <tr>
+              <td><code>0x04</code></td>
+              <td>Fuel Consumption Rate</td>
+              <td>L/h</td>
+              <td>&times;0.01</td>
+              <td>2</td>
+              <td>Secondary</td>
+            </tr>
+            <tr>
+              <td><code>0x05</code></td>
+              <td>Injector Quantity</td>
+              <td>mg/stroke</td>
+              <td>&times;0.01</td>
+              <td>2</td>
+              <td>Secondary</td>
+            </tr>
+            <tr>
+              <td><code>0x06</code></td>
+              <td>Battery Voltage</td>
+              <td>V</td>
+              <td>&times;0.1</td>
+              <td>1</td>
+              <td>Status bar</td>
+            </tr>
+            <tr>
+              <td><code>0x07</code></td>
+              <td>Turbo Boost Pressure</td>
+              <td>mbar</td>
+              <td>direct</td>
+              <td>2</td>
+              <td>Secondary (boost gauge)</td>
+            </tr>
+            <tr>
+              <td><code>0x08</code></td>
+              <td>Intake Air Temperature</td>
+              <td>&deg;C</td>
+              <td>&minus;40 offset</td>
+              <td>1</td>
+              <td>Secondary</td>
+            </tr>
+            <tr>
+              <td><code>0x09</code></td>
+              <td>Throttle Position</td>
+              <td>%</td>
+              <td>&times;0.4</td>
+              <td>1</td>
+              <td>Secondary</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3>Decoding Examples</h3>
+
+      <pre><code># Engine RPM: 2 bytes big-endian, multiply by 0.25
+raw = [0x0F, 0xA0]    # 4000 decimal
+rpm = ((0x0F &lt;&lt; 8) | 0xA0) * 0.25  # = 1000.0 rpm
+
+# Coolant Temperature: 1 byte, subtract 40
+raw = [0x69]           # 105 decimal
+temp = 105 - 40        # = 65.0 &deg;C
+
+# Battery Voltage: 1 byte, multiply by 0.1
+raw = [0x8C]           # 140 decimal
+voltage = 140 * 0.1    # = 14.0 V
+
+# Turbo Boost Pressure: 2 bytes big-endian, direct (mbar)
+raw = [0x04, 0x4C]     # 1100 decimal
+boost = (0x04 &lt;&lt; 8) | 0x4C  # = 1100 mbar</code></pre>
+
+      <h3>Default Polling Group</h3>
+
+      <p>
+        BCM polls a subset of PIDs in a 100ms round-robin cycle by default.
+        The <code>DEFAULT_ACTIVE_PIDS</code> from <code>edc15c7.py</code> are:
+      </p>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Local ID</th>
+              <th>Parameter</th>
+              <th>Event Topic</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>0x01</code></td>
+              <td>Engine RPM</td>
+              <td><code>obd.rpm</code></td>
+            </tr>
+            <tr>
+              <td><code>0x02</code></td>
+              <td>Vehicle Speed</td>
+              <td><code>obd.speed</code></td>
+            </tr>
+            <tr>
+              <td><code>0x03</code></td>
+              <td>Coolant Temperature</td>
+              <td><code>obd.coolant_temp</code></td>
+            </tr>
+            <tr>
+              <td><code>0x04</code></td>
+              <td>Fuel Consumption Rate</td>
+              <td><code>obd.fuel_rate</code></td>
+            </tr>
+            <tr>
+              <td><code>0x06</code></td>
+              <td>Battery Voltage</td>
+              <td><code>obd.battery_voltage</code></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p>
+        With 5 PIDs at ~100ms each (plus P3 inter-request timing), the full
+        polling cycle takes approximately 500&ndash;600ms, giving roughly 2
+        updates per second for each parameter. The remaining PIDs (injector
+        quantity, turbo pressure, intake air temperature, throttle position)
+        can be added to the active set in the configuration if needed.
+      </p>
+
+      <div class="box box-info">
+        <div class="box-title">Tester present keepalive</div>
+        <p>
+          The <code>EDC15C7Reader</code> automatically sends a
+          <code>testerPresent</code> (SID <code>0x3E</code>) keepalive
+          every 2 seconds to prevent the ECU from closing the diagnostic
+          session due to inactivity. This runs in the same polling loop as
+          the PID reads.
+        </p>
+      </div>
+
+      <hr>
+
+      <!-- ============================================================
+           SECTION 7: VERIFICATION
+           ============================================================ -->
+
+      <h2 id="verification">Verification</h2>
+
+      <p>
+        After building the adapter and connecting it, verify the entire chain
+        from USB device to live ECU data:
+      </p>
+
+      <h3>Step 1: Check Adapter Detection</h3>
+
+      <pre><code># Verify the CP2102 is detected by the kernel
+lsusb | grep -i "cp2102\|10c4"
+# Expected: Bus 00x Device 00x: ID 10c4:ea60 Silicon Labs CP210x UART Bridge
+
+# Verify the udev symlink exists
+ls -la /dev/ttyUSB_kline
+# Expected: lrwxrwxrwx 1 root root 7 ... /dev/ttyUSB_kline -> ttyUSB0</code></pre>
+
+      <h3>Step 2: Check BCM Logs (Engine Running)</h3>
+
+      <pre><code># Start the engine (key position II = ignition ON, or engine running)
+# Then check BCM logs for ECU communication:
+grep "edc15c7\|kline\|RPM\|coolant" /opt/bcm/logs/bcm.log | tail -10
+
+# Expected output (example):
+# obd.kline  - K-Line opened: /dev/ttyUSB_kline @ 10400 baud
+# obd.kline  - 5-baud init response: sync=0x55 KB1=0x08 KB2=0x08
+# obd.kline  - 5-baud init successful! ECU acknowledged.
+# obd.edc15c7 - EDC15C7 reader started (polling 5 PIDs)</code></pre>
+
+      <h3>Step 3: Live Data via Web API</h3>
+
+      <pre><code># Query the BCM REST API for live ECU data
+curl -s http://localhost:5002/api/status | python3 -m json.tool | grep -E "rpm|speed|coolant"
+
+# Expected output (with engine running):
+#   "rpm": 850.0,
+#   "speed": 0.0,
+#   "coolant_temp": 72.0</code></pre>
+
+      <hr>
+
+      <!-- ============================================================
+           SECTION 8: TROUBLESHOOTING
+           ============================================================ -->
+
+      <h2 id="troubleshooting">Troubleshooting</h2>
+
+      <h3>No ECU Response</h3>
+
+      <div class="box box-warning">
+        <div class="box-title">No ECU response during initialization</div>
+        <p>
+          <strong>Symptom:</strong> BCM logs show
+          <code>5-baud init: incomplete response (0 bytes)</code>
+          or <code>No ECU acknowledgement received</code>.
+        </p>
+        <p><strong>Check:</strong></p>
+        <ul>
+          <li>Verify 12V is present at OBD-II pin 16 with a multimeter</li>
+          <li>Confirm K-Line wire is connected to OBD-II pin 7 (not pin 6 or 14)</li>
+          <li>Check L9637D orientation &mdash; pin 1 dot/notch must face the correct direction</li>
+          <li>Verify the 510&Omega; pull-up resistor is between pin 16 (12V) and the K-Line</li>
+          <li>Measure L9637D VCC (pin 3): should be 4.5&ndash;5.5V</li>
+          <li>Make sure EN (pin 8) is tied to VCC</li>
+        </ul>
+      </div>
+
+      <h3>Timeout During Initialization</h3>
+
+      <div class="box box-warning">
+        <div class="box-title">Timeout or partial response</div>
+        <p>
+          <strong>Symptom:</strong> Sync byte <code>0x55</code> is received but
+          key bytes are missing, or the ECU sends no response at all.
+        </p>
+        <p><strong>Check:</strong></p>
+        <ul>
+          <li>The ignition must be ON (key position II, dashboard lights on).
+              The ECU does not respond when the ignition is OFF.</li>
+          <li>Try with the engine running &mdash; some ECUs only respond after cranking</li>
+          <li>Verify baud rate is 10400 in the configuration</li>
+          <li>Check for loose connections on the OBD-II plug</li>
+        </ul>
+      </div>
+
+      <h3>Wrong or Nonsensical Data</h3>
+
+      <div class="box box-warning">
+        <div class="box-title">Data values are incorrect</div>
+        <p>
+          <strong>Symptom:</strong> RPM shows 16000, coolant shows &minus;40&deg;C,
+          or values jump randomly.
+        </p>
+        <p><strong>Check:</strong></p>
+        <ul>
+          <li>Verify <code>ecu_address</code> is set to <code>1</code> (0x01)
+              in <code>bcm_config.yaml</code> &mdash; this must match the EDC15C7</li>
+          <li>Check for electrical noise &mdash; route K-Line wire away from ignition coils and alternator</li>
+          <li>Verify the 100nF decoupling capacitor is present on the L9637D</li>
+          <li>Check that TX/RX are not swapped between CP2102 and L9637D</li>
+        </ul>
+      </div>
+
+      <h3>Permission Denied</h3>
+
+      <div class="box box-warning">
+        <div class="box-title">Cannot open serial port</div>
+        <p>
+          <strong>Symptom:</strong> <code>PermissionError: [Errno 13] Permission denied: '/dev/ttyUSB_kline'</code>
+        </p>
+        <p><strong>Fix:</strong></p>
+        <ul>
+          <li>Add user to the <code>dialout</code> group:
+              <code>sudo usermod -aG dialout $USER</code></li>
+          <li>Log out and log back in (or reboot) for group changes to take effect</li>
+          <li>Verify with: <code>groups $USER</code> &mdash; should include <code>dialout</code></li>
+        </ul>
+      </div>
+
+      <h3>Keepalive Failures</h3>
+
+      <div class="box box-info">
+        <div class="box-title">Frequent keepalive warnings</div>
+        <p>
+          If the log shows <code>Keepalive failed</code> warnings, the ECU
+          session may be timing out. This can happen if the polling loop is
+          blocked or if there is excessive electrical noise. BCM will
+          automatically attempt to re-initialize the connection after 10
+          consecutive errors. Check for other USB devices causing CPU load
+          spikes or interrupt conflicts.
+        </p>
+      </div>
+
+      <!-- ---- Page Navigation ---- -->
+      <div class="page-nav">
+        <a href="04-software.html">&larr; 04 &mdash; BCM Software</a>
+        <a href="06-arduino.html">06 &mdash; Arduino Wiring &rarr;</a>
+      </div>
+
+      <!-- ---- Footer ---- -->
+      <footer class="page-footer">
+        <span>BCM v8.5 &mdash; x86 Production Documentation</span>
+        <span>Alfa Romeo 156 Headunit Project</span>
+      </footer>
+
+    </div>
+  </main>
+
+  <!-- Sidebar Toggle Script -->
+  <script>
+    function toggleSidebar() {
+      document.querySelector('.sidebar').classList.toggle('open');
+      document.querySelector('.sidebar-overlay').classList.toggle('active');
+    }
+
+    // Close sidebar when a nav link is clicked (mobile)
+    document.querySelectorAll('.sidebar nav a').forEach(function(link) {
+      link.addEventListener('click', function() {
+        if (window.innerWidth < 768) {
+          document.querySelector('.sidebar').classList.remove('open');
+          document.querySelector('.sidebar-overlay').classList.remove('active');
+        }
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/docs/x86-production/06-arduino.html
+++ b/docs/x86-production/06-arduino.html
@@ -1,0 +1,695 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>06 — Arduino Firmware &amp; Protocol | BCM x86 Production</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+
+  <!-- Hamburger toggle (mobile) -->
+  <button class="hamburger" aria-label="Toggle navigation" onclick="toggleSidebar()">&#9776;</button>
+  <div class="sidebar-overlay" onclick="toggleSidebar()"></div>
+
+  <!-- Sidebar Navigation -->
+  <aside class="sidebar">
+    <div class="sidebar-header">
+      <div class="logo-text">BCM v8.5</div>
+      <div class="logo-sub">Lenovo M910q &middot; Alfa 156</div>
+    </div>
+    <nav aria-label="Documentation pages">
+      <ul>
+        <li><a href="index.html"><span class="nav-num"></span>Overview</a></li>
+        <li><a href="01-bom.html"><span class="nav-num">01</span>Bill of Materials</a></li>
+        <li><a href="02-power.html"><span class="nav-num">02</span>Power Supply</a></li>
+        <li><a href="03-os-install.html"><span class="nav-num">03</span>OS Installation</a></li>
+        <li><a href="04-packages.html"><span class="nav-num">04</span>System Packages</a></li>
+        <li><a href="05-bcm-install.html"><span class="nav-num">05</span>BCM Installation</a></li>
+        <li><a href="06-systemd.html"><span class="nav-num">06</span>Systemd Services</a></li>
+        <li><a href="07-boot.html"><span class="nav-num">07</span>Boot &amp; Splash</a></li>
+        <li><a href="08-kiosk.html"><span class="nav-num">08</span>Kiosk Display</a></li>
+        <li><a href="09-suspend.html"><span class="nav-num">09</span>Suspend / Wake</a></li>
+        <li><a href="10-wifi.html"><span class="nav-num">10</span>WiFi &amp; Android Auto</a></li>
+        <li><a href="11-arduino.html"><span class="nav-num">11</span>Arduino Wiring</a></li>
+        <li><a href="12-verification.html"><span class="nav-num">12</span>Verification</a></li>
+      </ul>
+    </nav>
+  </aside>
+
+  <!-- Main Content -->
+  <div class="content">
+    <div class="content-inner">
+
+      <header>
+        <h1>
+          Arduino Firmware &amp; Serial Protocol
+          <span class="subtitle">Input controller (Pro Micro) and output controller (Nano) for vehicle I/O</span>
+        </h1>
+      </header>
+
+      <article>
+
+        <!-- ============================================================
+             OVERVIEW
+             ============================================================ -->
+        <section>
+          <h2 id="overview">Overview</h2>
+
+          <p>
+            The x86 M910q has no GPIO header, so all vehicle I/O passes through
+            two USB Arduinos connected via the powered USB hub:
+          </p>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Arduino</th>
+                  <th>MCU</th>
+                  <th>Role</th>
+                  <th>Baud Rate</th>
+                  <th>USB Mode</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><strong>#1 &mdash; Pro Micro</strong></td>
+                  <td>ATmega32U4</td>
+                  <td>Input &mdash; buttons, sensors, vehicle signals</td>
+                  <td>115200</td>
+                  <td>HID + Serial (native USB)</td>
+                </tr>
+                <tr>
+                  <td><strong>#2 &mdash; Nano</strong></td>
+                  <td>ATmega328P</td>
+                  <td>Output &mdash; relays, locks, lights, horn</td>
+                  <td>9600</td>
+                  <td>Serial only (CH340 USB-UART)</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="box box-info">
+            <div class="box-title">Dual USB</div>
+            <p>
+              The Pro Micro (ATmega32U4) exposes <strong>both</strong> a HID keyboard
+              device and a CDC serial port over a single USB connection. Button presses
+              are sent as USB HID keycodes (handled by <code>evdev</code> /
+              <code>arduino_hid.py</code>), while sensor data and vehicle signals
+              are sent as plain-text serial messages (handled by
+              <code>arduino_serial.py</code>). Both streams arrive on the same
+              <code>/dev/ttyACM0</code> port.
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             ARDUINO #1 — PRO MICRO INPUT CONTROLLER
+             ============================================================ -->
+        <section>
+          <h2 id="pro-micro">Arduino #1 &mdash; Pro Micro Input Controller</h2>
+
+          <h3>Hardware</h3>
+          <ul>
+            <li><strong>MCU:</strong> ATmega32U4 (native USB, no separate UART chip)</li>
+            <li><strong>USB:</strong> HID keyboard + CDC serial at <strong>115200 baud</strong></li>
+            <li><strong>Port:</strong> <code>/dev/ttyACM0</code> (or <code>ttyACM1</code>)</li>
+            <li><strong>Firmware:</strong> <code>arduino/rotary_encoder/rotary_encoder.ino</code></li>
+            <li><strong>Libraries:</strong> <code>Keyboard.h</code>, <code>HID-Project.h</code>, <code>EEPROM.h</code></li>
+          </ul>
+
+          <h3>Pin Assignments</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Function</th>
+                  <th>Pin(s)</th>
+                  <th>Notes</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Rotary encoder CLK</td>
+                  <td>D2</td>
+                  <td>External 10k&Omega; pull-up to VCC; interrupt-driven</td>
+                </tr>
+                <tr>
+                  <td>Rotary encoder DT</td>
+                  <td>D3</td>
+                  <td>External 10k&Omega; pull-up to VCC</td>
+                </tr>
+                <tr>
+                  <td>Encoder button (SW)</td>
+                  <td>D4</td>
+                  <td>Internal pull-up; press &rarr; KEY_RETURN</td>
+                </tr>
+                <tr>
+                  <td>HOME button</td>
+                  <td>D5</td>
+                  <td>Internal pull-up; press &rarr; KEY_HOME</td>
+                </tr>
+                <tr>
+                  <td>BACK button</td>
+                  <td>D6</td>
+                  <td>Internal pull-up; press &rarr; KEY_BACKSPACE</td>
+                </tr>
+                <tr>
+                  <td>MEDIA button</td>
+                  <td>D7</td>
+                  <td>Internal pull-up; press &rarr; MEDIA_PLAY_PAUSE</td>
+                </tr>
+                <tr>
+                  <td>VOL+ button</td>
+                  <td>D8</td>
+                  <td>Internal pull-up; press &rarr; MEDIA_VOLUME_UP</td>
+                </tr>
+                <tr>
+                  <td>VOL&minus; button</td>
+                  <td>D9</td>
+                  <td>Internal pull-up; press &rarr; MEDIA_VOLUME_DOWN</td>
+                </tr>
+                <tr>
+                  <td>Music PREV</td>
+                  <td>D10</td>
+                  <td>Internal pull-up; press &rarr; MEDIA_PREVIOUS</td>
+                </tr>
+                <tr>
+                  <td>Music NEXT</td>
+                  <td>D14</td>
+                  <td>Internal pull-up; press &rarr; MEDIA_NEXT</td>
+                </tr>
+                <tr>
+                  <td>Music VOL+</td>
+                  <td>D15</td>
+                  <td>Internal pull-up; press &rarr; MEDIA_VOLUME_UP</td>
+                </tr>
+                <tr>
+                  <td>Music VOL&minus;</td>
+                  <td>D16</td>
+                  <td>Internal pull-up; press &rarr; MEDIA_VOLUME_DOWN</td>
+                </tr>
+                <tr>
+                  <td>Music MUTE</td>
+                  <td>A3</td>
+                  <td>Internal pull-up; press &rarr; MEDIA_VOLUME_MUTE</td>
+                </tr>
+                <tr>
+                  <td>LDR light sensor</td>
+                  <td>A1</td>
+                  <td>Voltage divider: LDR + 10k&Omega; to GND &rarr; A1</td>
+                </tr>
+                <tr>
+                  <td>Brightness stalk button</td>
+                  <td>A2</td>
+                  <td>Internal pull-up; press &rarr; KEY_F9 (brightness cycle)</td>
+                </tr>
+                <tr>
+                  <td>SWC pod 1</td>
+                  <td>A0</td>
+                  <td>Resistor ladder, 12 buttons (analog 0&ndash;5 V)</td>
+                </tr>
+                <tr>
+                  <td>SWC pod 2</td>
+                  <td>A6</td>
+                  <td>Resistor ladder, 12 buttons (analog 0&ndash;5 V)</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>SWC Button Mapping (24 Buttons)</h3>
+
+          <p>
+            Each SWC pod provides 12 buttons via a resistor-ladder circuit. The
+            white wire from each SWC decoder box connects to an analog pin;
+            black to GND and red to 12 V ACC. The firmware reads the ADC value,
+            matches it against calibrated thresholds (tolerance &plusmn;40), and
+            sends the corresponding HID keycode.
+          </p>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Index</th>
+                  <th>Button</th>
+                  <th>Default ADC</th>
+                  <th>HID Keycode</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td>0</td><td>VOL+</td><td>75</td><td>MEDIA_VOLUME_UP</td></tr>
+                <tr><td>1</td><td>VOL&minus;</td><td>150</td><td>MEDIA_VOLUME_DOWN</td></tr>
+                <tr><td>2</td><td>UP</td><td>230</td><td>KEY_UP_ARROW</td></tr>
+                <tr><td>3</td><td>DOWN</td><td>310</td><td>KEY_DOWN_ARROW</td></tr>
+                <tr><td>4</td><td>MUTE</td><td>390</td><td>MEDIA_VOLUME_MUTE</td></tr>
+                <tr><td>5</td><td>MODE</td><td>470</td><td>KEY_F10 (power toggle)</td></tr>
+                <tr><td>6</td><td>NEXT</td><td>540</td><td>MEDIA_NEXT</td></tr>
+                <tr><td>7</td><td>PREV</td><td>610</td><td>MEDIA_PREVIOUS</td></tr>
+                <tr><td>8</td><td>PICKUP</td><td>690</td><td>KEY_F5</td></tr>
+                <tr><td>9</td><td>HANGUP</td><td>760</td><td>KEY_F6</td></tr>
+                <tr><td>10</td><td>VOICE</td><td>830</td><td>KEY_F7 (AA voice)</td></tr>
+                <tr><td>11</td><td>SRC</td><td>900</td><td>KEY_F8 (AA navigate)</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <p>
+            Pod 2 (indices 12&ndash;23) sends identical keycodes to Pod 1.
+            ADC values above <code>1000</code> are treated as idle (no button pressed).
+          </p>
+
+          <h3>SWC Calibration</h3>
+
+          <p>
+            Default ADC thresholds may not match your specific SWC decoder boxes.
+            The firmware includes an EEPROM-backed calibration routine:
+          </p>
+
+          <ol>
+            <li>Hold <strong>HOME + BACK</strong> while powering on the Arduino</li>
+            <li>Open serial monitor at 115200 baud</li>
+            <li>Press each button when prompted &mdash; Pod 1 first (12 buttons), then Pod 2 (12 buttons)</li>
+            <li>Calibrated ADC values are saved to EEPROM (magic byte <code>0xBD</code> at address 0)</li>
+            <li>Values persist across power cycles; re-calibrate by repeating the process</li>
+          </ol>
+
+          <div class="box box-warning">
+            <div class="box-title">Collision warning</div>
+            <p>
+              After calibration, the firmware checks for buttons with ADC values
+              closer than &plusmn;40 counts and prints a warning. If two buttons
+              collide, adjust the resistor values in the SWC decoder pod.
+            </p>
+          </div>
+
+          <h3>Flashing the Pro Micro</h3>
+
+          <ol>
+            <li>Open <code>arduino/rotary_encoder/rotary_encoder.ino</code> in Arduino IDE</li>
+            <li>Install the <strong>HID-Project</strong> library via Library Manager</li>
+            <li>Select board: <strong>Arduino Leonardo</strong> (ATmega32U4 boards share this profile)</li>
+            <li>Select port: <code>/dev/ttyACM0</code></li>
+            <li>Upload &mdash; the Pro Micro resets automatically via USB</li>
+          </ol>
+
+          <div class="box box-info">
+            <div class="box-title">Why Arduino Leonardo?</div>
+            <p>
+              The Pro Micro uses the same ATmega32U4 as the Leonardo. Arduino IDE
+              does not list "Pro Micro" by default &mdash; select
+              <strong>Arduino Leonardo</strong> and it will flash correctly.
+              If using SparkFun boards, install the SparkFun AVR boards package
+              and select <strong>SparkFun Pro Micro (5V, 16MHz)</strong>.
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             ARDUINO #2 — NANO OUTPUT CONTROLLER
+             ============================================================ -->
+        <section>
+          <h2 id="nano">Arduino #2 &mdash; Nano Output Controller</h2>
+
+          <h3>Hardware</h3>
+          <ul>
+            <li><strong>MCU:</strong> ATmega328P (CH340 USB-UART bridge)</li>
+            <li><strong>USB:</strong> Serial only at <strong>9600 baud</strong></li>
+            <li><strong>Port:</strong> <code>/dev/ttyUSB0</code> (or <code>ttyUSB1</code>)</li>
+            <li><strong>Relay module:</strong> 10-channel, active-low, opto-isolated</li>
+          </ul>
+
+          <h3>Pin Assignments</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Function</th>
+                  <th>Pin</th>
+                  <th>Notes</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Lock relay</td>
+                  <td>D2</td>
+                  <td>200 ms pulse</td>
+                </tr>
+                <tr>
+                  <td>Unlock relay</td>
+                  <td>D3</td>
+                  <td>200 ms pulse</td>
+                </tr>
+                <tr>
+                  <td>Trunk relay</td>
+                  <td>D4</td>
+                  <td>200 ms pulse</td>
+                </tr>
+                <tr>
+                  <td>Window up</td>
+                  <td>D5</td>
+                  <td>Hold while active</td>
+                </tr>
+                <tr>
+                  <td>Window down</td>
+                  <td>D6</td>
+                  <td>Hold while active</td>
+                </tr>
+                <tr>
+                  <td>Headlights</td>
+                  <td>D7</td>
+                  <td>On/off + configurable timeout</td>
+                </tr>
+                <tr>
+                  <td>Left blinker</td>
+                  <td>D8</td>
+                  <td>On/off toggle</td>
+                </tr>
+                <tr>
+                  <td>Right blinker</td>
+                  <td>D9</td>
+                  <td>On/off toggle</td>
+                </tr>
+                <tr>
+                  <td>Wipers</td>
+                  <td>D10</td>
+                  <td>Pulse (duration-controlled)</td>
+                </tr>
+                <tr>
+                  <td>Horn</td>
+                  <td>D11</td>
+                  <td>Hold while active</td>
+                </tr>
+                <tr>
+                  <td>RF receiver</td>
+                  <td>D12</td>
+                  <td>RXB6 433 MHz receiver (data input)</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>JSON Command Protocol</h3>
+
+          <p>
+            The BCM sends JSON commands over serial to the Nano at 9600 baud.
+            Each command is a single JSON object terminated by a newline character.
+          </p>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Command</th>
+                  <th>JSON Example</th>
+                  <th>Behaviour</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Lock doors</td>
+                  <td><code>{"cmd":"lock"}</code></td>
+                  <td>D2 pulse 200 ms</td>
+                </tr>
+                <tr>
+                  <td>Unlock doors</td>
+                  <td><code>{"cmd":"unlock"}</code></td>
+                  <td>D3 pulse 200 ms</td>
+                </tr>
+                <tr>
+                  <td>Trunk release</td>
+                  <td><code>{"cmd":"trunk"}</code></td>
+                  <td>D4 pulse 200 ms</td>
+                </tr>
+                <tr>
+                  <td>Headlights</td>
+                  <td><code>{"cmd":"lights","state":1,"timeout":60}</code></td>
+                  <td>D7 on; auto-off after 60 s</td>
+                </tr>
+                <tr>
+                  <td>Wipers</td>
+                  <td><code>{"cmd":"wipers","duration":5}</code></td>
+                  <td>D10 active for 5 s</td>
+                </tr>
+                <tr>
+                  <td>Horn</td>
+                  <td><code>{"cmd":"horn","state":1}</code></td>
+                  <td>D11 hold while state=1</td>
+                </tr>
+                <tr>
+                  <td>Blinkers</td>
+                  <td><code>{"cmd":"blinker","side":"left","state":1}</code></td>
+                  <td>D8 or D9 on/off</td>
+                </tr>
+                <tr>
+                  <td>Window</td>
+                  <td><code>{"cmd":"window","dir":"up","state":1}</code></td>
+                  <td>D5 or D6 hold while state=1</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="box box-warning">
+            <div class="box-title">Nano firmware not in repo yet</div>
+            <p>
+              The output Arduino Nano firmware is not yet committed to the repository.
+              The protocol documented above is the <strong>expected interface</strong>
+              that the BCM Python code will send. When implementing the Nano firmware,
+              use <code>ArduinoJson</code> to parse incoming serial data and drive
+              the relay module pins accordingly. The RF receiver (D12) should use
+              the <code>RCSwitch</code> library to decode 433 MHz keyfob signals.
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             SERIAL PROTOCOL (INPUT MESSAGES → BCM)
+             ============================================================ -->
+        <section>
+          <h2 id="serial-protocol">Serial Protocol &mdash; Input Messages</h2>
+
+          <p>
+            The Pro Micro sends plain-text serial messages to the BCM over
+            <code>/dev/ttyACM0</code> at 115200 baud. The Python module
+            <code>src/input/arduino_serial.py</code> (<code>ArduinoSerialListener</code>
+            class) parses each line and publishes it to the event bus. Auto-detection
+            tries <code>/dev/ttyACM0..1</code>, <code>/dev/ttyUSB0..2</code>, and
+            falls back to stub mode if no port is found.
+          </p>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Message</th>
+                  <th>Example</th>
+                  <th>Event Bus Topic</th>
+                  <th>Value Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>DOOR:keys</code></td>
+                  <td><code>DOOR:FL=1,FR=0,RL=0,RR=0,BONNET=0,TRUNK=0</code></td>
+                  <td><code>vehicle.doors</code></td>
+                  <td>dict {fl, fr, rl, rr, bonnet, trunk} &rarr; bool</td>
+                </tr>
+                <tr>
+                  <td><code>HBRAKE:X</code></td>
+                  <td><code>HBRAKE:1</code></td>
+                  <td><code>vehicle.handbrake</code></td>
+                  <td>bool</td>
+                </tr>
+                <tr>
+                  <td><code>IGN:X</code></td>
+                  <td><code>IGN:1</code></td>
+                  <td><code>vehicle.ignition_raw</code></td>
+                  <td>bool</td>
+                </tr>
+                <tr>
+                  <td><code>RAIN:X</code></td>
+                  <td><code>RAIN:1</code></td>
+                  <td><code>vehicle.rain</code></td>
+                  <td>bool</td>
+                </tr>
+                <tr>
+                  <td><code>TEMP:XX.X</code></td>
+                  <td><code>TEMP:23.5</code></td>
+                  <td><code>vehicle.ext_temp_raw</code></td>
+                  <td>float (&deg;C)</td>
+                </tr>
+                <tr>
+                  <td><code>PARK:keys</code></td>
+                  <td><code>PARK:FL=45,FR=123,RL=200,RR=180</code></td>
+                  <td><code>vehicle.parking_raw</code></td>
+                  <td>dict {fl, fr, rl, rr} &rarr; int (cm)</td>
+                </tr>
+                <tr>
+                  <td><code>LIGHT:XXX</code></td>
+                  <td><code>LIGHT:512</code></td>
+                  <td><code>arduino.light_level</code></td>
+                  <td>int (ADC 0&ndash;1023)</td>
+                </tr>
+                <tr>
+                  <td><code>CRUISE:X</code></td>
+                  <td><code>CRUISE:1</code></td>
+                  <td><code>vehicle.cruise</code></td>
+                  <td>bool</td>
+                </tr>
+                <tr>
+                  <td><code>IMMO:X</code></td>
+                  <td><code>IMMO:1</code></td>
+                  <td><code>vehicle.immo_ok</code></td>
+                  <td>bool</td>
+                </tr>
+                <tr>
+                  <td><code>AIRBAG:X</code></td>
+                  <td><code>AIRBAG:1</code></td>
+                  <td><code>vehicle.airbag_ok</code></td>
+                  <td>bool</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <p>
+            Debug messages (<code>SWC:...</code>, <code>MUSIC:...</code>,
+            <code>STALK:...</code>) are logged but not published to the event bus.
+            Unrecognised lines are logged at debug level.
+          </p>
+
+          <h3>Timing</h3>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Message</th>
+                  <th>Frequency</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>LIGHT:XXX</code></td>
+                  <td>Every 2 seconds (<code>LIGHT_REPORT_MS = 2000</code>)</td>
+                </tr>
+                <tr>
+                  <td><code>TEMP:XX.X</code></td>
+                  <td>Every 10 seconds (<code>DEFAULT_READ_INTERVAL = 10.0</code>)</td>
+                </tr>
+                <tr>
+                  <td><code>PARK:keys</code></td>
+                  <td>Continuous when reverse engaged (~4 scans/s, 240 ms cycle)</td>
+                </tr>
+                <tr>
+                  <td>All others</td>
+                  <td>On change (interrupt-driven via optoisolators)</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             VERIFICATION
+             ============================================================ -->
+        <section>
+          <h2 id="verification">Verification</h2>
+
+          <h3>Check serial connection</h3>
+
+          <pre><code># Verify Arduino is detected
+ls -la /dev/ttyACM*
+# Should show: /dev/ttyACM0 (Pro Micro)
+
+ls -la /dev/ttyUSB*
+# Should show: /dev/ttyUSB0 (Nano, if connected)
+
+# Check dmesg for USB enumeration
+dmesg | grep -i "ttyACM\|ttyUSB\|arduino\|ch341\|cdc_acm"</code></pre>
+
+          <h3>Test Pro Micro serial output</h3>
+
+          <pre><code># Install minicom if not present
+sudo apt install minicom
+
+# Open serial monitor for Pro Micro
+minicom -D /dev/ttyACM0 -b 115200
+
+# Expected output on startup:
+#   BCM v7 Input Controller ready (encoder + buttons + SWC + music + brightness)
+# Then every 2 seconds:
+#   LIGHT:512
+# Press buttons to see SWC/MUSIC debug lines</code></pre>
+
+          <h3>Test Nano serial output</h3>
+
+          <pre><code># Open serial monitor for Nano
+minicom -D /dev/ttyUSB0 -b 9600
+
+# Send a JSON command (type in minicom):
+#   {"cmd":"lock"}
+# The lock relay should pulse for 200ms</code></pre>
+
+          <h3>Test BCM integration</h3>
+
+          <pre><code># Check BCM log for Arduino serial detection
+sudo journalctl -u bcm-headunit --no-pager | grep -i "arduino"
+# Should show: "Arduino serial listener started: /dev/ttyACM0"
+
+# Monitor event bus for live sensor data
+# (in BCM debug console or log)
+# Look for: arduino.light_level, vehicle.doors, vehicle.ignition_raw</code></pre>
+
+          <div class="box box-info">
+            <div class="box-title">Permissions</div>
+            <p>
+              If <code>/dev/ttyACM0</code> or <code>/dev/ttyUSB0</code> returns
+              "permission denied", add the BCM user to the <code>dialout</code>
+              group: <code>sudo usermod -aG dialout $USER</code> then log out
+              and back in.
+            </p>
+          </div>
+        </section>
+
+      </article>
+
+      <!-- Page Navigation -->
+      <div class="page-nav">
+        <a href="05-kline-obd.html">&larr; 05 &mdash; K-Line / OBD</a>
+        <a href="07-sensors.html">07 &mdash; Sensors &rarr;</a>
+      </div>
+
+      <!-- Footer -->
+      <footer class="page-footer">
+        <span>BCM v8.5 &mdash; Alfa Romeo 156 Headunit</span>
+        <span>Lenovo M910q x86 Production Build</span>
+      </footer>
+
+    </div>
+  </div>
+
+  <!-- Sidebar Toggle Script -->
+  <script>
+    function toggleSidebar() {
+      document.querySelector('.sidebar').classList.toggle('open');
+      document.querySelector('.sidebar-overlay').classList.toggle('active');
+    }
+
+    document.querySelectorAll('.sidebar nav a').forEach(function(link) {
+      link.addEventListener('click', function() {
+        if (window.innerWidth < 768) {
+          document.querySelector('.sidebar').classList.remove('open');
+          document.querySelector('.sidebar-overlay').classList.remove('active');
+        }
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/docs/x86-production/07-sensors.html
+++ b/docs/x86-production/07-sensors.html
@@ -1,0 +1,683 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>07 — Sensors | BCM x86 Production</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+
+  <!-- Hamburger toggle (mobile) -->
+  <button class="hamburger" aria-label="Toggle navigation" onclick="toggleSidebar()">&#9776;</button>
+  <div class="sidebar-overlay" onclick="toggleSidebar()"></div>
+
+  <!-- Sidebar Navigation -->
+  <aside class="sidebar">
+    <div class="sidebar-header">
+      <div class="logo-text">BCM v8.5</div>
+      <div class="logo-sub">Lenovo M910q &middot; Alfa 156</div>
+    </div>
+    <nav aria-label="Documentation pages">
+      <ul>
+        <li><a href="index.html"><span class="nav-num"></span>Overview</a></li>
+        <li><a href="01-bom.html"><span class="nav-num">01</span>Bill of Materials</a></li>
+        <li><a href="02-power.html"><span class="nav-num">02</span>Power Supply</a></li>
+        <li><a href="03-os-install.html"><span class="nav-num">03</span>OS Installation</a></li>
+        <li><a href="04-packages.html"><span class="nav-num">04</span>System Packages</a></li>
+        <li><a href="05-bcm-install.html"><span class="nav-num">05</span>BCM Installation</a></li>
+        <li><a href="06-systemd.html"><span class="nav-num">06</span>Systemd Services</a></li>
+        <li><a href="07-boot.html"><span class="nav-num">07</span>Boot &amp; Splash</a></li>
+        <li><a href="08-kiosk.html"><span class="nav-num">08</span>Kiosk Display</a></li>
+        <li><a href="09-suspend.html"><span class="nav-num">09</span>Suspend / Wake</a></li>
+        <li><a href="10-wifi.html"><span class="nav-num">10</span>WiFi &amp; Android Auto</a></li>
+        <li><a href="11-arduino.html"><span class="nav-num">11</span>Arduino Wiring</a></li>
+        <li><a href="12-verification.html"><span class="nav-num">12</span>Verification</a></li>
+      </ul>
+    </nav>
+  </aside>
+
+  <!-- Main Content -->
+  <div class="content">
+    <div class="content-inner">
+
+      <header>
+        <h1>
+          Environmental Sensors
+          <span class="subtitle">Temperature, parking, rain, light, and optoisolator wiring for vehicle signals</span>
+        </h1>
+      </header>
+
+      <article>
+
+        <!-- ============================================================
+             OVERVIEW
+             ============================================================ -->
+        <section>
+          <h2 id="overview">Overview</h2>
+
+          <p>
+            On the x86 platform (Lenovo M910q), there is no GPIO header.
+            All sensors connect through the <strong>Arduino Pro Micro</strong>
+            via USB. The Arduino reads sensor data, formats it as serial
+            messages, and sends it to the BCM over <code>/dev/ttyACM0</code>
+            at 115200 baud. The Python module
+            <code>src/input/arduino_serial.py</code> parses each message
+            and publishes it to the event bus.
+          </p>
+
+          <div class="box box-info">
+            <div class="box-title">OPi vs x86</div>
+            <p>
+              On the Orange Pi, sensors like the DS18B20 connect directly to
+              the GPIO header via the kernel 1-Wire driver. On x86, the same
+              sensor connects to the Arduino, which reads it and sends
+              <code>TEMP:23.5</code> over serial. The BCM software handles
+              both paths transparently via the config option
+              <code>environment.temperature.source: arduino</code> (default on x86).
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             DS18B20 TEMPERATURE SENSOR
+             ============================================================ -->
+        <section>
+          <h2 id="ds18b20">DS18B20 Temperature Sensor</h2>
+
+          <h3>Specifications</h3>
+          <ul>
+            <li><strong>Type:</strong> Dallas DS18B20 digital 1-Wire temperature sensor</li>
+            <li><strong>Range:</strong> &minus;55 &deg;C to +125 &deg;C (&plusmn;0.5 &deg;C accuracy)</li>
+            <li><strong>Probe:</strong> Waterproof stainless steel, cable length ~1 m</li>
+            <li><strong>Mounting:</strong> Under the front bumper (external air temperature)</li>
+            <li><strong>Arduino pin:</strong> D14 (1-Wire data)</li>
+          </ul>
+
+          <h3>Wiring</h3>
+
+          <pre><code>                    4.7k&Omega;
+  Arduino 5V ────┬──[####]──┐
+                 │           │
+                 │    DS18B20 (waterproof probe)
+                 │    ┌─────────────┐
+  Arduino D14 ───┼────┤ DQ (data)   │
+                 │    │ VDD (power)  ├─── Arduino 5V
+                 │    │ GND (ground) ├─── Arduino GND
+                 │    └─────────────┘
+                 │
+  Arduino GND ───┘</code></pre>
+
+          <div class="box box-info">
+            <div class="box-title">Pull-up resistor</div>
+            <p>
+              The 4.7 k&Omega; pull-up between DQ and 5 V is required for
+              reliable 1-Wire communication. Without it, readings will be
+              intermittent or stuck at 85.0 &deg;C (the DS18B20 power-on default).
+              Use powered mode (VDD connected), not parasitic mode.
+            </p>
+          </div>
+
+          <h3>Serial Output</h3>
+
+          <p>
+            The Arduino reads the DS18B20 every <strong>10 seconds</strong>
+            (<code>DEFAULT_READ_INTERVAL = 10.0</code> in
+            <code>src/environment/ds18b20.py</code>) and sends:
+          </p>
+
+          <pre><code>TEMP:23.5</code></pre>
+
+          <p>
+            The BCM parses this and publishes <code>vehicle.ext_temp_raw</code>
+            (float, degrees Celsius) to the event bus.
+          </p>
+
+          <h3>Configuration</h3>
+
+          <pre><code># config/bcm.yml
+environment:
+  temperature:
+    source: arduino        # "arduino" (x86 default) or "onewire" (OPi)
+    read_interval: 10      # seconds between readings
+    offset: 0.0            # calibration offset in °C</code></pre>
+        </section>
+
+        <!-- ============================================================
+             HC-SR04 ULTRASONIC PARKING SENSORS
+             ============================================================ -->
+        <section>
+          <h2 id="hcsr04">HC-SR04 Ultrasonic Parking Sensors (4&times;)</h2>
+
+          <h3>Specifications</h3>
+          <ul>
+            <li><strong>Type:</strong> HC-SR04 ultrasonic distance sensor</li>
+            <li><strong>Range:</strong> 2 cm to 250 cm (max distance capped at 2.5 m in firmware)</li>
+            <li><strong>Measurement cycle:</strong> ~60 ms per sensor, ~240 ms for all four (sequential to avoid cross-talk)</li>
+            <li><strong>Speed of sound:</strong> 343 m/s at ~20 &deg;C</li>
+          </ul>
+
+          <h3>Pin Assignments</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Sensor</th>
+                  <th>TRIG Pin</th>
+                  <th>ECHO Pin</th>
+                  <th>Position</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Front Left (FL)</td>
+                  <td>D15 (shared)</td>
+                  <td>D16</td>
+                  <td>Rear bumper, left</td>
+                </tr>
+                <tr>
+                  <td>Front Right (FR)</td>
+                  <td>D15 (shared)</td>
+                  <td>A2</td>
+                  <td>Rear bumper, centre-left</td>
+                </tr>
+                <tr>
+                  <td>Rear Left (RL)</td>
+                  <td>D15 (shared)</td>
+                  <td>A3</td>
+                  <td>Rear bumper, centre-right</td>
+                </tr>
+                <tr>
+                  <td>Rear Right (RR)</td>
+                  <td>D15 (shared)</td>
+                  <td>A7</td>
+                  <td>Rear bumper, right</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>Wiring (per sensor)</h3>
+
+          <pre><code>  Arduino D15 (TRIG) ─────────── HC-SR04 TRIG
+  HC-SR04 ECHO ──────────────── Arduino D16 (or A2/A3/A7)
+  HC-SR04 VCC ───────────────── Arduino 5V
+  HC-SR04 GND ───────────────── Arduino GND</code></pre>
+
+          <div class="box box-info">
+            <div class="box-title">Voltage divider (optional)</div>
+            <p>
+              The HC-SR04 ECHO output is 5 V, which is safe for the Arduino
+              (also 5 V logic). If connecting to a 3.3 V board (such as an
+              OPi), add a voltage divider: ECHO &rarr; 1 k&Omega; &rarr;
+              GPIO &rarr; 2 k&Omega; &rarr; GND. This drops 5 V to ~3.3 V.
+            </p>
+          </div>
+
+          <h3>Mounting</h3>
+          <ul>
+            <li>Drill four 18 mm holes in the rear bumper, spaced ~30 cm apart</li>
+            <li>Angle sensors 15&deg; outward from centre for wider coverage</li>
+            <li>Route cables through the bumper to the trunk area, then to the Arduino</li>
+            <li>Use silicone sealant around the sensor housings for waterproofing</li>
+          </ul>
+
+          <h3>Serial Output</h3>
+
+          <pre><code>PARK:FL=45,FR=123,RL=200,RR=180</code></pre>
+
+          <p>
+            Distances are in centimetres. Values near <code>250</code> indicate
+            no obstacle detected (max range). The BCM parses this and publishes
+            <code>vehicle.parking_raw</code> (dict with keys fl, fr, rl, rr
+            mapping to integers) to the event bus.
+          </p>
+
+          <h3>Buzzer</h3>
+          <p>
+            A piezo buzzer connected to a spare Arduino digital pin provides
+            audible feedback. Beep frequency increases as the closest sensor
+            distance decreases: continuous tone below 30 cm, fast beep at
+            30&ndash;60 cm, slow beep at 60&ndash;120 cm, silent above 120 cm.
+          </p>
+        </section>
+
+        <!-- ============================================================
+             RAIN SENSOR
+             ============================================================ -->
+        <section>
+          <h2 id="rain-sensor">Rain Sensor</h2>
+
+          <h3>Specifications</h3>
+          <ul>
+            <li><strong>Type:</strong> Capacitive digital rain sensor module (active-low output)</li>
+            <li><strong>Arduino pin:</strong> D10 (via PC817 optoisolator)</li>
+            <li><strong>12 V car side &rarr; 5 V Arduino side</strong> (galvanic isolation)</li>
+          </ul>
+
+          <h3>Wiring through PC817 Optoisolator</h3>
+
+          <p>
+            The rain sensor operates on the car's 12 V circuit. A PC817
+            optocoupler provides galvanic isolation between the car electrical
+            system and the Arduino:
+          </p>
+
+          <pre><code>  CAR SIDE (12V)                         ARDUINO SIDE (5V)
+  ══════════════                         ═════════════════
+
+  12V rain signal ──[1k&Omega;]──┐              ┌─── Arduino 5V
+                              │    PC817    │
+                         LED+ ●────────● collector ── Arduino D10
+                              │  opto   │        (10k&Omega; pull-up)
+                         LED- ●────────● emitter ─── Arduino GND
+                              │              │
+  GND (car) ──────────────────┘              └─── (pull-up to 5V)</code></pre>
+
+          <div class="box box-info">
+            <div class="box-title">How it works</div>
+            <p>
+              When rain is detected, the sensor pulls its output LOW (12 V side),
+              current flows through the 1 k&Omega; resistor and the PC817 LED.
+              The phototransistor conducts, pulling Arduino D10 LOW. The
+              10 k&Omega; pull-up holds D10 HIGH when no rain is detected.
+            </p>
+          </div>
+
+          <h3>Serial Output</h3>
+
+          <pre><code>RAIN:1    (rain detected)
+RAIN:0    (dry)</code></pre>
+
+          <p>
+            The BCM publishes <code>vehicle.rain</code> (bool) to the event bus.
+          </p>
+
+          <h3>Auto-Wiper</h3>
+          <p>
+            When rain is detected, the BCM can automatically activate the wipers
+            by sending a JSON command to the output Arduino (Nano):
+          </p>
+
+          <pre><code>{"cmd":"wipers","duration":5}</code></pre>
+
+          <h3>Configuration</h3>
+
+          <pre><code># config/bcm.yml
+rain_sensor:
+  enabled: true
+  sensitivity: medium    # light=2s, medium=5s, heavy=10s wiper duration
+  auto_wiper: true       # automatically trigger wipers on rain detection</code></pre>
+        </section>
+
+        <!-- ============================================================
+             LIGHT SENSOR (LDR)
+             ============================================================ -->
+        <section>
+          <h2 id="ldr">Light Sensor (LDR)</h2>
+
+          <h3>Specifications</h3>
+          <ul>
+            <li><strong>Type:</strong> Photoresistor (LDR) with 10 k&Omega; voltage divider</li>
+            <li><strong>Arduino pin:</strong> A1 (analog input, ADC 0&ndash;1023)</li>
+            <li><strong>Report interval:</strong> Every 2 seconds (<code>LIGHT_REPORT_MS = 2000</code>)</li>
+          </ul>
+
+          <h3>Wiring</h3>
+
+          <pre><code>  Arduino 5V ─── LDR ──┬── Arduino A1
+                       │
+                     [10k&Omega;]
+                       │
+  Arduino GND ─────────┘</code></pre>
+
+          <p>
+            The LDR and fixed 10 k&Omega; resistor form a voltage divider.
+            In bright light, the LDR resistance drops, pulling A1 higher.
+            In darkness, LDR resistance increases, pulling A1 lower. The
+            firmware averages 4 ADC samples to reduce noise.
+          </p>
+
+          <h3>Serial Output</h3>
+
+          <pre><code>LIGHT:512</code></pre>
+
+          <p>
+            Value range: <strong>0</strong> (complete darkness) to
+            <strong>1023</strong> (bright sunlight). Published as
+            <code>arduino.light_level</code> (int) on the event bus.
+          </p>
+
+          <h3>Auto-Brightness</h3>
+
+          <p>
+            The BCM maps the ADC value to six display brightness levels:
+          </p>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>ADC Range</th>
+                  <th>Ambient</th>
+                  <th>Brightness</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td>0 &ndash; 100</td><td>Night / tunnel</td><td>15%</td></tr>
+                <tr><td>101 &ndash; 250</td><td>Dusk / dawn</td><td>30%</td></tr>
+                <tr><td>251 &ndash; 400</td><td>Overcast</td><td>45%</td></tr>
+                <tr><td>401 &ndash; 600</td><td>Cloudy</td><td>60%</td></tr>
+                <tr><td>601 &ndash; 800</td><td>Partly sunny</td><td>80%</td></tr>
+                <tr><td>801 &ndash; 1023</td><td>Direct sunlight</td><td>100%</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>Stalk Brightness Button</h3>
+          <p>
+            The spare column stalk button (Arduino A2, internal pull-up)
+            allows manual brightness cycling. Each press sends
+            <code>KEY_F9</code> as a HID keycode, which the BCM intercepts
+            to step through brightness levels, overriding auto-brightness
+            until the next ignition cycle.
+          </p>
+        </section>
+
+        <!-- ============================================================
+             OPTOISOLATOR CIRCUITS (PC817)
+             ============================================================ -->
+        <section>
+          <h2 id="optoisolators">Optoisolator Circuits (PC817)</h2>
+
+          <p>
+            All 12 V car signals must be isolated from the 5 V Arduino using
+            PC817 optocouplers. This protects the Arduino from voltage spikes,
+            ground loops, and alternator noise on the car's electrical system.
+          </p>
+
+          <h3>Standard Circuit (same for all signals)</h3>
+
+          <pre><code>  CAR SIDE (12V)                         ARDUINO SIDE (5V)
+  ══════════════                         ═════════════════
+
+  12V signal ──────[1k&Omega;]──┐              ┌─── Arduino 5V
+                              │    PC817    │       │
+                         LED+ ●────────● collector ─┤
+                              │  opto   │        [10k&Omega;] pull-up
+                         LED- ●────────● emitter    │
+                              │              │   Arduino Dx (input)
+  GND (car) ──────────────────┘              │
+                                       Arduino GND</code></pre>
+
+          <p>
+            When the 12 V signal is active, current flows through the 1 k&Omega;
+            limiting resistor and the PC817 internal LED, causing the
+            phototransistor to conduct and pulling the Arduino input pin LOW.
+            The 10 k&Omega; pull-up holds the pin HIGH when no signal is present.
+            All signals are therefore <strong>active-low</strong> on the Arduino side.
+          </p>
+
+          <h3>Pin Assignments</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>12 V Car Signal</th>
+                  <th>Arduino Pin</th>
+                  <th>Event Bus Topic</th>
+                  <th>Notes</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Ignition (ACC 12 V)</td>
+                  <td>D2</td>
+                  <td><code>vehicle.ignition_raw</code></td>
+                  <td>Main power-on signal; triggers suspend/wake</td>
+                </tr>
+                <tr>
+                  <td>Handbrake</td>
+                  <td>D3</td>
+                  <td><code>vehicle.handbrake</code></td>
+                  <td>Handbrake warning lamp wire</td>
+                </tr>
+                <tr>
+                  <td>Door FL (front left)</td>
+                  <td>D4</td>
+                  <td rowspan="4"><code>vehicle.doors</code></td>
+                  <td>Door courtesy light switch</td>
+                </tr>
+                <tr>
+                  <td>Door FR (front right)</td>
+                  <td>D5</td>
+                  <td>Door courtesy light switch</td>
+                </tr>
+                <tr>
+                  <td>Door RL (rear left)</td>
+                  <td>D6</td>
+                  <td>Door courtesy light switch</td>
+                </tr>
+                <tr>
+                  <td>Door RR (rear right)</td>
+                  <td>D7</td>
+                  <td>Door courtesy light switch</td>
+                </tr>
+                <tr>
+                  <td>Bonnet</td>
+                  <td>D8</td>
+                  <td><code>vehicle.doors</code> (bonnet key)</td>
+                  <td>Bonnet switch or mercury tilt sensor</td>
+                </tr>
+                <tr>
+                  <td>Trunk</td>
+                  <td>D9</td>
+                  <td><code>vehicle.doors</code> (trunk key)</td>
+                  <td>Trunk courtesy light switch</td>
+                </tr>
+                <tr>
+                  <td>Rain sensor</td>
+                  <td>D10</td>
+                  <td><code>vehicle.rain</code></td>
+                  <td>Capacitive rain module output</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>Parts Required</h3>
+          <ul>
+            <li><strong>6&times; PC817</strong> optocouplers (or equivalent: EL817, LTV-817)</li>
+            <li><strong>6&times; 1 k&Omega;</strong> resistors (1/4 W, LED current limiting)</li>
+            <li><strong>6&times; 10 k&Omega;</strong> resistors (1/4 W, pull-up)</li>
+          </ul>
+
+          <p>
+            Multiple signals can share a single PC817 if they are active at
+            different times, but for reliability each signal should have its own
+            optocoupler. Use a small perfboard or purpose-built PCB to mount
+            all six circuits compactly.
+          </p>
+
+          <div class="box box-warning">
+            <div class="box-title">Ground isolation</div>
+            <p>
+              The PC817 provides galvanic isolation &mdash; the car GND and
+              Arduino GND must <strong>not</strong> be connected together.
+              If they share a ground, the optoisolator is bypassed and
+              voltage spikes from the alternator or starter motor can
+              damage the Arduino or the M910q USB port.
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             VERIFICATION
+             ============================================================ -->
+        <section>
+          <h2 id="verification">Verification</h2>
+
+          <h3>Test each sensor individually</h3>
+
+          <pre><code># Open serial monitor
+minicom -D /dev/ttyACM0 -b 115200
+
+# ── Temperature ──
+# Wait 10 seconds, should see:
+#   TEMP:23.5
+# Hold the probe in your hand — value should rise
+
+# ── Light sensor ──
+# Every 2 seconds:
+#   LIGHT:512
+# Cover the LDR — value should drop toward 0
+# Shine a light — value should rise toward 1023
+
+# ── Parking sensors ──
+# Place hand in front of a sensor:
+#   PARK:FL=15,FR=250,RL=250,RR=250
+# Move hand closer — FL value decreases
+
+# ── Rain sensor ──
+# Wet the sensor surface:
+#   RAIN:1
+# Dry it:
+#   RAIN:0
+
+# ── Doors / ignition ──
+# Open a door (or bridge the optoisolator input):
+#   DOOR:FL=1,FR=0,RL=0,RR=0,BONNET=0,TRUNK=0
+# Turn ignition key:
+#   IGN:1</code></pre>
+
+          <h3>Verify BCM event bus</h3>
+
+          <pre><code># Check BCM logs for parsed sensor data
+sudo journalctl -u bcm-headunit --no-pager -n 50 | grep -E "temp|light|parking|rain|door|ignition"
+
+# Expected log entries:
+#   Arduino serial listener started: /dev/ttyACM0
+#   Temperature: 23.5°C
+#   Light level: 512
+#   Parking: FL=45 FR=123 RL=200 RR=180</code></pre>
+
+          <h3>Checklist</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Test</th>
+                  <th>Expected Result</th>
+                  <th>Pass</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>DS18B20 connected</td>
+                  <td><code>TEMP:XX.X</code> every 10 s, value changes with heat</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>LDR connected</td>
+                  <td><code>LIGHT:XXX</code> every 2 s, responds to light changes</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Parking sensor FL</td>
+                  <td><code>PARK:FL=XX,...</code> changes with hand distance</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Parking sensor FR</td>
+                  <td>FR value changes independently</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Parking sensor RL</td>
+                  <td>RL value changes independently</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Parking sensor RR</td>
+                  <td>RR value changes independently</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Rain sensor</td>
+                  <td><code>RAIN:1</code> when wet, <code>RAIN:0</code> when dry</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Ignition optoisolator</td>
+                  <td><code>IGN:1</code> with 12 V applied</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Door optoisolators (4&times;)</td>
+                  <td><code>DOOR:FL=1,...</code> for each door</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Bonnet optoisolator</td>
+                  <td>BONNET=1 in DOOR message</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Trunk optoisolator</td>
+                  <td>TRUNK=1 in DOOR message</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Stalk brightness button</td>
+                  <td>Serial shows <code>STALK: Brightness cycle</code></td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Auto-brightness</td>
+                  <td>Display brightness changes with light level</td>
+                  <td>[ ]</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+      </article>
+
+      <!-- Page Navigation -->
+      <div class="page-nav">
+        <a href="06-arduino.html">&larr; 06 &mdash; Arduino Firmware</a>
+        <a href="08-wifi-bt.html">08 &mdash; WiFi &amp; Bluetooth &rarr;</a>
+      </div>
+
+      <!-- Footer -->
+      <footer class="page-footer">
+        <span>BCM v8.5 &mdash; Alfa Romeo 156 Headunit</span>
+        <span>Lenovo M910q x86 Production Build</span>
+      </footer>
+
+    </div>
+  </div>
+
+  <!-- Sidebar Toggle Script -->
+  <script>
+    function toggleSidebar() {
+      document.querySelector('.sidebar').classList.toggle('open');
+      document.querySelector('.sidebar-overlay').classList.toggle('active');
+    }
+
+    document.querySelectorAll('.sidebar nav a').forEach(function(link) {
+      link.addEventListener('click', function() {
+        if (window.innerWidth < 768) {
+          document.querySelector('.sidebar').classList.remove('open');
+          document.querySelector('.sidebar-overlay').classList.remove('active');
+        }
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/docs/x86-production/08-wifi-bt.html
+++ b/docs/x86-production/08-wifi-bt.html
@@ -1,0 +1,465 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>08 WiFi &amp; Bluetooth &mdash; BCM v8.5 x86 Production</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+
+  <!-- Hamburger toggle (mobile only) -->
+  <button class="hamburger" aria-label="Toggle navigation" onclick="toggleSidebar()">&#9776;</button>
+
+  <!-- Overlay behind sidebar on mobile -->
+  <div class="sidebar-overlay" onclick="toggleSidebar()"></div>
+
+  <!-- ======== Sidebar Navigation ======== -->
+  <aside class="sidebar">
+    <div class="sidebar-header">
+      <div class="logo-text">BCM v8.5</div>
+      <div class="logo-sub">Lenovo M910q &middot; Alfa 156</div>
+    </div>
+    <nav aria-label="Documentation pages">
+      <ul>
+        <li><a href="index.html"><span class="nav-num"></span>Overview</a></li>
+        <li><a href="01-bom.html"><span class="nav-num">01</span>Bill of Materials</a></li>
+        <li><a href="02-power.html"><span class="nav-num">02</span>Power Supply</a></li>
+        <li><a href="03-os-install.html"><span class="nav-num">03</span>OS Installation</a></li>
+        <li><a href="04-packages.html"><span class="nav-num">04</span>System Packages</a></li>
+        <li><a href="05-bcm-install.html"><span class="nav-num">05</span>BCM Installation</a></li>
+        <li><a href="06-systemd.html"><span class="nav-num">06</span>Systemd Services</a></li>
+        <li><a href="07-sensors.html"><span class="nav-num">07</span>Sensors</a></li>
+        <li><a href="08-wifi-bt.html" class="active"><span class="nav-num">08</span>WiFi &amp; Bluetooth</a></li>
+        <li><a href="09-display-touch.html"><span class="nav-num">09</span>Display &amp; Touch</a></li>
+        <li><a href="10-wifi.html"><span class="nav-num">10</span>WiFi &amp; Android Auto</a></li>
+        <li><a href="11-arduino.html"><span class="nav-num">11</span>Arduino Wiring</a></li>
+        <li><a href="12-verification.html"><span class="nav-num">12</span>Verification</a></li>
+      </ul>
+    </nav>
+  </aside>
+
+  <!-- ======== Main Content ======== -->
+  <div class="content">
+    <div class="content-inner">
+
+      <header>
+        <h1>
+          08 &mdash; WiFi &amp; Bluetooth
+          <span class="subtitle">Fenvi FU-AX1800 (MediaTek MT7921) &mdash; Dual-SSID AP &amp; BT Pairing</span>
+        </h1>
+      </header>
+
+      <article>
+
+        <!-- ---- 1. Overview ---- -->
+        <section>
+          <h2>Overview</h2>
+
+          <p>
+            The <strong>Fenvi FU-AX1800</strong> (MediaTek MT7921 chipset) replaces the
+            stock Intel 8265 wireless card in the Lenovo M910q. While the Intel 8265
+            provides basic WiFi and Bluetooth, it cannot reliably operate as a 5&nbsp;GHz
+            access point &mdash; a requirement for wireless Android Auto. The Fenvi
+            FU-AX1800 resolves this with full WiFi&nbsp;6 (802.11ax) support on both
+            2.4&nbsp;GHz and 5&nbsp;GHz bands, plus Bluetooth&nbsp;5.2.
+          </p>
+
+          <div class="box box-info">
+            <div class="box-title">Why replace the Intel 8265?</div>
+            <p>
+              The Intel 8265 uses the <code>iwlwifi</code> driver, which does not
+              support 5&nbsp;GHz AP mode. Android Auto wireless requires a 5&nbsp;GHz
+              access point for acceptable latency and bandwidth. The MT7921 driver
+              (<code>mt7921e</code>) is mainline since kernel 5.18 and supports both
+              AP mode on 5&nbsp;GHz and dual-SSID virtual interfaces, making it the
+              ideal upgrade.
+            </p>
+          </div>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Feature</th>
+                  <th>Intel 8265</th>
+                  <th>Fenvi FU-AX1800 (MT7921)</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>WiFi Standard</td>
+                  <td>802.11ac (WiFi 5)</td>
+                  <td class="winner">802.11ax (WiFi 6)</td>
+                </tr>
+                <tr>
+                  <td>5 GHz AP Mode</td>
+                  <td class="downside">Not supported</td>
+                  <td class="winner">Supported</td>
+                </tr>
+                <tr>
+                  <td>Dual-SSID (virtual interfaces)</td>
+                  <td class="downside">Not supported</td>
+                  <td class="winner">Supported</td>
+                </tr>
+                <tr>
+                  <td>Bluetooth</td>
+                  <td>BT 4.2</td>
+                  <td class="winner">BT 5.2</td>
+                </tr>
+                <tr>
+                  <td>Linux Driver</td>
+                  <td>iwlwifi</td>
+                  <td>mt7921e (mainline &ge; 5.18)</td>
+                </tr>
+                <tr>
+                  <td>Form Factor</td>
+                  <td>M.2 Key E (2230)</td>
+                  <td>M.2 Key E (2230)</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <!-- ---- 2. Hardware Installation ---- -->
+        <section>
+          <h2>Hardware Installation</h2>
+
+          <h3>M.2 Key E Slot Swap</h3>
+          <ol>
+            <li>Power off the M910q and unplug all cables.</li>
+            <li>Remove the top cover (single thumbscrew on the back).</li>
+            <li>Locate the M.2 Key E slot &mdash; the Intel 8265 card is held by a single screw.</li>
+            <li>Disconnect the two IPEX/U.FL antenna pigtails from the Intel card.</li>
+            <li>Remove the mounting screw, slide out the Intel 8265.</li>
+            <li>Insert the Fenvi FU-AX1800 into the same M.2 Key E slot at a 30&deg; angle, press down, and secure with the screw.</li>
+            <li>Reconnect both IPEX/U.FL antenna pigtails to the Fenvi card.</li>
+          </ol>
+
+          <h3>Antenna Pigtails</h3>
+          <p>
+            The Fenvi FU-AX1800 uses <strong>2&times; IPEX/U.FL</strong> connectors, same
+            as the Intel 8265. Reuse the existing antenna pigtails if they are in good
+            condition. For best WiFi and Bluetooth range, route the antenna cables toward
+            the windshield &mdash; metal bodywork behind the dashboard attenuates the signal
+            significantly.
+          </p>
+
+          <div class="box box-warning">
+            <div class="box-title">Antenna placement matters</div>
+            <p>
+              Place antennas as close to the windshield as possible. Glass has much lower
+              RF attenuation than steel. Tuck the pigtails behind the A-pillar trim or
+              above the headliner near the windshield edge for optimal coverage to the
+              phone in a dash mount or cupholder.
+            </p>
+          </div>
+        </section>
+
+        <!-- ---- 3. Driver Setup ---- -->
+        <section>
+          <h2>Driver Setup</h2>
+
+          <p>
+            The MT7921 driver (<code>mt7921e</code>) is included in the mainline Linux
+            kernel since version 5.18. Debian 13 (Trixie) ships with kernel 6.x, so the
+            driver is available out of the box. Only the firmware package needs to be
+            installed.
+          </p>
+
+          <pre><code># MT7921 driver is mainline (kernel 5.18+, Debian 13 has it)
+apt install firmware-mediatek
+
+# Blacklist Intel WiFi (prevent conflicts if Intel 8265 is still detected)
+echo "blacklist iwlwifi" &gt; /etc/modprobe.d/blacklist-intel-wifi.conf
+
+# Verify the card is detected
+lspci | grep -i mediatek
+ip link show | grep wl
+iw dev</code></pre>
+
+          <p>
+            After installing the firmware and rebooting, <code>lspci</code> should show the
+            MediaTek MT7921 device, and <code>ip link</code> should list a <code>wlan0</code>
+            interface. The <code>iw dev</code> command confirms the wireless interface is
+            operational.
+          </p>
+        </section>
+
+        <!-- ---- 4. WiFi AP — Dual SSID Configuration ---- -->
+        <section>
+          <h2>WiFi AP &mdash; Dual SSID Configuration</h2>
+
+          <p>
+            The BCM build uses <strong>two SSIDs</strong> on a single physical interface
+            via hostapd BSS (Basic Service Set) support. This allows dedicated networks for
+            Android Auto and general connectivity without a second wireless adapter.
+          </p>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>SSID</th>
+                  <th>Band</th>
+                  <th>Purpose</th>
+                  <th>Subnet</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>ALFA_AA</code></td>
+                  <td>5 GHz (channel 36 or 149)</td>
+                  <td>Android Auto wireless &mdash; low latency, high throughput</td>
+                  <td>192.168.44.0/24</td>
+                </tr>
+                <tr>
+                  <td><code>ALFA_NET</code></td>
+                  <td>2.4 GHz</td>
+                  <td>General connectivity &mdash; phone hotspot relay, SSH access</td>
+                  <td>192.168.45.0/24</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>hostapd Configuration</h3>
+          <p>
+            Create or edit <code>/etc/hostapd/hostapd.conf</code>:
+          </p>
+
+          <pre><code>interface=wlan0
+driver=nl80211
+
+# Primary BSS — 5GHz for Android Auto
+ssid=ALFA_AA
+hw_mode=a
+channel=36
+ieee80211n=1
+ieee80211ac=1
+ieee80211ax=1
+wpa=2
+wpa_passphrase=AlfaRomeo156
+wpa_key_mgmt=WPA-PSK
+rsn_pairwise=CCMP
+country_code=PL
+
+# Secondary BSS — 2.4GHz general
+bss=wlan0_1
+ssid=ALFA_NET
+wpa=2
+wpa_passphrase=AlfaNet2026
+wpa_key_mgmt=WPA-PSK
+rsn_pairwise=CCMP</code></pre>
+
+          <div class="box box-warning">
+            <div class="box-title">Dual-SSID requires virtual interface support</div>
+            <p>
+              Dual-SSID depends on the MT7921 supporting virtual interfaces. Verify
+              with <code>iw list | grep -A5 "valid interface combinations"</code>.
+              The output should list support for multiple APs. If not supported by
+              your firmware version, fall back to a single SSID
+              (<code>ALFA_AA</code> on 5&nbsp;GHz) and use the phone's mobile hotspot
+              for general internet connectivity.
+            </p>
+          </div>
+
+          <h3>dnsmasq Configuration</h3>
+          <p>
+            Configure DHCP for both interfaces in <code>/etc/dnsmasq.d/bcm-wifi.conf</code>:
+          </p>
+
+          <pre><code>interface=wlan0
+interface=wlan0_1
+bind-interfaces
+dhcp-range=interface:wlan0,192.168.44.10,192.168.44.50,255.255.255.0,24h
+dhcp-range=interface:wlan0_1,192.168.45.10,192.168.45.50,255.255.255.0,24h</code></pre>
+
+          <p>
+            This assigns IPs in the <code>192.168.44.x</code> range for the Android Auto
+            network and <code>192.168.45.x</code> for the general network. The
+            <code>bind-interfaces</code> directive ensures dnsmasq only listens on the
+            specified interfaces, avoiding conflicts with other network services.
+          </p>
+        </section>
+
+        <!-- ---- 5. Bluetooth Setup ---- -->
+        <section>
+          <h2>Bluetooth Setup</h2>
+
+          <p>
+            Bluetooth is managed by two components: the system-level
+            <code>bcm-bluetooth.service</code> and the application-level
+            <code>BluetoothManager</code> in BCM.
+          </p>
+
+          <h3>bcm-bluetooth.service</h3>
+          <p>
+            This systemd service runs at boot and configures the Bluetooth adapter:
+          </p>
+          <ul>
+            <li><strong>Power on</strong> &mdash; enables the BT adapter</li>
+            <li><strong>Alias</strong> &mdash; sets the device name to <code>Alfa156 Headunit</code></li>
+            <li><strong>Discoverable</strong> &mdash; makes the adapter visible to nearby devices</li>
+            <li><strong>Pairable</strong> &mdash; allows incoming pairing requests</li>
+            <li><strong>Agent</strong> &mdash; registers a pairing agent for passkey confirmation</li>
+          </ul>
+
+          <h3>BluetoothManager (BCM Application)</h3>
+          <p>
+            The <code>BluetoothManager</code> class in the BCM Python application provides:
+          </p>
+          <ul>
+            <li><strong>D-Bus pairing agent</strong> &mdash; handles pairing requests programmatically</li>
+            <li><strong>A2DP sink</strong> &mdash; receives audio streams from the phone for music playback</li>
+            <li><strong>HFP</strong> &mdash; hands-free profile for phone calls through the car speakers</li>
+          </ul>
+
+          <h3>Pairing Flow</h3>
+          <ol>
+            <li>Phone discovers <strong>"Alfa156 Headunit"</strong> in its Bluetooth settings.</li>
+            <li>Phone initiates a pairing request.</li>
+            <li>BCM global polling detects the pairing request (polls every 2 seconds).</li>
+            <li>A passkey confirmation popup appears on the BCM dashboard (works from any screen).</li>
+            <li>User confirms on the BCM touchscreen &mdash; pairing completes.</li>
+          </ol>
+
+          <h3>Supported BT Profiles</h3>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Profile</th>
+                  <th>Function</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><strong>A2DP</strong></td>
+                  <td>Advanced Audio Distribution &mdash; high-quality music streaming from phone to car</td>
+                </tr>
+                <tr>
+                  <td><strong>HFP</strong></td>
+                  <td>Hands-Free Profile &mdash; phone calls through car speakers and microphone</td>
+                </tr>
+                <tr>
+                  <td><strong>AVRCP</strong></td>
+                  <td>Audio/Video Remote Control &mdash; play, pause, skip, volume from SWC buttons</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <!-- ---- 6. Verification ---- -->
+        <section>
+          <h2>Verification</h2>
+
+          <h3>WiFi AP</h3>
+          <pre><code># Check hostapd is running
+sudo systemctl status hostapd
+
+# Verify AP mode on wlan0
+iw dev wlan0 info  # should show type AP
+
+# List connected clients
+iw dev wlan0 station dump</code></pre>
+
+          <h3>Bluetooth</h3>
+          <pre><code># Check BT adapter state
+bluetoothctl show | grep -E "Powered|Discoverable|Pairable"
+
+# Verify BluetoothManager initialized in BCM
+grep "BluetoothManager initialized" /opt/bcm/logs/bcm.log | tail -3
+
+# List paired devices
+bluetoothctl devices Paired</code></pre>
+        </section>
+
+        <!-- ---- 7. Troubleshooting ---- -->
+        <section>
+          <h2>Troubleshooting</h2>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Problem</th>
+                  <th>Cause</th>
+                  <th>Solution</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>hostapd fails: <code>Channel 36 not allowed</code></td>
+                  <td>Regulatory domain blocks the channel</td>
+                  <td>Set <code>country_code=PL</code> in hostapd.conf and run <code>iw reg set PL</code>. Try channel 149 as an alternative. Verify with <code>iw list | grep -A20 "Frequencies"</code>.</td>
+                </tr>
+                <tr>
+                  <td>Dual-SSID not working</td>
+                  <td>MT7921 firmware does not support multiple virtual APs</td>
+                  <td>Run <code>iw list | grep -A5 "valid interface combinations"</code>. If only 1 AP is listed, remove the <code>bss=wlan0_1</code> block from hostapd.conf and use a single SSID. Update firmware: <code>apt update &amp;&amp; apt upgrade firmware-mediatek</code>.</td>
+                </tr>
+                <tr>
+                  <td>Bluetooth not discoverable</td>
+                  <td><code>bcm-bluetooth.service</code> failed or adapter not powered</td>
+                  <td>Check <code>systemctl status bcm-bluetooth</code>. Manually run <code>bluetoothctl power on</code> and <code>bluetoothctl discoverable on</code>. Verify adapter exists with <code>hciconfig -a</code>.</td>
+                </tr>
+                <tr>
+                  <td>Pairing request times out</td>
+                  <td>BCM polling missed the D-Bus signal or agent not registered</td>
+                  <td>Check BCM logs: <code>grep -i "pairing\|agent" /opt/bcm/logs/bcm.log | tail -20</code>. Restart BCM: <code>systemctl restart bcm</code>. Ensure <code>BluetoothManager</code> is enabled in BCM config.</td>
+                </tr>
+                <tr>
+                  <td>No audio over A2DP</td>
+                  <td>PipeWire not routing BT audio to the DAC</td>
+                  <td>Check PipeWire status: <code>wpctl status</code>. Ensure the BT source is connected: <code>pactl list sources short</code>. Restart PipeWire: <code>systemctl --user restart pipewire wireplumber</code>.</td>
+                </tr>
+                <tr>
+                  <td>WiFi interface not appearing after reboot</td>
+                  <td>Missing firmware or driver not loaded</td>
+                  <td>Verify firmware installed: <code>dpkg -l firmware-mediatek</code>. Check kernel module: <code>lsmod | grep mt7921</code>. Load manually: <code>modprobe mt7921e</code>. Check dmesg: <code>dmesg | grep mt7921</code>.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+      </article>
+
+      <!-- ---- Page Navigation ---- -->
+      <div class="page-nav">
+        <a href="07-sensors.html">&larr; 07 &mdash; Sensors</a>
+        <a href="09-display-touch.html">09 &mdash; Display &amp; Touch &rarr;</a>
+      </div>
+
+      <!-- ---- Footer ---- -->
+      <footer class="page-footer">
+        <span>BCM v8.5 &mdash; Alfa Romeo 156 Headunit</span>
+        <span>Lenovo M910q x86 Production Build</span>
+      </footer>
+
+    </div>
+  </div>
+
+  <!-- ======== Sidebar Toggle Script ======== -->
+  <script>
+    function toggleSidebar() {
+      document.querySelector('.sidebar').classList.toggle('open');
+      document.querySelector('.sidebar-overlay').classList.toggle('active');
+    }
+
+    // Close sidebar when a nav link is clicked (mobile)
+    document.querySelectorAll('.sidebar nav a').forEach(function(link) {
+      link.addEventListener('click', function() {
+        if (window.innerWidth < 768) {
+          document.querySelector('.sidebar').classList.remove('open');
+          document.querySelector('.sidebar-overlay').classList.remove('active');
+        }
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/docs/x86-production/09-display-touch.html
+++ b/docs/x86-production/09-display-touch.html
@@ -1,0 +1,689 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>09 — Display &amp; Touch | BCM x86 Production</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+
+  <!-- Hamburger toggle (mobile) -->
+  <button class="hamburger" aria-label="Toggle navigation" onclick="toggleSidebar()">&#9776;</button>
+  <div class="sidebar-overlay" onclick="toggleSidebar()"></div>
+
+  <!-- Sidebar Navigation -->
+  <aside class="sidebar">
+    <div class="sidebar-header">
+      <div class="logo-text">BCM v8.5</div>
+      <div class="logo-sub">Lenovo M910q &middot; Alfa 156</div>
+    </div>
+    <nav aria-label="Documentation pages">
+      <ul>
+        <li><a href="index.html"><span class="nav-num"></span>Overview</a></li>
+        <li><a href="01-bom.html"><span class="nav-num">01</span>Bill of Materials</a></li>
+        <li><a href="02-power.html"><span class="nav-num">02</span>Power Supply</a></li>
+        <li><a href="03-os-install.html"><span class="nav-num">03</span>OS Installation</a></li>
+        <li><a href="04-packages.html"><span class="nav-num">04</span>System Packages</a></li>
+        <li><a href="05-bcm-install.html"><span class="nav-num">05</span>BCM Installation</a></li>
+        <li><a href="06-systemd.html"><span class="nav-num">06</span>Systemd Services</a></li>
+        <li><a href="07-boot.html"><span class="nav-num">07</span>Boot &amp; Splash</a></li>
+        <li><a href="08-kiosk.html"><span class="nav-num">08</span>Kiosk Display</a></li>
+        <li><a href="09-display-touch.html" class="active"><span class="nav-num">09</span>Display &amp; Touch</a></li>
+        <li><a href="10-wifi.html"><span class="nav-num">10</span>WiFi &amp; Android Auto</a></li>
+        <li><a href="11-arduino.html"><span class="nav-num">11</span>Arduino Wiring</a></li>
+        <li><a href="12-verification.html"><span class="nav-num">12</span>Verification</a></li>
+      </ul>
+    </nav>
+  </aside>
+
+  <!-- Main Content -->
+  <div class="content">
+    <div class="content-inner">
+
+      <header>
+        <h1>
+          Display &amp; Touch
+          <span class="subtitle">Dual display setup, touchscreen calibration, and boot splash configuration for M910q</span>
+        </h1>
+      </header>
+
+      <article>
+
+        <!-- ============================================================
+             OVERVIEW
+             ============================================================ -->
+        <section>
+          <h2 id="overview">Overview</h2>
+
+          <p>
+            The Lenovo M910q has <strong>2&times; mini-DisplayPort</strong> outputs,
+            providing native dual-display support without any USB display adapters.
+            Both outputs connect to car displays using passive DP-to-HDMI adapters.
+            The primary display is a <strong>7" IPS touchscreen</strong> (1024&times;600)
+            for the main BCM dashboard, and the secondary is a
+            <strong>4.3" TFT</strong> (800&times;480) for the status dashboard.
+          </p>
+
+          <p>
+            This page covers the complete display pipeline: hardware connections,
+            X11 kiosk setup (autologin, xrandr layout, Chromium instances),
+            USB touchscreen calibration, DRM boot splash on both screens, and
+            troubleshooting common issues.
+          </p>
+
+          <div class="box box-info">
+            <div class="box-title">Adapters matter</div>
+            <p>
+              Use <strong>passive</strong> DP-to-HDMI adapters (not active converters).
+              The M910q's Intel HD 530 supports HDMI output natively through
+              passive adapters. Active adapters add latency and are unnecessary.
+              Typical cost: 10&ndash;20 PLN each.
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             DISPLAY HARDWARE
+             ============================================================ -->
+        <section>
+          <h2 id="display-hardware">Display Hardware</h2>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Output</th>
+                  <th>Display</th>
+                  <th>Resolution</th>
+                  <th>Content</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>DP-1 &rarr; HDMI-1</td>
+                  <td>7" IPS touchscreen</td>
+                  <td>1024&times;600</td>
+                  <td>BCM dashboard (port 5002)</td>
+                </tr>
+                <tr>
+                  <td>DP-2 &rarr; HDMI-2</td>
+                  <td>4.3" TFT</td>
+                  <td>800&times;480</td>
+                  <td>Status dashboard (port 5003)</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>Connector Naming</h3>
+
+          <p>
+            Two different subsystems use different names for the same physical outputs:
+          </p>
+
+          <ul>
+            <li><strong>xrandr (X11):</strong> <code>HDMI-1</code> and <code>HDMI-2</code></li>
+            <li><strong>DRM (kernel/framebuffer):</strong> <code>HDMI-A-1</code> and <code>HDMI-A-2</code></li>
+          </ul>
+
+          <p>
+            The <code>setup-x86.sh</code> script translates between these naming
+            conventions automatically. You only need to be aware of the difference
+            when debugging splash (DRM) vs kiosk (X11) issues.
+          </p>
+
+          <h3>Discover Connected Outputs</h3>
+
+          <p>
+            To see which DRM connectors are active:
+          </p>
+
+          <pre><code>for f in /sys/class/drm/card*-*/status; do echo "$f: $(cat $f)"; done</code></pre>
+
+          <p>Expected output with both displays connected:</p>
+
+          <pre><code>/sys/class/drm/card0-HDMI-A-1/status: connected
+/sys/class/drm/card0-HDMI-A-2/status: connected</code></pre>
+        </section>
+
+        <!-- ============================================================
+             KIOSK SETUP
+             ============================================================ -->
+        <section>
+          <h2 id="kiosk-setup">Kiosk Setup</h2>
+
+          <p>
+            The <code>setup-x86.sh</code> script configures a complete kiosk
+            environment that boots directly into dual Chromium windows without
+            any desktop environment. Here is what the script sets up:
+          </p>
+
+          <h3>X11 Xwrapper</h3>
+
+          <p>
+            Allows non-root users to start the X server:
+          </p>
+
+          <pre><code># /etc/X11/Xwrapper.config
+allowed_users=anybody</code></pre>
+
+          <h3>Autologin on tty1</h3>
+
+          <p>
+            A systemd getty override enables automatic login on the first virtual
+            terminal:
+          </p>
+
+          <pre><code># /etc/systemd/system/getty@tty1.service.d/autologin.conf
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin bcm --noclear %I $TERM</code></pre>
+
+          <h3>Login Shell &rarr; X Server</h3>
+
+          <p>
+            The <code>.bash_profile</code> for the <code>bcm</code> user starts
+            X automatically on tty1, but waits for the boot splash to finish first
+            (see <a href="#boot-splash">Boot Splash</a> below).
+          </p>
+
+          <h3>.xinitrc Pipeline</h3>
+
+          <p>
+            When X starts, <code>.xinitrc</code> performs these steps in order:
+          </p>
+
+          <ol>
+            <li>Configure xrandr layout (side-by-side, main display on the left)</li>
+            <li>Map the USB touchscreen to the correct display output</li>
+            <li>Launch the main Chromium instance on the 7" display (port 5002)</li>
+            <li>Launch the small Chromium instance on the 4.3" display (port 5003)</li>
+          </ol>
+
+          <h3>Chromium Policy</h3>
+
+          <p>
+            A managed policy file disables all browser prompts that would interfere
+            with kiosk operation:
+          </p>
+
+          <ul>
+            <li>No first-run dialog or welcome page</li>
+            <li>No popup windows or new tabs</li>
+            <li>No translate bar</li>
+            <li>No password manager prompts</li>
+            <li>No crash recovery bubble</li>
+          </ul>
+        </section>
+
+        <!-- ============================================================
+             TOUCH CALIBRATION
+             ============================================================ -->
+        <section>
+          <h2 id="touch-calibration">Touch Calibration</h2>
+
+          <p>
+            USB touchscreens appear as separate input devices in X11. By default,
+            touch events map to the entire X screen (which spans both displays).
+            The setup script uses <code>xinput map-to-output</code> to constrain
+            touch events to the correct display.
+          </p>
+
+          <h3>How It Works</h3>
+
+          <p>
+            The setup script sets a <code>TOUCH_DEVICE</code> variable with the
+            name of the detected touchscreen, then maps it:
+          </p>
+
+          <pre><code># In .xinitrc (generated by setup-x86.sh)
+xinput map-to-output "$TOUCH_DEVICE" "$MAIN_OUTPUT"</code></pre>
+
+          <h3>Find Your Touch Device</h3>
+
+          <pre><code>DISPLAY=:0 xinput list</code></pre>
+
+          <p>
+            Look for entries containing "touch", "HID", or your display's brand
+            name. Common touchscreen device names:
+          </p>
+
+          <ul>
+            <li><strong>QDtech MPI5001:</strong> <code>QDtech MPI5001</code> or <code>HID 222a:0001</code></li>
+            <li><strong>Waveshare:</strong> <code>WaveShare WaveShare</code> or <code>wch.cn USBtiny</code></li>
+            <li><strong>Generic USB HID:</strong> <code>HID xxxx:xxxx</code> (vendor:product format)</li>
+          </ul>
+
+          <h3>Diagnostics</h3>
+
+          <p>
+            The setup script logs all touch mapping actions to
+            <code>/tmp/bcm-xinput.log</code>. Check this file to see what
+            happened during the last X startup:
+          </p>
+
+          <pre><code>cat /tmp/bcm-xinput.log</code></pre>
+
+          <h3>Touch Offset Fix</h3>
+
+          <div class="box box-warning">
+            <div class="box-title">Touch is offset or maps to the wrong screen</div>
+            <p>
+              If touch events land on the wrong screen or are offset, verify that
+              <code>MAIN_OUTPUT</code> in <code>.xinitrc</code> matches the actual
+              xrandr output name for your 7" display. Run
+              <code>DISPLAY=:0 xrandr</code> and check which output shows
+              1024x600. The name must match exactly (e.g., <code>HDMI-1</code>
+              not <code>HDMI1</code>).
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             BOOT SPLASH
+             ============================================================ -->
+        <section>
+          <h2 id="boot-splash">Boot Splash</h2>
+
+          <p>
+            Two systemd services provide boot splash video on both displays
+            before X11 starts. They use <strong>mpv</strong> with
+            <code>--vo=drm</code> for direct framebuffer rendering &mdash; no X
+            server is needed.
+          </p>
+
+          <h3>Splash Services</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Service</th>
+                  <th>DRM Connector</th>
+                  <th>Video File</th>
+                  <th>Resolution</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>bcm-splash-main</code></td>
+                  <td>HDMI-A-1</td>
+                  <td><code>/opt/bcm/assets/splash/main.mp4</code></td>
+                  <td>1024&times;600</td>
+                </tr>
+                <tr>
+                  <td><code>bcm-splash-small</code></td>
+                  <td>HDMI-A-2</td>
+                  <td><code>/opt/bcm/assets/splash/small.mp4</code></td>
+                  <td>800&times;480</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>DRM Connector Configuration</h3>
+
+          <p>
+            The DRM connector names are set via systemd drop-in overrides so
+            they can be changed per-machine without editing the main service files:
+          </p>
+
+          <pre><code># /etc/systemd/system/bcm-splash-main.service.d/drm.conf
+[Service]
+Environment="DRM_CONNECTOR=HDMI-A-1"
+
+# /etc/systemd/system/bcm-splash-small.service.d/drm.conf
+[Service]
+Environment="DRM_CONNECTOR=HDMI-A-2"</code></pre>
+
+          <h3>DRM Wait Loop</h3>
+
+          <p>
+            The i915 GPU driver may take a few seconds to initialize after boot.
+            The splash service includes a wait loop that checks for
+            <code>/dev/dri/card0</code> up to <strong>10 seconds</strong> before
+            giving up:
+          </p>
+
+          <pre><code># Wait for GPU (i915 driver load)
+for i in $(seq 1 10); do
+    [ -e /dev/dri/card0 ] && break
+    sleep 1
+done</code></pre>
+
+          <h3>Splash Lifecycle</h3>
+
+          <ol>
+            <li>System boots, systemd starts <code>bcm-splash-main</code> and <code>bcm-splash-small</code></li>
+            <li>Each service waits for <code>/dev/dri/card0</code> (up to 10 s)</li>
+            <li>mpv plays the splash video on the DRM framebuffer</li>
+            <li>Splash loops until the Flask backend responds on <code>:5002</code>, then exits</li>
+            <li><code>.bash_profile</code> waits for splash to finish before starting X</li>
+            <li>X starts, xrandr takes over the displays, Chromium launches</li>
+          </ol>
+
+          <h3>Placeholder Videos</h3>
+
+          <p>
+            If no custom splash videos are provided, the setup script generates
+            placeholder videos using <code>ffmpeg</code>:
+          </p>
+
+          <pre><code># Generated automatically by setup-x86.sh
+ffmpeg -f lavfi -i color=c=black:s=1024x600:d=5 \
+       -vf "drawtext=text='BCM v8.5':fontsize=48:fontcolor=white:x=(w-tw)/2:y=(h-th)/2" \
+       -c:v libx264 -pix_fmt yuv420p /opt/bcm/assets/splash/main.mp4
+
+ffmpeg -f lavfi -i color=c=black:s=800x480:d=3 \
+       -vf "drawtext=text='BCM':fontsize=36:fontcolor=white:x=(w-tw)/2:y=(h-th)/2" \
+       -c:v libx264 -pix_fmt yuv420p /opt/bcm/assets/splash/small.mp4</code></pre>
+
+          <h3>Custom Splash</h3>
+
+          <p>
+            To use your own splash videos, copy them to:
+          </p>
+
+          <ul>
+            <li><code>/opt/bcm/assets/splash/main.mp4</code> &mdash; 1024&times;600, H.264, ~8 s recommended (audio optional)</li>
+            <li><code>/opt/bcm/assets/splash/small.mp4</code> &mdash; 800&times;480, H.264, ~5 s recommended (silent)</li>
+          </ul>
+
+          <div class="box box-info">
+            <div class="box-title">Splash encoding tips</div>
+            <p>
+              Use H.264 Baseline profile for fastest decode on the Intel HD 530.
+              Keep file size under 5 MB for instant playback from NVMe. If the
+              main splash includes audio, the mpv DRM output will route it through
+              the default PipeWire/ALSA sink (typically the USB DAC if configured).
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             CHROMIUM KIOSK
+             ============================================================ -->
+        <section>
+          <h2 id="chromium-kiosk">Chromium Kiosk</h2>
+
+          <p>
+            Two separate Chromium instances run in <code>--app=</code> mode
+            (no address bar, no tabs, no browser UI). Each instance targets a
+            different Flask dashboard on a different display.
+          </p>
+
+          <h3>Instance Configuration</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Instance</th>
+                  <th>URL</th>
+                  <th>Window Position</th>
+                  <th>User Data Dir</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Main (7")</td>
+                  <td><code>http://localhost:5002</code></td>
+                  <td><code>--window-position=0,0</code></td>
+                  <td><code>/tmp/bcm-chromium-main</code></td>
+                </tr>
+                <tr>
+                  <td>Small (4.3")</td>
+                  <td><code>http://localhost:5003</code></td>
+                  <td><code>--window-position=1024,0</code> (offset by main width)</td>
+                  <td><code>/tmp/bcm-chromium-small</code></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>Key Chromium Flags</h3>
+
+          <pre><code>chromium --app=http://localhost:5002 \
+         --window-position=0,0 \
+         --window-size=1024,600 \
+         --user-data-dir=/tmp/bcm-chromium-main \
+         --no-first-run \
+         --disable-infobars \
+         --disable-session-crashed-bubble \
+         --noerrdialogs \
+         --kiosk</code></pre>
+
+          <h3>Clean on Boot</h3>
+
+          <p>
+            User data directories are located in <code>/tmp/bcm-chromium-*</code>,
+            which is a tmpfs mount. This means Chromium starts with a clean profile
+            on every boot &mdash; no stale cache, no session restore prompts, and
+            no disk wear on the NVMe SSD.
+          </p>
+
+          <h3>Policy File</h3>
+
+          <p>
+            A managed policy file is installed to suppress all browser prompts:
+          </p>
+
+          <pre><code># /etc/chromium/policies/managed/bcm-kiosk.json
+{
+  "AutofillAddressEnabled": false,
+  "AutofillCreditCardEnabled": false,
+  "BrowserSignin": 0,
+  "DefaultPopupsSetting": 2,
+  "PasswordManagerEnabled": false,
+  "TranslateEnabled": false,
+  "BookmarkBarEnabled": false
+}</code></pre>
+        </section>
+
+        <!-- ============================================================
+             VERIFICATION
+             ============================================================ -->
+        <section>
+          <h2 id="verification">Verification</h2>
+
+          <h3>Display Layout</h3>
+
+          <pre><code># Check xrandr sees both displays with correct resolutions
+DISPLAY=:0 xrandr</code></pre>
+
+          <p>Expected: HDMI-1 at 1024x600 and HDMI-2 at 800x480, side by side.</p>
+
+          <h3>Touch Mapping</h3>
+
+          <pre><code># List input devices
+DISPLAY=:0 xinput list
+
+# Check what the setup script configured
+cat /tmp/bcm-xinput.log</code></pre>
+
+          <h3>Splash Logs</h3>
+
+          <pre><code># Main display splash
+sudo journalctl -u bcm-splash-main --no-pager -n 10
+
+# Small display splash
+sudo journalctl -u bcm-splash-small --no-pager -n 10</code></pre>
+
+          <h3>Checklist</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Test</th>
+                  <th>Expected Result</th>
+                  <th>Pass</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Both displays detected</td>
+                  <td><code>xrandr</code> shows HDMI-1 and HDMI-2 connected</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Main display resolution</td>
+                  <td>1024x600 on HDMI-1</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Small display resolution</td>
+                  <td>800x480 on HDMI-2</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Touch maps to main display</td>
+                  <td>Tapping the 7" screen interacts with port 5002 dashboard only</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Touch does not affect small display</td>
+                  <td>No touch events registered on the 4.3" status screen</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Boot splash (main)</td>
+                  <td>Splash video plays on 7" during boot, exits when Flask is ready</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Boot splash (small)</td>
+                  <td>Splash video plays on 4.3" during boot</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Chromium main</td>
+                  <td>Dashboard on port 5002 fills the 7" display, no browser UI</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Chromium small</td>
+                  <td>Status dashboard on port 5003 fills the 4.3" display</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>No browser prompts</td>
+                  <td>No translate bar, password prompt, or crash bubble on either screen</td>
+                  <td>[ ]</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             TROUBLESHOOTING
+             ============================================================ -->
+        <section>
+          <h2 id="troubleshooting">Troubleshooting</h2>
+
+          <h3>Displays Are Merged (Mirrored)</h3>
+
+          <p>
+            If both displays show the same content instead of side-by-side layout:
+          </p>
+
+          <ul>
+            <li>Check <code>.xinitrc</code> for the <code>xrandr --output HDMI-2 --right-of HDMI-1</code> command</li>
+            <li>Run <code>DISPLAY=:0 xrandr</code> and verify both outputs are listed separately</li>
+            <li>If xrandr shows only one output, check the DP-to-HDMI adapters &mdash; one may be faulty or not fully seated</li>
+            <li>Some cheap adapters do not support EDID passthrough; try a different adapter</li>
+          </ul>
+
+          <h3>Touch Events on Wrong Screen</h3>
+
+          <ul>
+            <li>Check <code>/tmp/bcm-xinput.log</code> for the <code>map-to-output</code> command</li>
+            <li>Verify <code>TOUCH_DEVICE</code> matches the actual device name in <code>xinput list</code></li>
+            <li>Verify <code>MAIN_OUTPUT</code> matches the xrandr name for the 7" display</li>
+            <li>If displays were swapped physically, swap the DP adapter cables or update <code>MAIN_OUTPUT</code></li>
+          </ul>
+
+          <h3>Splash Not Playing</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Symptom</th>
+                  <th>Cause</th>
+                  <th>Fix</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Black screen, no splash</td>
+                  <td>DRM device not ready &mdash; <code>/dev/dri/card0</code> missing</td>
+                  <td>Check <code>lsmod | grep i915</code>; if missing, the GPU driver did not load. Verify BIOS has integrated graphics enabled.</td>
+                </tr>
+                <tr>
+                  <td>Splash on wrong screen</td>
+                  <td>DRM connector name mismatch</td>
+                  <td>Check <code>for f in /sys/class/drm/card*-*/status; do echo "$f: $(cat $f)"; done</code> and update the systemd drop-in override to match</td>
+                </tr>
+                <tr>
+                  <td>Splash plays but never stops</td>
+                  <td>Flask not starting on port 5002</td>
+                  <td>Check <code>sudo journalctl -u bcm-headunit</code> for Flask errors; splash waits for <code>curl localhost:5002</code> to succeed</td>
+                </tr>
+                <tr>
+                  <td>mpv error: "no DRM connector"</td>
+                  <td>Connector name uses X11 format instead of DRM format</td>
+                  <td>Use <code>HDMI-A-1</code> (DRM) not <code>HDMI-1</code> (X11) in the splash service</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>X Starts Before Splash Finishes</h3>
+
+          <ul>
+            <li>The <code>.bash_profile</code> should contain a wait loop that checks if the splash service is still active</li>
+            <li>Verify with: <code>systemctl is-active bcm-splash-main</code></li>
+            <li>If the splash service exits immediately (failed), X will start right away &mdash; check splash logs for errors</li>
+            <li>Ensure the splash service is <code>Type=simple</code> (not <code>oneshot</code>) so <code>is-active</code> reports correctly while mpv is running</li>
+          </ul>
+        </section>
+
+      </article>
+
+      <!-- Page Navigation -->
+      <div class="page-nav">
+        <a href="08-wifi-bt.html">&larr; 08 &mdash; WiFi &amp; Bluetooth</a>
+        <a href="10-power-suspend.html">10 &mdash; Power &amp; Suspend &rarr;</a>
+      </div>
+
+      <!-- Footer -->
+      <footer class="page-footer">
+        <span>BCM v8.5 &mdash; Alfa Romeo 156 Headunit</span>
+        <span>Lenovo M910q x86 Production Build</span>
+      </footer>
+
+    </div>
+  </div>
+
+  <!-- Sidebar Toggle Script -->
+  <script>
+    function toggleSidebar() {
+      document.querySelector('.sidebar').classList.toggle('open');
+      document.querySelector('.sidebar-overlay').classList.toggle('active');
+    }
+
+    document.querySelectorAll('.sidebar nav a').forEach(function(link) {
+      link.addEventListener('click', function() {
+        if (window.innerWidth < 768) {
+          document.querySelector('.sidebar').classList.remove('open');
+          document.querySelector('.sidebar-overlay').classList.remove('active');
+        }
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/docs/x86-production/10-power-suspend.html
+++ b/docs/x86-production/10-power-suspend.html
@@ -1,0 +1,884 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>10 — Power &amp; Suspend | BCM x86 Production</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+
+  <!-- Hamburger toggle (mobile) -->
+  <button class="hamburger" aria-label="Toggle navigation" onclick="toggleSidebar()">&#9776;</button>
+  <div class="sidebar-overlay" onclick="toggleSidebar()"></div>
+
+  <!-- Sidebar Navigation -->
+  <aside class="sidebar">
+    <div class="sidebar-header">
+      <div class="logo-text">BCM v8.5</div>
+      <div class="logo-sub">Lenovo M910q &middot; Alfa 156</div>
+    </div>
+    <nav aria-label="Documentation pages">
+      <ul>
+        <li><a href="index.html"><span class="nav-num"></span>Overview</a></li>
+        <li><a href="01-bom.html"><span class="nav-num">01</span>Bill of Materials</a></li>
+        <li><a href="02-power.html"><span class="nav-num">02</span>Power Supply</a></li>
+        <li><a href="03-os-install.html"><span class="nav-num">03</span>OS Installation</a></li>
+        <li><a href="04-packages.html"><span class="nav-num">04</span>System Packages</a></li>
+        <li><a href="05-bcm-install.html"><span class="nav-num">05</span>BCM Installation</a></li>
+        <li><a href="06-systemd.html"><span class="nav-num">06</span>Systemd Services</a></li>
+        <li><a href="07-boot.html"><span class="nav-num">07</span>Boot &amp; Splash</a></li>
+        <li><a href="08-kiosk.html"><span class="nav-num">08</span>Kiosk Display</a></li>
+        <li><a href="09-display-touch.html"><span class="nav-num">09</span>Display &amp; Touch</a></li>
+        <li><a href="10-power-suspend.html" class="active"><span class="nav-num">10</span>Power &amp; Suspend</a></li>
+        <li><a href="11-android-auto.html"><span class="nav-num">11</span>Android Auto</a></li>
+        <li><a href="12-verification.html"><span class="nav-num">12</span>Verification</a></li>
+      </ul>
+    </nav>
+  </aside>
+
+  <!-- Main Content -->
+  <div class="content">
+    <div class="content-inner">
+
+      <header>
+        <h1>
+          Power &amp; Suspend
+          <span class="subtitle">Power supply, battery buffer, S3 suspend/resume, and ignition watcher for M910q in-car deployment</span>
+        </h1>
+      </header>
+
+      <article>
+
+        <!-- ============================================================
+             OVERVIEW
+             ============================================================ -->
+        <section>
+          <h2 id="overview">Overview</h2>
+
+          <p>
+            The Lenovo M910q uses a <strong>65 W, 20 V barrel jack</strong>
+            power supply &mdash; not a standard ATX connector. In the car, this
+            means you need a <strong>12 V &rarr; 20 V boost converter</strong>
+            to step up the vehicle's 12 V supply to the required 20 V input.
+          </p>
+
+          <p>
+            Because the car's 12 V rail drops to 6&ndash;8 V during engine
+            cranking, a <strong>12 V AGM battery buffer</strong> (7.2 Ah) is
+            placed between the car battery and the boost converter. A Schottky
+            diode isolates the AGM from the car battery so it never backfeeds.
+            A low-voltage disconnect (LVD) at 10.5 V protects the AGM from deep
+            discharge when the car is parked for extended periods.
+          </p>
+
+          <p>
+            For power management, the M910q supports native <strong>ACPI S3
+            suspend</strong> with a typical draw of only ~0.2 A at 12 V. This
+            gives approximately 36 hours of standby on the 7.2 Ah AGM buffer.
+            An Arduino-based ignition watcher automates the suspend/resume cycle
+            based on the car's ignition state.
+          </p>
+
+          <div class="box box-info">
+            <div class="box-title">Why not just shut down?</div>
+            <p>
+              A full shutdown requires a cold boot (~12 s). S3 suspend resumes
+              in <strong>3&ndash;5 seconds</strong> from power button press to
+              a visible dashboard &mdash; fast enough that the driver sees the
+              BCM interface before they finish adjusting their seatbelt. The
+              AGM battery buffer provides 36 hours of standby, more than enough
+              for any typical parking duration.
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             POWER SUPPLY CHAIN
+             ============================================================ -->
+        <section>
+          <h2 id="power-supply-chain">Power Supply Chain</h2>
+
+          <p>
+            The complete power path from the car battery to the M910q and
+            amplifier:
+          </p>
+
+          <pre><code>Car 12V ─[25A fuse]─┬─[Schottky diode MBR2045]─ AGM 12V 7.2Ah
+                    │                              │
+                    └───────────┬──────────────────┘
+                                │
+                   ┌────────────┴────────────┐
+                   │ LVD cutoff (10.5V)      │
+                   └────────────┬────────────┘
+                                │
+                  ┌─────────────┴────────────┐
+                  │                           │
+            [12V→20V boost]             [20A fuse]
+                  │                           │
+            M910q barrel jack           TDA7388 amp</code></pre>
+
+          <h3>Key Design Points</h3>
+
+          <ul>
+            <li>
+              <strong>Schottky diode (MBR2045):</strong> Prevents the AGM
+              battery from backfeeding into the car battery. The diode's low
+              forward voltage drop (~0.45 V) minimizes power loss. Current
+              flows from the car battery into the AGM for charging, but not
+              in reverse.
+            </li>
+            <li>
+              <strong>LVD cutoff (10.5 V):</strong> Protects the AGM from
+              deep discharge. If the battery voltage drops below 10.5 V
+              (indicating the car has been parked for an extended period and
+              the AGM is draining), the LVD disconnects all loads. This
+              prevents permanent damage to the AGM and ensures it retains
+              enough charge to power the next S3 resume cycle.
+            </li>
+            <li>
+              <strong>Standby calculation:</strong> 7.2 Ah &divide; 0.2 A
+              (S3 draw) = <strong>36 hours</strong> of standby time. In
+              practice, the AGM will hit the 10.5 V LVD cutoff after
+              approximately 30&ndash;34 hours, providing a safety margin.
+            </li>
+          </ul>
+
+          <h3>Component Specifications</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Component</th>
+                  <th>Specification</th>
+                  <th>Notes</th>
+                  <th>Price (PLN)</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>AGM battery</td>
+                  <td>12 V 7.2 Ah (e.g., CSB GP1272F2)</td>
+                  <td>Sealed, maintenance-free, fits behind dash</td>
+                  <td>50&ndash;80</td>
+                </tr>
+                <tr>
+                  <td>12 V &rarr; 20 V boost converter</td>
+                  <td>150 W, 12 V in &rarr; 20 V / 7.5 A out</td>
+                  <td>Must handle 65 W sustained for M910q</td>
+                  <td>40&ndash;70</td>
+                </tr>
+                <tr>
+                  <td>Schottky diode</td>
+                  <td>MBR2045CT (20 A, 45 V, dual)</td>
+                  <td>TO-220 package, ~0.45 V drop</td>
+                  <td>5&ndash;10</td>
+                </tr>
+                <tr>
+                  <td>LVD module</td>
+                  <td>12 V low-voltage disconnect, 10.5 V cutoff</td>
+                  <td>Adjustable cutoff preferred; 30 A rated</td>
+                  <td>20&ndash;40</td>
+                </tr>
+                <tr>
+                  <td>Fuse (main)</td>
+                  <td>25 A blade fuse</td>
+                  <td>Inline fuse holder on car battery positive</td>
+                  <td>5&ndash;10</td>
+                </tr>
+                <tr>
+                  <td>Fuse (amp)</td>
+                  <td>20 A blade fuse</td>
+                  <td>Separate fuse for TDA7388 amplifier branch</td>
+                  <td>5&ndash;10</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             BIOS POWER SETTINGS
+             ============================================================ -->
+        <section>
+          <h2 id="bios-power-settings">BIOS Power Settings</h2>
+
+          <p>
+            Two BIOS settings are critical for in-car operation. Access the
+            M910q BIOS by pressing <kbd>F1</kbd> during boot.
+          </p>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Setting</th>
+                  <th>Location</th>
+                  <th>Value</th>
+                  <th>Purpose</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>After Power Loss</td>
+                  <td>Power &rarr; After Power Loss</td>
+                  <td><strong>Power On</strong></td>
+                  <td>Auto-start when 12 V returns (e.g., after cranking dip or LVD reconnect)</td>
+                </tr>
+                <tr>
+                  <td>Wake on USB</td>
+                  <td>Power &rarr; Wake on USB</td>
+                  <td><strong>Enabled</strong></td>
+                  <td>Allows the Arduino to wake the M910q from S3 suspend via USB activity</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="box box-warning">
+            <div class="box-title">After Power Loss must be "Power On"</div>
+            <p>
+              If this is set to "Last State" or "Power Off", the M910q will not
+              restart automatically after a cranking voltage dip causes the boost
+              converter to briefly lose output. "Power On" ensures the PC always
+              boots when power is available.
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             S3 SUSPEND CONFIGURATION
+             ============================================================ -->
+        <section>
+          <h2 id="s3-suspend-config">S3 Suspend Configuration</h2>
+
+          <h3>Verify S3 Support</h3>
+
+          <p>
+            Check that the kernel supports deep (S3) sleep:
+          </p>
+
+          <pre><code>cat /sys/power/mem_sleep</code></pre>
+
+          <p>
+            Expected output with S3 active (note the brackets indicating the
+            current selection):
+          </p>
+
+          <pre><code>s2idle [deep]</code></pre>
+
+          <h3>Enable S3 if Only s2idle is Available</h3>
+
+          <p>
+            If the output shows <code>[s2idle] deep</code> (s2idle selected by
+            default) or just <code>[s2idle]</code>, add the following kernel
+            parameter to force deep sleep:
+          </p>
+
+          <pre><code># Edit GRUB defaults
+sudo nano /etc/default/grub
+
+# Add to GRUB_CMDLINE_LINUX_DEFAULT:
+GRUB_CMDLINE_LINUX_DEFAULT="quiet mem_sleep_default=deep"
+
+# Rebuild GRUB config
+sudo update-grub
+sudo reboot</code></pre>
+
+          <h3>logind Configuration</h3>
+
+          <p>
+            Disable systemd-logind's built-in power button handling so that
+            <code>acpid</code> can manage it instead:
+          </p>
+
+          <pre><code># /etc/systemd/logind.conf
+[Login]
+HandlePowerKey=ignore</code></pre>
+
+          <p>
+            This prevents logind from intercepting the power button press before
+            acpid can run the custom suspend script.
+          </p>
+
+          <h3>acpid Power Button Handler</h3>
+
+          <p>
+            The <code>acpid</code> daemon listens for ACPI power button events
+            and runs <code>bcm-power-toggle.sh</code> to perform a clean
+            suspend:
+          </p>
+
+          <pre><code># /etc/acpi/events/power-button
+event=button/power
+action=/opt/bcm/scripts/bcm-power-toggle.sh</code></pre>
+        </section>
+
+        <!-- ============================================================
+             POWER BUTTON FLOW
+             ============================================================ -->
+        <section>
+          <h2 id="power-button-flow">Power Button Flow (bcm-power-toggle.sh)</h2>
+
+          <p>
+            When the power button is pressed (or the ignition watcher triggers
+            a suspend), the <code>bcm-power-toggle.sh</code> script performs a
+            clean shutdown sequence before entering S3:
+          </p>
+
+          <ol>
+            <li>
+              <strong>Stop bcm-headunit service</strong> &mdash; Gracefully
+              shuts down the Flask backend, closes camera streams, and releases
+              audio devices.
+            </li>
+            <li>
+              <strong>Disable all USB wake sources</strong> &mdash; Prevents
+              spurious wake events from USB devices moving during driving.
+            </li>
+            <li>
+              <strong>Unbind Huawei LTE modem</strong> &mdash; The Huawei E3372
+              HiLink modem is known to prevent successful S3 suspend on many
+              systems. Unbinding it from the USB driver before suspend avoids
+              this failure.
+            </li>
+            <li>
+              <strong>Disable XHCI and PS2K ACPI wake sources</strong> &mdash;
+              Disables the USB controller (XHCI) and PS/2 keyboard controller
+              wake sources to prevent unintended wakeups.
+            </li>
+            <li>
+              <strong>systemctl suspend</strong> &mdash; Enters ACPI S3 deep
+              sleep. Power draw drops to ~0.2 A at 12 V.
+            </li>
+          </ol>
+
+          <pre><code>#!/bin/bash
+# /opt/bcm/scripts/bcm-power-toggle.sh
+
+# Step 1: Stop BCM
+systemctl stop bcm-headunit
+
+# Step 2: Disable USB wake sources
+for f in /sys/bus/usb/devices/*/power/wakeup; do
+    echo disabled > "$f" 2>/dev/null
+done
+
+# Step 3: Unbind Huawei LTE modem (prevents suspend failure)
+MODEM_ID=$(lsusb | grep -i huawei | grep -oP '\d+:\d+' | head -1)
+if [ -n "$MODEM_ID" ]; then
+    for dev in /sys/bus/usb/devices/*; do
+        if [ -f "$dev/idVendor" ]; then
+            vendor=$(cat "$dev/idVendor")
+            product=$(cat "$dev/idProduct")
+            if lsusb -d "${vendor}:${product}" 2>/dev/null | grep -qi huawei; then
+                echo "$(basename $dev)" > /sys/bus/usb/drivers/usb/unbind 2>/dev/null
+            fi
+        fi
+    done
+fi
+
+# Step 4: Disable XHCI and PS2K wake sources
+for src in XHCI PS2K; do
+    grep -q "enabled" /proc/acpi/wakeup | grep "$src" && \
+        echo "$src" > /proc/acpi/wakeup
+done
+
+# Step 5: Suspend
+systemctl suspend</code></pre>
+        </section>
+
+        <!-- ============================================================
+             RESUME FLOW
+             ============================================================ -->
+        <section>
+          <h2 id="resume-flow">Resume Flow (bcm-resume.service)</h2>
+
+          <p>
+            A systemd service runs after every S3 resume to restore USB devices
+            and restart the BCM application:
+          </p>
+
+          <pre><code># /etc/systemd/system/bcm-resume.service
+[Unit]
+Description=BCM resume handler
+After=suspend.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/bcm/scripts/bcm-resume.sh
+
+[Install]
+WantedBy=suspend.target</code></pre>
+
+          <h3>Resume Script Steps</h3>
+
+          <ol>
+            <li>
+              <strong>Wait 2 seconds for hardware</strong> &mdash; Gives USB
+              controllers and attached devices time to re-enumerate after
+              waking from S3.
+            </li>
+            <li>
+              <strong>Rebind USB root hubs</strong> &mdash; Re-attaches the
+              USB root hub devices to the kernel driver. This forces
+              re-enumeration of all USB devices, including the Huawei LTE
+              modem that was unbound before suspend.
+            </li>
+            <li>
+              <strong>Start bcm-headunit service</strong> &mdash; Restarts
+              the Flask backend, camera streams, and audio pipeline.
+            </li>
+          </ol>
+
+          <pre><code>#!/bin/bash
+# /opt/bcm/scripts/bcm-resume.sh
+
+# Step 1: Wait for hardware to settle
+sleep 2
+
+# Step 2: Rebind USB root hubs (LTE modem reconnects)
+for rhub in /sys/bus/usb/devices/usb*/; do
+    devname=$(basename "$rhub")
+    echo "$devname" > /sys/bus/usb/drivers/usb/unbind 2>/dev/null
+    sleep 0.5
+    echo "$devname" > /sys/bus/usb/drivers/usb/bind 2>/dev/null
+done
+
+# Step 3: Start BCM
+systemctl start bcm-headunit</code></pre>
+        </section>
+
+        <!-- ============================================================
+             IGNITION WATCHER
+             ============================================================ -->
+        <section>
+          <h2 id="ignition-watcher">Ignition Watcher</h2>
+
+          <p>
+            On the x86 platform, the ignition watcher uses the
+            <strong>Arduino input board</strong> to detect the car's ignition
+            state. The car's 12 V ignition signal is connected to the Arduino
+            via a <strong>PC817 optoisolator</strong>, which provides
+            electrical isolation between the car's ignition circuit and the
+            Arduino's digital input.
+          </p>
+
+          <h3>Hardware Signal Path</h3>
+
+          <pre><code>Ignition 12V ─[1K resistor]─ PC817 LED side
+                                    │
+                              PC817 transistor side ─ Arduino D2 (INPUT_PULLUP)
+                                    │
+                                   GND</code></pre>
+
+          <p>
+            When the ignition is <strong>ON</strong>, the PC817's internal LED
+            illuminates, the transistor conducts, and Arduino pin D2 reads LOW.
+            When the ignition is <strong>OFF</strong>, D2 reads HIGH (pulled up
+            internally). The Arduino sends an <code>IGN:ON</code> or
+            <code>IGN:OFF</code> message over USB serial to the M910q.
+          </p>
+
+          <h3>bcm-ignition-watcher.service</h3>
+
+          <p>
+            A systemd service monitors the ignition state reported by the
+            Arduino and triggers suspend/resume accordingly:
+          </p>
+
+          <pre><code># /etc/systemd/system/bcm-ignition-watcher.service
+[Unit]
+Description=BCM ignition watcher
+After=bcm-headunit.service
+Requires=bcm-headunit.service
+
+[Service]
+Type=simple
+ExecStart=/opt/bcm/scripts/bcm-ignition-watcher.sh
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target</code></pre>
+
+          <h3>Ignition State Transitions</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Event</th>
+                  <th>Action</th>
+                  <th>Details</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Ignition OFF</td>
+                  <td>Stop BCM &rarr; suspend after 5 s delay</td>
+                  <td>The 5-second delay prevents false triggers from momentary ignition switch bouncing during engine cranking</td>
+                </tr>
+                <tr>
+                  <td>Ignition ON</td>
+                  <td>Resume &rarr; restart BCM</td>
+                  <td>The Arduino USB activity wakes the M910q from S3 (Wake on USB enabled in BIOS); the resume service restarts BCM</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>Configuration</h3>
+
+          <p>
+            The ignition watcher is enabled in the BCM configuration file:
+          </p>
+
+          <pre><code># /opt/bcm/config.yaml (relevant section)
+power:
+  ignition_watcher:
+    autostart: true</code></pre>
+
+          <div class="box box-info">
+            <div class="box-title">Manual override</div>
+            <p>
+              The physical power button on the M910q always works as a manual
+              suspend/resume toggle, regardless of the ignition watcher state.
+              If <code>autostart</code> is set to <code>false</code>, the
+              ignition watcher service will not start automatically, and
+              suspend/resume must be triggered manually via the power button.
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             BOOT TIMELINE
+             ============================================================ -->
+        <section>
+          <h2 id="boot-timeline">Boot Timeline</h2>
+
+          <p>
+            Cold boot and S3 resume timings for the M910q with NVMe SSD and
+            optimized BIOS settings (fast boot enabled, boot device list
+            minimized):
+          </p>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Time</th>
+                  <th>Event</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>0&ndash;2 s</td>
+                  <td>Lenovo BIOS POST (fast boot enabled, no splash logo)</td>
+                </tr>
+                <tr>
+                  <td>2&ndash;4 s</td>
+                  <td>Kernel loads (silent boot, GRUB menu hidden with 0 s timeout)</td>
+                </tr>
+                <tr>
+                  <td>4&ndash;5 s</td>
+                  <td>DRM device ready &rarr; splash video starts playing on both displays</td>
+                </tr>
+                <tr>
+                  <td>5&ndash;10 s</td>
+                  <td>Flask backend starts behind splash (loading config, initializing serial, cameras)</td>
+                </tr>
+                <tr>
+                  <td>10&ndash;12 s</td>
+                  <td>Splash ends &rarr; X11 starts &rarr; Chromium launches in kiosk mode</td>
+                </tr>
+                <tr>
+                  <td>~12 s</td>
+                  <td><strong>Dashboard visible</strong> &mdash; full BCM interface on both screens</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Mode</th>
+                  <th>Time to Dashboard</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Cold boot (power on)</td>
+                  <td>~12 s</td>
+                </tr>
+                <tr>
+                  <td>S3 resume (suspend &rarr; wake)</td>
+                  <td>~3&ndash;5 s from power button to dashboard</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="box box-info">
+            <div class="box-title">S3 resume is 3&times; faster</div>
+            <p>
+              With S3 suspend, the driver sees the BCM dashboard in 3&ndash;5
+              seconds after turning the ignition key. This is fast enough that
+              the interface is ready before the driver finishes adjusting their
+              mirrors. This is the primary reason for using S3 suspend instead
+              of a full shutdown.
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             VERIFICATION
+             ============================================================ -->
+        <section>
+          <h2 id="verification">Verification</h2>
+
+          <h3>S3 Suspend State</h3>
+
+          <pre><code># Verify deep sleep is selected
+cat /sys/power/mem_sleep
+# Expected: s2idle [deep]</code></pre>
+
+          <h3>Suspend and Resume Test</h3>
+
+          <pre><code># Trigger a manual suspend
+sudo systemctl suspend
+
+# After wake, check suspend/resume logs
+sudo journalctl -b -k | grep -i "suspend\|resume\|PM:"</code></pre>
+
+          <h3>Resume Service Status</h3>
+
+          <pre><code>systemctl status bcm-resume.service
+sudo journalctl -u bcm-resume.service --no-pager -n 20</code></pre>
+
+          <h3>Ignition Watcher Status</h3>
+
+          <pre><code>systemctl status bcm-ignition-watcher.service
+sudo journalctl -u bcm-ignition-watcher.service --no-pager -n 20</code></pre>
+
+          <h3>ACPI Wake Sources</h3>
+
+          <pre><code># Check which wake sources are enabled
+cat /proc/acpi/wakeup</code></pre>
+
+          <h3>Checklist</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Test</th>
+                  <th>Expected Result</th>
+                  <th>Pass</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>S3 deep sleep available</td>
+                  <td><code>/sys/power/mem_sleep</code> shows <code>[deep]</code></td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Manual suspend works</td>
+                  <td><code>systemctl suspend</code> enters S3; power LED blinks</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Power button resumes</td>
+                  <td>Pressing power button wakes from S3 within 3&ndash;5 s</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>BCM restarts on resume</td>
+                  <td><code>bcm-headunit</code> service is active after wake</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>LTE modem reconnects</td>
+                  <td><code>lsusb</code> shows Huawei device after resume</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Ignition watcher triggers suspend</td>
+                  <td>Turning ignition OFF suspends after 5 s delay</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Ignition watcher triggers resume</td>
+                  <td>Turning ignition ON wakes from S3 and restarts BCM</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>Cold boot time</td>
+                  <td>Dashboard visible in ~12 s from power on</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>BIOS: After Power Loss</td>
+                  <td>Set to "Power On"</td>
+                  <td>[ ]</td>
+                </tr>
+                <tr>
+                  <td>BIOS: Wake on USB</td>
+                  <td>Set to "Enabled"</td>
+                  <td>[ ]</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             TROUBLESHOOTING
+             ============================================================ -->
+        <section>
+          <h2 id="troubleshooting">Troubleshooting</h2>
+
+          <h3>Instant Wake After Suspend</h3>
+
+          <p>
+            The M910q enters S3 but immediately wakes up:
+          </p>
+
+          <ul>
+            <li>
+              A USB device is triggering a wake event. Check which device
+              caused the last wake:
+              <pre><code>cat /proc/acpi/wakeup
+dmesg | grep -i "wake"</code></pre>
+            </li>
+            <li>
+              Ensure the power-toggle script disables all USB wake sources
+              before suspending. The Huawei LTE modem is the most common
+              culprit &mdash; verify it is unbound.
+            </li>
+            <li>
+              Check if XHCI or PS2K wake sources are still enabled in
+              <code>/proc/acpi/wakeup</code> and disable them in the script.
+            </li>
+          </ul>
+
+          <h3>Full 40-Second Boot Instead of S3 Resume</h3>
+
+          <p>
+            If the system takes ~40 seconds to reach the dashboard instead of
+            3&ndash;5 seconds, it is performing a full cold boot rather than
+            an S3 resume:
+          </p>
+
+          <ul>
+            <li>
+              The AGM battery may have hit the LVD cutoff (10.5 V), causing
+              a full power loss. Check AGM voltage with a multimeter.
+            </li>
+            <li>
+              The boost converter may have shut down during engine cranking.
+              Verify the AGM buffer is properly wired with the Schottky diode
+              isolating it from the car battery.
+            </li>
+            <li>
+              BIOS "After Power Loss" may be set to "Last State" instead of
+              "Power On". A power loss during S3 requires auto-restart.
+            </li>
+          </ul>
+
+          <h3>No S3 Available (Only s2idle)</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Symptom</th>
+                  <th>Cause</th>
+                  <th>Fix</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>[s2idle]</code> only in <code>mem_sleep</code></td>
+                  <td>Kernel defaulting to s2idle (modern standby)</td>
+                  <td>Add <code>mem_sleep_default=deep</code> to <code>GRUB_CMDLINE_LINUX_DEFAULT</code> and run <code>update-grub</code></td>
+                </tr>
+                <tr>
+                  <td><code>s2idle</code> only, no <code>deep</code> option listed</td>
+                  <td>BIOS does not advertise S3 support (some BIOS updates remove it)</td>
+                  <td>Check for a BIOS setting "Sleep State" or "Suspend Mode" and set it to "Linux" or "S3". Downgrade BIOS if the option was removed in a newer version.</td>
+                </tr>
+                <tr>
+                  <td>Suspend hangs (screen goes black but fans keep running)</td>
+                  <td>A device driver is blocking suspend</td>
+                  <td>Check <code>dmesg | grep -i "suspend"</code> for the failing driver. The Huawei LTE modem is the most common cause &mdash; ensure it is unbound before suspend.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>Ignition Watcher Not Triggering</h3>
+
+          <ul>
+            <li>
+              Verify the Arduino is sending <code>IGN:ON</code> /
+              <code>IGN:OFF</code> messages:
+              <pre><code>cat /dev/ttyACM0</code></pre>
+            </li>
+            <li>
+              Check that the PC817 optoisolator is wired correctly &mdash;
+              the LED side connects to the car's ignition 12 V through a
+              1 K&ohm; resistor, and the transistor side pulls Arduino D2
+              low when ignition is on.
+            </li>
+            <li>
+              Ensure <code>power.ignition_watcher.autostart</code> is set
+              to <code>true</code> in <code>/opt/bcm/config.yaml</code>.
+            </li>
+            <li>
+              Check the service logs:
+              <pre><code>sudo journalctl -u bcm-ignition-watcher.service -f</code></pre>
+            </li>
+          </ul>
+        </section>
+
+      </article>
+
+      <!-- Page Navigation -->
+      <div class="page-nav">
+        <a href="09-display-touch.html">&larr; 09 &mdash; Display &amp; Touch</a>
+        <a href="11-android-auto.html">11 &mdash; Android Auto &rarr;</a>
+      </div>
+
+      <!-- Footer -->
+      <footer class="page-footer">
+        <span>BCM v8.5 &mdash; Alfa Romeo 156 Headunit</span>
+        <span>Lenovo M910q x86 Production Build</span>
+      </footer>
+
+    </div>
+  </div>
+
+  <!-- Sidebar Toggle Script -->
+  <script>
+    function toggleSidebar() {
+      document.querySelector('.sidebar').classList.toggle('open');
+      document.querySelector('.sidebar-overlay').classList.toggle('active');
+    }
+
+    document.querySelectorAll('.sidebar nav a').forEach(function(link) {
+      link.addEventListener('click', function() {
+        if (window.innerWidth < 768) {
+          document.querySelector('.sidebar').classList.remove('open');
+          document.querySelector('.sidebar-overlay').classList.remove('active');
+        }
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/docs/x86-production/11-android-auto.html
+++ b/docs/x86-production/11-android-auto.html
@@ -1,0 +1,613 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>11 — Android Auto | BCM x86 Production</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+
+  <!-- Hamburger toggle (mobile) -->
+  <button class="hamburger" aria-label="Toggle navigation" onclick="toggleSidebar()">&#9776;</button>
+  <div class="sidebar-overlay" onclick="toggleSidebar()"></div>
+
+  <!-- Sidebar Navigation -->
+  <aside class="sidebar">
+    <div class="sidebar-header">
+      <div class="logo-text">BCM v8.5</div>
+      <div class="logo-sub">Lenovo M910q &middot; Alfa 156</div>
+    </div>
+    <nav aria-label="Documentation pages">
+      <ul>
+        <li><a href="index.html"><span class="nav-num"></span>Overview</a></li>
+        <li><a href="01-bom.html"><span class="nav-num">01</span>Bill of Materials</a></li>
+        <li><a href="02-power.html"><span class="nav-num">02</span>Power Supply</a></li>
+        <li><a href="03-os-install.html"><span class="nav-num">03</span>OS Installation</a></li>
+        <li><a href="04-packages.html"><span class="nav-num">04</span>System Packages</a></li>
+        <li><a href="05-bcm-install.html"><span class="nav-num">05</span>BCM Installation</a></li>
+        <li><a href="06-systemd.html"><span class="nav-num">06</span>Systemd Services</a></li>
+        <li><a href="07-boot.html"><span class="nav-num">07</span>Boot &amp; Splash</a></li>
+        <li><a href="08-kiosk.html"><span class="nav-num">08</span>Kiosk Display</a></li>
+        <li><a href="09-suspend.html"><span class="nav-num">09</span>Suspend / Wake</a></li>
+        <li><a href="10-wifi.html"><span class="nav-num">10</span>WiFi &amp; Android Auto</a></li>
+        <li><a href="11-android-auto.html" class="active"><span class="nav-num">11</span>Android Auto</a></li>
+        <li><a href="12-verification.html"><span class="nav-num">12</span>Verification</a></li>
+      </ul>
+    </nav>
+  </aside>
+
+  <!-- Main Content -->
+  <div class="content">
+    <div class="content-inner">
+
+      <header>
+        <h1>
+          Android Auto
+          <span class="subtitle">OpenAuto compilation, wired &amp; wireless AA setup, and x86 display pipeline</span>
+        </h1>
+      </header>
+
+      <article>
+
+        <!-- ============================================================
+             OVERVIEW
+             ============================================================ -->
+        <section>
+          <h2 id="overview">Overview</h2>
+
+          <p>
+            <strong>OpenAuto</strong> (built on <code>openauto</code> + <code>aasdk</code>
+            from the openDsh project) provides both wired and wireless Android Auto
+            for BCM. On the x86 platform, AA renders to an <strong>Xvfb virtual
+            display</strong> and streams to the browser-based dashboard via MJPEG.
+            Touch input is forwarded from the browser back to the virtual display
+            using <code>xdotool</code>.
+          </p>
+
+          <p>
+            This page covers compiling OpenAuto from source, setting up wired and
+            wireless Android Auto, and the internal display pipeline that connects
+            the Qt-based OpenAuto renderer to the BCM web dashboard.
+          </p>
+
+          <div class="box box-info">
+            <div class="box-title">AA is optional</div>
+            <p>
+              Android Auto is an optional feature. All other BCM functions (dashboard,
+              OBD-II, cameras, audio, sensors) work without it. Complete all other
+              build stages (<a href="index.html">sections 1&ndash;10</a>) before
+              attempting this step.
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             BUILD DEPENDENCIES
+             ============================================================ -->
+        <section>
+          <h2 id="build-dependencies">Build Dependencies</h2>
+
+          <p>
+            Install all required build tools, Qt5 libraries, GStreamer plugins,
+            and the Xvfb virtual framebuffer. This is a one-time operation &mdash;
+            these packages remain installed for future rebuilds.
+          </p>
+
+          <pre><code>sudo apt install -y \
+    cmake build-essential \
+    libboost-all-dev libusb-1.0-0-dev libssl-dev \
+    libprotobuf-dev protobuf-compiler \
+    qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools \
+    qtmultimedia5-dev libqt5multimedia5-plugins \
+    qtconnectivity5-dev qtdeclarative5-dev \
+    qml-module-qtquick2 qml-module-qtquick-controls2 \
+    libqt5websockets5-dev libqt5bluetooth5 \
+    libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+    gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
+    gstreamer1.0-libav \
+    libtag1-dev librtaudio-dev \
+    xvfb matchbox-window-manager</code></pre>
+
+          <div class="box box-warning">
+            <div class="box-title">Qt5 vs Qt6</div>
+            <p>
+              OpenAuto requires <strong>Qt5</strong>. Debian 13 ships both Qt5 and Qt6;
+              make sure the <code>qt5-qmake</code> and <code>qtbase5-dev</code> packages
+              are installed, not their Qt6 equivalents. The <code>qtchooser</code>
+              package handles version selection.
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             BUILD AASDK
+             ============================================================ -->
+        <section>
+          <h2 id="build-aasdk">Build aasdk</h2>
+
+          <p>
+            The <code>aasdk</code> library implements the Android Auto protocol
+            (USB and TCP transport, protobuf messaging, SSL handshake). It must
+            be built first since <code>openauto</code> depends on it.
+          </p>
+
+          <pre><code>cd /tmp
+git clone --recurse-submodules https://github.com/openDsh/aasdk.git
+cd aasdk
+
+# Fix: OpenSSL 3.0 removed FIPS_mode_set
+sed -i 's/FIPS_mode_set(0);/\/\/ FIPS_mode_set(0); \/\/ removed in OpenSSL 3.0/' \
+    src/Transport/SSLWrapper.cpp
+
+mkdir build &amp;&amp; cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j$(nproc)
+sudo make install
+sudo ldconfig</code></pre>
+
+          <div class="box box-info">
+            <div class="box-title">OpenSSL 3.0 FIPS fix</div>
+            <p>
+              The upstream <code>aasdk</code> calls <code>FIPS_mode_set(0)</code> which
+              was removed in OpenSSL 3.0 (shipped with Debian 12+). The <code>sed</code>
+              command comments out this call. Without this fix, the build will fail with
+              <code>undefined reference to FIPS_mode_set</code>.
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             BUILD H264BITSTREAM
+             ============================================================ -->
+        <section>
+          <h2 id="build-h264bitstream">Build h264bitstream</h2>
+
+          <p>
+            The <code>h264bitstream</code> library parses H.264 NAL units. The
+            upstream repository has no Makefile, so we compile and install it manually.
+          </p>
+
+          <pre><code>cd /tmp
+git clone https://github.com/aizvorski/h264bitstream.git
+cd h264bitstream
+
+gcc -c -fPIC h264_stream.c h264_sei.c -I.
+ar rcs libh264bitstream.a h264_stream.o h264_sei.o
+
+sudo cp libh264bitstream.a /usr/local/lib/
+sudo cp h264_stream.h h264_sei.h h264_avcc.h h264_slice_data.h bs.h \
+    /usr/local/include/
+sudo ldconfig</code></pre>
+
+          <p>
+            This creates a static library (<code>libh264bitstream.a</code>) and
+            installs the headers to <code>/usr/local/include/</code>. The
+            <code>openauto</code> build will find them via the default search paths.
+          </p>
+        </section>
+
+        <!-- ============================================================
+             BUILD OPENAUTO
+             ============================================================ -->
+        <section>
+          <h2 id="build-openauto">Build openauto</h2>
+
+          <p>
+            The <code>openauto</code> project contains the main <code>autoapp</code>
+            binary that renders the Android Auto projection.
+          </p>
+
+          <pre><code>cd /tmp
+git clone --recurse-submodules https://github.com/openDsh/openauto.git
+cd openauto
+
+# Fix: Debian 13 librtaudio 6.x renamed RtAudioError
+sed -i 's/catch(const RtAudioError&amp; e)/catch(const std::exception\&amp; e)/g' \
+    openauto/Projection/RtAudioOutput.cpp
+
+mkdir build &amp;&amp; cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j$(nproc)
+sudo make install</code></pre>
+
+          <div class="box box-warning">
+            <div class="box-title">RtAudio fix for Debian 13</div>
+            <p>
+              Debian 13 (Trixie) ships <code>librtaudio 6.x</code> which renamed the
+              <code>RtAudioError</code> exception class. The <code>sed</code> command
+              replaces it with the standard <code>std::exception</code> catch. Without
+              this fix, the build fails with <code>RtAudioError was not declared</code>.
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             VERIFY
+             ============================================================ -->
+        <section>
+          <h2 id="verify">Verify Installation</h2>
+
+          <p>
+            After a successful build, the <code>autoapp</code> binary should be
+            installed at <code>/usr/local/bin/autoapp</code>.
+          </p>
+
+          <pre><code>ls -la /usr/local/bin/autoapp
+# Should show the binary (~5MB)</code></pre>
+
+          <p>Restart BCM so it detects the newly installed OpenAuto binary:</p>
+
+          <pre><code>sudo systemctl restart bcm-ignition-watcher
+sudo journalctl -u bcm-headunit --no-pager | grep -i openauto
+# Should show: "OpenAuto found: /usr/local/bin/autoapp"</code></pre>
+
+          <p>
+            BCM searches for the <code>autoapp</code> binary in three locations
+            at startup: <code>/usr/local/bin/autoapp</code>,
+            <code>/opt/openauto/bin/autoapp</code>, and <code>/usr/bin/autoapp</code>.
+            The first one found is used.
+          </p>
+        </section>
+
+        <!-- ============================================================
+             WIRED ANDROID AUTO
+             ============================================================ -->
+        <section>
+          <h2 id="wired-aa">Wired Android Auto</h2>
+
+          <p>
+            Wired Android Auto uses a direct USB connection between the phone and
+            the M910q. This is the simplest setup and provides the lowest latency.
+          </p>
+
+          <h3>Setup Steps</h3>
+
+          <ol>
+            <li>Install <strong>Android Auto</strong> from the Google Play Store on your phone</li>
+            <li>Enable <strong>Developer options</strong> on the phone (Settings &rarr; About phone &rarr; tap Build number 7 times)</li>
+            <li>Enable <strong>USB debugging</strong> in Developer options</li>
+            <li>Connect the phone to the M910q via a USB cable (use one of the USB 3.0 ports)</li>
+            <li>Accept the <strong>"Allow USB debugging"</strong> prompt on the phone</li>
+            <li>Select <strong>"Android Auto"</strong> mode when prompted</li>
+            <li>AA appears on BCM screen A2 (the multimedia page in the dashboard)</li>
+          </ol>
+
+          <div class="box box-info">
+            <div class="box-title">USB cable quality matters</div>
+            <p>
+              Use a high-quality USB cable that supports data transfer (not a charge-only
+              cable). USB 3.0 cables provide better throughput for the H.264 video stream.
+              If the phone is not detected, try a different cable first.
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             WIRELESS ANDROID AUTO
+             ============================================================ -->
+        <section>
+          <h2 id="wireless-aa">Wireless Android Auto</h2>
+
+          <p>
+            Wireless Android Auto uses Bluetooth for initial pairing and the
+            5 GHz WiFi access point for the actual data stream. This requires
+            the Fenvi FU-AX1800 (or compatible WiFi 6 card) and a working
+            <code>hostapd</code> setup from <a href="10-wifi.html">section 10</a>.
+          </p>
+
+          <h3>Prerequisites</h3>
+
+          <ul>
+            <li>WiFi AP running: <code>ALFA_AA</code> on 5 GHz band (configured via hostapd)</li>
+            <li>Bluetooth pairing completed and phone trusted</li>
+            <li><code>autoapp</code> binary installed (see sections above)</li>
+          </ul>
+
+          <h3>Connection Flow</h3>
+
+          <ol>
+            <li>Phone pairs with BCM via <strong>Bluetooth</strong></li>
+            <li>Phone discovers the <code>ALFA_AA</code> WiFi access point through the BT connection</li>
+            <li>Phone connects to the AP and receives a DHCP address (192.168.44.x range)</li>
+            <li>AA video/audio stream flows over the WiFi connection</li>
+          </ol>
+
+          <h3>BCM Configuration</h3>
+
+          <p>
+            The WiFi credentials must be set in <code>bcm_config.yaml</code> so that
+            BCM knows which AP to advertise during the BT pairing handshake:
+          </p>
+
+          <pre><code># config/bcm_config.yaml:
+wifi:
+  enabled: true
+  ssid: ALFA_AA
+  password: AlfaRomeo156</code></pre>
+
+          <div class="box box-warning">
+            <div class="box-title">5 GHz is required for wireless AA</div>
+            <p>
+              Android Auto requires a 5 GHz WiFi connection for wireless mode. The
+              2.4 GHz band does not have enough bandwidth for the H.264 video stream.
+              If using the stock Intel 8265 card, verify it can create a 5 GHz AP &mdash;
+              some firmware versions restrict AP mode to 2.4 GHz. The Fenvi FU-AX1800
+              (Intel AX200) is the recommended upgrade if 5 GHz AP is unstable.
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             HOW AA DISPLAY WORKS ON X86
+             ============================================================ -->
+        <section>
+          <h2 id="aa-display-pipeline">How AA Display Works on x86</h2>
+
+          <p>
+            On the x86 platform, BCM runs a browser-based dashboard (Flask + Chromium).
+            OpenAuto is a Qt application that renders to a native X11 window. To bridge
+            these two worlds, BCM uses a virtual framebuffer pipeline:
+          </p>
+
+          <h3>Display Pipeline</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Stage</th>
+                  <th>Component</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>1</td>
+                  <td><strong>Xvfb</strong></td>
+                  <td>Virtual framebuffer running at display <code>:99</code> &mdash; no physical monitor needed</td>
+                </tr>
+                <tr>
+                  <td>2</td>
+                  <td><strong>OpenAuto (autoapp)</strong></td>
+                  <td>Renders AA projection via Qt <code>xcb</code> platform plugin to display <code>:99</code></td>
+                </tr>
+                <tr>
+                  <td>3</td>
+                  <td><strong>ffmpeg</strong></td>
+                  <td>Captures display <code>:99</code> and encodes as MJPEG stream</td>
+                </tr>
+                <tr>
+                  <td>4</td>
+                  <td><strong>BCM Flask</strong></td>
+                  <td>Serves the MJPEG stream at <code>/aa/stream</code> endpoint</td>
+                </tr>
+                <tr>
+                  <td>5</td>
+                  <td><strong>Browser</strong></td>
+                  <td>Displays the MJPEG stream in an <code>&lt;img&gt;</code> tag inside the AA page</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>Touch Input Pipeline</h3>
+
+          <p>
+            Touch input flows in the reverse direction &mdash; from the browser back
+            to the virtual display:
+          </p>
+
+          <ol>
+            <li>User taps on the AA area in the browser (Chromium on the physical touchscreen)</li>
+            <li>Browser sends a <code>POST /aa/touch</code> request with <code>{x, y}</code> coordinates</li>
+            <li>BCM translates the coordinates to the Xvfb virtual display space</li>
+            <li><code>xdotool mousemove --screen 0 &lt;x&gt; &lt;y&gt; click 1</code> is executed on display <code>:99</code></li>
+            <li>OpenAuto receives the click event and forwards it to the phone via the AA protocol</li>
+          </ol>
+
+          <h3>Canvas Sizing</h3>
+
+          <p>
+            The AA canvas size is calculated dynamically based on the dashboard
+            dimensions. BCM reserves a 48 px AppBar at the top and a 48 px NavBar
+            at the bottom:
+          </p>
+
+          <pre><code># From src/multimedia/openauto.py:
+# Canvas = (dashboard_width, dashboard_height - appbar - navbar)
+# Default: (1024, 600 - 48 - 48) = 1024 x 504
+
+dash_w = config.get("display.dashboard.width", 1024)
+dash_h = config.get("display.dashboard.height", 600)
+appbar = config.get("display.appbar_px", 48)
+navbar = config.get("display.navbar_px", 48)
+canvas = (dash_w, max(240, dash_h - appbar - navbar))</code></pre>
+
+          <p>
+            If <code>display.multimedia.width</code> and <code>display.multimedia.height</code>
+            are explicitly set in <code>bcm_config.yaml</code>, those values override
+            the automatic calculation.
+          </p>
+
+          <div class="box box-info">
+            <div class="box-title">Why Xvfb?</div>
+            <p>
+              On ARM (OPi 5 Pro), OpenAuto renders directly to a physical HDMI output
+              using EGL/SDL2. On x86, the physical displays are already used by Chromium
+              kiosk instances. Xvfb provides a virtual display that OpenAuto can render
+              to without conflicting with the existing X11 session. The MJPEG streaming
+              approach adds ~30 ms latency but keeps the architecture clean and avoids
+              compositing issues.
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             TROUBLESHOOTING
+             ============================================================ -->
+        <section>
+          <h2 id="troubleshooting">Troubleshooting</h2>
+
+          <h3>autoapp not found</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Symptom</th>
+                  <th>Cause</th>
+                  <th>Fix</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>BCM log: "OpenAuto not found"</td>
+                  <td>Binary not in expected path</td>
+                  <td>Check <code>ls /usr/local/bin/autoapp</code> &mdash; if missing, re-run <code>sudo make install</code> in the openauto build directory</td>
+                </tr>
+                <tr>
+                  <td><code>autoapp: error while loading shared libraries</code></td>
+                  <td>aasdk libraries not in linker cache</td>
+                  <td>Run <code>sudo ldconfig</code> and verify <code>ls /usr/local/lib/libaasdk*</code></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>Phone Not Detected (Wired)</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Symptom</th>
+                  <th>Cause</th>
+                  <th>Fix</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Phone charges but no AA prompt</td>
+                  <td>USB debugging not enabled or charge-only cable</td>
+                  <td>Enable USB debugging in Developer options; try a data-capable USB cable</td>
+                </tr>
+                <tr>
+                  <td><code>lsusb</code> does not show phone</td>
+                  <td>Bad USB port or cable</td>
+                  <td>Try a different USB 3.0 port on the M910q; test the cable with another device</td>
+                </tr>
+                <tr>
+                  <td>Phone shows "Allow USB debugging" but AA never starts</td>
+                  <td>Android Auto app not installed or outdated</td>
+                  <td>Install/update Android Auto from Play Store; reboot phone</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>Wireless AA Timeout</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Symptom</th>
+                  <th>Cause</th>
+                  <th>Fix</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Phone pairs via BT but never connects to WiFi</td>
+                  <td>5 GHz AP not running or phone cannot see it</td>
+                  <td>Verify <code>systemctl status hostapd</code>; check <code>iw dev</code> for AP on 5 GHz channel</td>
+                </tr>
+                <tr>
+                  <td>Phone connects to WiFi but AA does not start</td>
+                  <td>DHCP not assigning address</td>
+                  <td>Check <code>journalctl -u dnsmasq</code> for lease assignment; verify <code>192.168.44.0/24</code> subnet</td>
+                </tr>
+                <tr>
+                  <td>AA connects then disconnects after a few seconds</td>
+                  <td>WiFi signal too weak (2.4 GHz fallback)</td>
+                  <td>Confirm AP is on 5 GHz: <code>iw dev | grep channel</code>; consider upgrading to Fenvi AX200</td>
+                </tr>
+                <tr>
+                  <td>Wireless AA lag or stutter</td>
+                  <td>WiFi interference or low signal</td>
+                  <td>Move antenna position; switch to a less congested 5 GHz channel in <code>/etc/hostapd/hostapd.conf</code></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>Touch Not Reaching AA</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Symptom</th>
+                  <th>Cause</th>
+                  <th>Fix</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>AA video shows but taps do nothing</td>
+                  <td><code>xdotool</code> not installed or DISPLAY not set</td>
+                  <td>Install: <code>sudo apt install xdotool</code>; verify <code>DISPLAY=:99</code> is set in the touch handler</td>
+                </tr>
+                <tr>
+                  <td>Taps land in wrong position</td>
+                  <td>Canvas size mismatch between browser and Xvfb</td>
+                  <td>Check <code>display.multimedia.width/height</code> in config matches Xvfb resolution</td>
+                </tr>
+                <tr>
+                  <td>Touch works but with noticeable delay</td>
+                  <td>Normal for MJPEG pipeline (~30&ndash;50 ms)</td>
+                  <td>This is expected; reduce MJPEG quality or increase frame rate if needed</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+      </article>
+
+      <!-- Page Navigation -->
+      <div class="page-nav">
+        <a href="10-power-suspend.html">&larr; 10 &mdash; Power &amp; Suspend</a>
+        <a href="12-verification.html">12 &mdash; Verification &rarr;</a>
+      </div>
+
+      <!-- Footer -->
+      <footer class="page-footer">
+        <span>BCM v8.5 &mdash; Alfa Romeo 156 Headunit</span>
+        <span>Lenovo M910q x86 Production Build</span>
+      </footer>
+
+    </div>
+  </div>
+
+  <!-- Sidebar Toggle Script -->
+  <script>
+    function toggleSidebar() {
+      document.querySelector('.sidebar').classList.toggle('open');
+      document.querySelector('.sidebar-overlay').classList.toggle('active');
+    }
+
+    document.querySelectorAll('.sidebar nav a').forEach(function(link) {
+      link.addEventListener('click', function() {
+        if (window.innerWidth < 768) {
+          document.querySelector('.sidebar').classList.remove('open');
+          document.querySelector('.sidebar-overlay').classList.remove('active');
+        }
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/docs/x86-production/12-verification.html
+++ b/docs/x86-production/12-verification.html
@@ -1,0 +1,859 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>12 — Verification | BCM x86 Production</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+
+  <!-- Hamburger toggle (mobile) -->
+  <button class="hamburger" aria-label="Toggle navigation" onclick="toggleSidebar()">&#9776;</button>
+  <div class="sidebar-overlay" onclick="toggleSidebar()"></div>
+
+  <!-- Sidebar Navigation -->
+  <aside class="sidebar">
+    <div class="sidebar-header">
+      <div class="logo-text">BCM v8.5</div>
+      <div class="logo-sub">Lenovo M910q &middot; Alfa 156</div>
+    </div>
+    <nav aria-label="Documentation pages">
+      <ul>
+        <li><a href="index.html"><span class="nav-num"></span>Overview</a></li>
+        <li><a href="01-bom.html"><span class="nav-num">01</span>Bill of Materials</a></li>
+        <li><a href="02-power.html"><span class="nav-num">02</span>Power Supply</a></li>
+        <li><a href="03-os-install.html"><span class="nav-num">03</span>OS Installation</a></li>
+        <li><a href="04-packages.html"><span class="nav-num">04</span>System Packages</a></li>
+        <li><a href="05-bcm-install.html"><span class="nav-num">05</span>BCM Installation</a></li>
+        <li><a href="06-systemd.html"><span class="nav-num">06</span>Systemd Services</a></li>
+        <li><a href="07-boot.html"><span class="nav-num">07</span>Boot &amp; Splash</a></li>
+        <li><a href="08-kiosk.html"><span class="nav-num">08</span>Kiosk Display</a></li>
+        <li><a href="09-suspend.html"><span class="nav-num">09</span>Suspend / Wake</a></li>
+        <li><a href="10-wifi.html"><span class="nav-num">10</span>WiFi &amp; Android Auto</a></li>
+        <li><a href="11-android-auto.html"><span class="nav-num">11</span>Android Auto</a></li>
+        <li><a href="12-verification.html" class="active"><span class="nav-num">12</span>Verification</a></li>
+      </ul>
+    </nav>
+  </aside>
+
+  <!-- Main Content -->
+  <div class="content">
+    <div class="content-inner">
+
+      <header>
+        <h1>
+          Verification
+          <span class="subtitle">Complete checklist, diagnostic commands, and troubleshooting for the final production build</span>
+        </h1>
+      </header>
+
+      <article>
+
+        <!-- ============================================================
+             OVERVIEW
+             ============================================================ -->
+        <section>
+          <h2 id="overview">Overview</h2>
+
+          <p>
+            This is the final verification checklist after completing all installation
+            steps (sections 01&ndash;11). Work through each category systematically,
+            marking items as Pass or Fail. Any failures should be resolved using the
+            troubleshooting table at the bottom of this page before considering the
+            build production-ready.
+          </p>
+
+          <div class="box box-info">
+            <div class="box-title">When to run this checklist</div>
+            <p>
+              Run the full checklist after completing the initial build, after any
+              hardware changes (new display, new WiFi card, etc.), and after major
+              software updates. For day-to-day operation, the quick diagnostic script
+              in <a href="#quick-diagnostics">section 3</a> covers the essentials.
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             PRE-FLIGHT CHECKLIST
+             ============================================================ -->
+        <section>
+          <h2 id="preflight-checklist">Pre-flight Checklist</h2>
+
+          <!-- ---- Core System ---- -->
+          <h3>Core System</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Check</th>
+                  <th>Command / Action</th>
+                  <th>Pass</th>
+                  <th>Fail</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>BCM Flask running</td>
+                  <td><code>curl http://localhost:5002</code> returns HTML</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>Main display shows dashboard</td>
+                  <td>Dashboard visible on HDMI-1 (primary display)</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>Small display shows status</td>
+                  <td>Status dashboard visible on HDMI-2 (secondary display)</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>Displays are separate</td>
+                  <td>Not merged/spanning &mdash; each display has its own Chromium instance</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>Touch accurate on main display</td>
+                  <td>Tap targets on the 7" touchscreen respond correctly</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>No simulation data</td>
+                  <td>Verify <code>system.simulation: false</code> in <code>bcm_config.yaml</code></td>
+                  <td></td>
+                  <td></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- ---- ECU / OBD ---- -->
+          <h3>ECU / OBD</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Check</th>
+                  <th>Command / Action</th>
+                  <th>Pass</th>
+                  <th>Fail</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>K-Line adapter detected</td>
+                  <td><code>ls /dev/ttyUSB_kline</code></td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>ECU communication</td>
+                  <td><code>grep "controller found\|RPM" /opt/bcm/logs/bcm.log</code></td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>Live data flowing</td>
+                  <td>RPM, speed, coolant temp updating on dashboard in real-time</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- ---- Sensors ---- -->
+          <h3>Sensors</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Check</th>
+                  <th>Command / Action</th>
+                  <th>Pass</th>
+                  <th>Fail</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>External temperature updating</td>
+                  <td>DS18B20 via Arduino &mdash; temperature value changes on dashboard</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>Parking sensors responding</td>
+                  <td>HC-SR04 sensors report distance when objects are near</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>Light sensor auto-brightness</td>
+                  <td>Dashboard brightness adjusts with ambient light changes</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>Rain sensor triggers wipers</td>
+                  <td>If wired &mdash; rain detection triggers wiper relay</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- ---- Input ---- -->
+          <h3>Input</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Check</th>
+                  <th>Command / Action</th>
+                  <th>Pass</th>
+                  <th>Fail</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>SWC buttons mapped and working</td>
+                  <td>Both steering wheel pods respond (all 24 buttons)</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>Rotary encoder navigates menus</td>
+                  <td>Rotate and press &mdash; menu navigation works</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>Main buttons respond</td>
+                  <td>HOME, BACK, MEDIA, VOL buttons trigger correct actions</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- ---- Connectivity ---- -->
+          <h3>Connectivity</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Check</th>
+                  <th>Command / Action</th>
+                  <th>Pass</th>
+                  <th>Fail</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>WiFi AP broadcasting</td>
+                  <td><code>ALFA_AA</code> visible on 5 GHz (Fenvi)</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>Phone connects to AP</td>
+                  <td>Phone gets DHCP IP in 192.168.44.x range</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>Bluetooth powered and discoverable</td>
+                  <td><code>bluetoothctl show</code> &mdash; Powered: yes, Discoverable: yes</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>BT pairing popup appears</td>
+                  <td>When phone initiates pairing, confirmation popup shows on dashboard</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>LTE modem online</td>
+                  <td><code>ip addr show wwx*</code> &mdash; interface has IP address</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>GPS fix</td>
+                  <td><code>grep "gps\|fix" /opt/bcm/logs/bcm.log</code> &mdash; shows position data</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- ---- Audio / Media ---- -->
+          <h3>Audio / Media</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Check</th>
+                  <th>Command / Action</th>
+                  <th>Pass</th>
+                  <th>Fail</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Audio plays through USB DAC</td>
+                  <td>Test audio file plays through speakers via ES9038Q2M DAC</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>BT A2DP music streaming</td>
+                  <td>Play music from phone &mdash; audio streams to car speakers via BT</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>HFP phone calls</td>
+                  <td>Make/receive phone call &mdash; audio through car speakers, mic working</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- ---- Android Auto ---- -->
+          <h3>Android Auto</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Check</th>
+                  <th>Command / Action</th>
+                  <th>Pass</th>
+                  <th>Fail</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Wired AA connects</td>
+                  <td>Phone connected via USB &mdash; AA screen appears on dashboard</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>Touch forwarding works</td>
+                  <td>Tap on AA area in browser &mdash; phone responds to touch input</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>Wireless AA connects</td>
+                  <td>Phone connects via BT &rarr; WiFi &mdash; AA screen appears wirelessly</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- ---- Power ---- -->
+          <h3>Power</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Check</th>
+                  <th>Command / Action</th>
+                  <th>Pass</th>
+                  <th>Fail</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Splash video plays on both displays</td>
+                  <td>Boot &mdash; splash video visible on main and small display simultaneously</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>Boot time &lt; 15s</td>
+                  <td>Cold boot to dashboard in under 15 seconds</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>Power button &rarr; S3 suspend</td>
+                  <td>Press power button &mdash; system enters S3 suspend and stays sleeping</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>Power button &rarr; resume</td>
+                  <td>Press power button again &mdash; system resumes in ~3&ndash;5 seconds</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>Ignition OFF &rarr; suspend</td>
+                  <td>Turn ignition off &mdash; system suspends after 5-second delay</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>Ignition ON &rarr; resume</td>
+                  <td>Turn ignition on &mdash; system resumes and shows dashboard</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- ---- Boot ---- -->
+          <h3>Boot</h3>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Check</th>
+                  <th>Command / Action</th>
+                  <th>Pass</th>
+                  <th>Fail</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>No kernel messages visible</td>
+                  <td>Boot shows splash only &mdash; no scrolling text (quiet boot)</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>No GRUB menu visible</td>
+                  <td>GRUB timeout is 0 &mdash; boots directly without menu</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>Splash &rarr; dashboard transition smooth</td>
+                  <td>No black screen gap between splash video ending and dashboard appearing</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             QUICK DIAGNOSTIC COMMANDS
+             ============================================================ -->
+        <section>
+          <h2 id="quick-diagnostics">Quick Diagnostic Commands</h2>
+
+          <p>
+            Run this all-in-one diagnostic script to check the most critical subsystems
+            at a glance. Copy and paste the entire block into a terminal:
+          </p>
+
+          <pre><code>#!/bin/bash
+# BCM Quick Diagnostics — run as root or with sudo
+echo "============================================"
+echo "  BCM v8.5 — Quick Diagnostic Report"
+echo "============================================"
+echo ""
+
+# Core system
+echo "--- Core System ---"
+echo -n "BCM Flask (port 5002): "
+curl -s -o /dev/null -w "%{http_code}" http://localhost:5002 2>/dev/null || echo "FAIL"
+echo ""
+echo -n "BCM service: "
+systemctl is-active bcm-headunit 2>/dev/null || echo "inactive"
+echo -n "Ignition watcher: "
+systemctl is-active bcm-ignition-watcher 2>/dev/null || echo "inactive"
+echo ""
+
+# Displays
+echo "--- Displays ---"
+xrandr --listmonitors 2>/dev/null || echo "xrandr not available"
+echo ""
+
+# ECU / OBD
+echo "--- ECU / OBD ---"
+echo -n "K-Line adapter: "
+ls /dev/ttyUSB_kline 2>/dev/null &amp;&amp; echo "OK" || echo "NOT FOUND"
+echo -n "ECU comms: "
+grep -c "controller found\|RPM" /opt/bcm/logs/bcm.log 2>/dev/null || echo "0"
+echo " matches in bcm.log"
+echo ""
+
+# Connectivity
+echo "--- Connectivity ---"
+echo -n "WiFi AP (hostapd): "
+systemctl is-active hostapd 2>/dev/null || echo "inactive"
+echo -n "Bluetooth: "
+systemctl is-active bluetooth 2>/dev/null || echo "inactive"
+echo -n "LTE modem: "
+ip addr show wwx* 2>/dev/null | grep -q "inet " &amp;&amp; echo "ONLINE" || echo "OFFLINE"
+echo -n "GPS fix: "
+grep -c "fix" /opt/bcm/logs/bcm.log 2>/dev/null || echo "0"
+echo " fix entries in log"
+echo ""
+
+# Audio
+echo "--- Audio ---"
+echo -n "USB DAC: "
+aplay -l 2>/dev/null | grep -qi "usb\|dac" &amp;&amp; echo "DETECTED" || echo "NOT FOUND"
+echo -n "PipeWire: "
+systemctl --user is-active pipewire 2>/dev/null || echo "inactive"
+echo ""
+
+# Android Auto
+echo "--- Android Auto ---"
+echo -n "autoapp binary: "
+ls /usr/local/bin/autoapp 2>/dev/null &amp;&amp; echo "OK" || echo "NOT FOUND"
+echo -n "Xvfb (:99): "
+ps aux | grep -v grep | grep -q "Xvfb.*:99" &amp;&amp; echo "RUNNING" || echo "NOT RUNNING"
+echo ""
+
+# Power / Boot
+echo "--- Power / Boot ---"
+echo -n "Suspend support: "
+cat /sys/power/state 2>/dev/null || echo "unknown"
+echo -n "Boot time: "
+systemd-analyze 2>/dev/null | head -1 || echo "unknown"
+echo ""
+
+# Arduino
+echo "--- Arduino ---"
+echo -n "Input Arduino: "
+ls /dev/ttyACM0 2>/dev/null &amp;&amp; echo "OK" || echo "NOT FOUND"
+echo -n "Output Arduino: "
+ls /dev/ttyUSB_arduino_out 2>/dev/null &amp;&amp; echo "OK" || echo "NOT FOUND"
+echo ""
+
+echo "============================================"
+echo "  Diagnostic complete"
+echo "============================================"</code></pre>
+
+          <div class="box box-info">
+            <div class="box-title">Save as a script</div>
+            <p>
+              Save this as <code>/opt/bcm/scripts/diagnostics.sh</code> and make it
+              executable with <code>chmod +x</code>. Run with <code>sudo bash /opt/bcm/scripts/diagnostics.sh</code>
+              for a quick health check at any time.
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             COMMON ISSUES & FIXES
+             ============================================================ -->
+        <section>
+          <h2 id="common-issues">Common Issues &amp; Fixes</h2>
+
+          <p>
+            This table compiles the most common issues encountered across all build
+            stages, along with their symptoms, root causes, and fixes.
+          </p>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Issue</th>
+                  <th>Symptom</th>
+                  <th>Cause</th>
+                  <th>Fix</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>BCM won't start</td>
+                  <td><code>systemctl status bcm-headunit</code> shows failed</td>
+                  <td>Python venv broken or missing dependency</td>
+                  <td>Re-run <code>cd /opt/bcm &amp;&amp; source venv/bin/activate &amp;&amp; pip install -r requirements.txt</code></td>
+                </tr>
+                <tr>
+                  <td>No display output</td>
+                  <td>Both screens black after boot</td>
+                  <td>DP-to-HDMI adapters not connected or X11 not starting</td>
+                  <td>Check adapter connections; verify <code>xinit</code> runs in <code>.bash_profile</code>; check <code>/tmp/bcm-xinput.log</code></td>
+                </tr>
+                <tr>
+                  <td>Displays mirrored</td>
+                  <td>Both screens show same content</td>
+                  <td><code>xrandr</code> not configured for separate outputs</td>
+                  <td>Verify <code>.xinitrc</code> has <code>xrandr --output DP-1 --auto --output DP-2 --auto --right-of DP-1</code></td>
+                </tr>
+                <tr>
+                  <td>Touch offset</td>
+                  <td>Taps land in wrong position</td>
+                  <td>Touch device mapped to wrong display or not calibrated</td>
+                  <td>Run <code>xinput map-to-output &lt;touch-id&gt; DP-1</code>; check coordinate transform matrix</td>
+                </tr>
+                <tr>
+                  <td>No audio</td>
+                  <td>Dashboard loads but no sound from speakers</td>
+                  <td>USB DAC not default sink or PipeWire not running</td>
+                  <td><code>wpctl set-default &lt;dac-sink-id&gt;</code>; verify <code>systemctl --user status pipewire</code></td>
+                </tr>
+                <tr>
+                  <td>K-Line not detected</td>
+                  <td><code>/dev/ttyUSB_kline</code> missing</td>
+                  <td>udev rule not installed or adapter unplugged</td>
+                  <td>Check <code>/etc/udev/rules.d/99-bcm.rules</code>; run <code>udevadm trigger</code>; reconnect adapter</td>
+                </tr>
+                <tr>
+                  <td>No ECU data</td>
+                  <td>Dashboard shows 0 RPM, 0 km/h</td>
+                  <td>K-Line wiring issue or wrong baud rate</td>
+                  <td>Verify K-Line wiring (Tx/Rx/GND); check baud rate is 10400 in config</td>
+                </tr>
+                <tr>
+                  <td>WiFi AP not starting</td>
+                  <td><code>hostapd</code> fails immediately</td>
+                  <td>WiFi card does not support AP mode on 5 GHz</td>
+                  <td>Check <code>iw list | grep AP</code>; consider Fenvi AX200 upgrade; try 2.4 GHz as fallback</td>
+                </tr>
+                <tr>
+                  <td>BT not discoverable</td>
+                  <td>Phone cannot find BCM in BT scan</td>
+                  <td>Bluetooth service not running or adapter powered off</td>
+                  <td><code>sudo systemctl restart bluetooth</code>; <code>bluetoothctl power on</code>; <code>bluetoothctl discoverable on</code></td>
+                </tr>
+                <tr>
+                  <td>LTE no internet</td>
+                  <td>Huawei E3372 plugged in but no connectivity</td>
+                  <td>Modem not switching to HiLink mode or no SIM</td>
+                  <td>Check <code>lsusb</code> for Huawei device; verify SIM has data; check <code>ip route</code> for default gateway</td>
+                </tr>
+                <tr>
+                  <td>GPS no fix</td>
+                  <td>Position shows 0,0 or "No fix"</td>
+                  <td>GPS antenna obstructed or <code>gpsd</code> not running</td>
+                  <td>Ensure GPS puck has sky view; check <code>systemctl status gpsd</code>; verify <code>/dev/ttyACM*</code> or <code>/dev/ttyUSB*</code></td>
+                </tr>
+                <tr>
+                  <td>Suspend not working</td>
+                  <td>System does not enter S3 on power button</td>
+                  <td>BIOS S3 disabled or systemd sleep target masked</td>
+                  <td>Enable S3 in BIOS (Advanced &rarr; Power); <code>sudo systemctl unmask sleep.target suspend.target</code></td>
+                </tr>
+                <tr>
+                  <td>Resume fails</td>
+                  <td>System does not wake from S3 or hangs on resume</td>
+                  <td>USB wake not enabled or GPU driver issue</td>
+                  <td>Enable USB wake in BIOS; check <code>cat /proc/acpi/wakeup</code>; update Intel GPU firmware</td>
+                </tr>
+                <tr>
+                  <td>Splash not showing</td>
+                  <td>Black screen during boot, then dashboard appears</td>
+                  <td>Splash service failed or video file missing</td>
+                  <td>Check <code>journalctl -u bcm-splash-main</code>; verify splash video exists at configured path</td>
+                </tr>
+                <tr>
+                  <td>GRUB menu appears</td>
+                  <td>GRUB menu visible for a few seconds before boot</td>
+                  <td>GRUB timeout not set to 0</td>
+                  <td>Set <code>GRUB_TIMEOUT=0</code> in <code>/etc/default/grub</code>; run <code>sudo update-grub</code></td>
+                </tr>
+                <tr>
+                  <td>Kernel messages on screen</td>
+                  <td>Scrolling text visible during boot</td>
+                  <td>Quiet boot not configured</td>
+                  <td>Add <code>quiet loglevel=0 vt.global_cursor_default=0</code> to <code>GRUB_CMDLINE_LINUX_DEFAULT</code>; run <code>sudo update-grub</code></td>
+                </tr>
+                <tr>
+                  <td>Arduino not responding</td>
+                  <td>No sensor data or relay control</td>
+                  <td>Serial port name changed or Arduino disconnected</td>
+                  <td>Check <code>ls /dev/ttyACM* /dev/ttyUSB*</code>; verify udev rules; re-flash Arduino firmware if needed</td>
+                </tr>
+                <tr>
+                  <td>AA touch offset</td>
+                  <td>Taps on AA screen land in wrong position</td>
+                  <td>Canvas size mismatch between browser and Xvfb</td>
+                  <td>Check <code>display.multimedia.width/height</code> matches Xvfb resolution; verify xdotool coordinate mapping</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             LOG LOCATIONS
+             ============================================================ -->
+        <section>
+          <h2 id="log-locations">Log Locations</h2>
+
+          <p>
+            All BCM-related logs and their access commands, collected in one place
+            for quick reference during troubleshooting.
+          </p>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Log</th>
+                  <th>Command</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>BCM application</td>
+                  <td><code>/opt/bcm/logs/bcm.log</code></td>
+                </tr>
+                <tr>
+                  <td>Splash (main display)</td>
+                  <td><code>journalctl -u bcm-splash-main</code></td>
+                </tr>
+                <tr>
+                  <td>Splash (small display)</td>
+                  <td><code>journalctl -u bcm-splash-small</code></td>
+                </tr>
+                <tr>
+                  <td>Hostapd (WiFi AP)</td>
+                  <td><code>journalctl -u hostapd</code></td>
+                </tr>
+                <tr>
+                  <td>Bluetooth</td>
+                  <td><code>journalctl -u bluetooth</code></td>
+                </tr>
+                <tr>
+                  <td>Touch input</td>
+                  <td><code>/tmp/bcm-xinput.log</code></td>
+                </tr>
+                <tr>
+                  <td>Boot time analysis</td>
+                  <td><code>systemd-analyze blame</code></td>
+                </tr>
+                <tr>
+                  <td>Kernel messages</td>
+                  <td><code>dmesg</code></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="box box-info">
+            <div class="box-title">Live log monitoring</div>
+            <p>
+              For real-time log monitoring during debugging, use
+              <code>tail -f /opt/bcm/logs/bcm.log</code> or
+              <code>journalctl -u bcm-headunit -f</code> to stream log entries
+              as they are written.
+            </p>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             NEXT STEPS
+             ============================================================ -->
+        <section>
+          <h2 id="next-steps">Next Steps</h2>
+
+          <p>
+            Once all checklist items pass, the BCM build is production-ready.
+            Here are the recommended next steps:
+          </p>
+
+          <ul>
+            <li>
+              <strong>Return to the <a href="index.html">Overview</a></strong> for a
+              summary of the complete build and links to all documentation sections.
+            </li>
+            <li>
+              <strong>OTA updates:</strong> The BCM software can be updated in-place
+              by pulling the latest changes from the git repository and re-running
+              the setup script:
+              <pre><code>cd /opt/bcm
+git pull
+sudo bash setup-x86.sh</code></pre>
+              This preserves your <code>bcm_config.yaml</code> and only updates
+              the application code, templates, and systemd services.
+            </li>
+            <li>
+              <strong>Backup your configuration:</strong> Copy <code>/opt/bcm/config/bcm_config.yaml</code>
+              and <code>/etc/udev/rules.d/99-bcm.rules</code> to a USB drive or
+              cloud storage. These are the only files that contain your specific
+              hardware mappings.
+            </li>
+            <li>
+              <strong>Create a disk image:</strong> Once everything is verified, create
+              a full disk image with <code>dd</code> or <code>clonezilla</code> for
+              disaster recovery. A 256 GB NVMe image compresses to ~8&ndash;15 GB.
+            </li>
+          </ul>
+
+          <div class="box box-info">
+            <div class="box-title">Build complete</div>
+            <p>
+              Congratulations &mdash; your BCM v8.5 headunit on the Lenovo M910q is
+              now fully operational. The system provides a modern infotainment platform
+              with dual displays, full OBD-II diagnostics, Android Auto, 4.1 audio,
+              quad cameras, and intelligent power management &mdash; all running on
+              standard Debian with no custom kernel patches.
+            </p>
+          </div>
+        </section>
+
+      </article>
+
+      <!-- Page Navigation -->
+      <div class="page-nav">
+        <a href="11-android-auto.html">&larr; 11 &mdash; Android Auto</a>
+        <a href="index.html">Overview &rarr;</a>
+      </div>
+
+      <!-- Footer -->
+      <footer class="page-footer">
+        <span>BCM v8.5 &mdash; Alfa Romeo 156 Headunit</span>
+        <span>Lenovo M910q x86 Production Build</span>
+      </footer>
+
+    </div>
+  </div>
+
+  <!-- Sidebar Toggle Script -->
+  <script>
+    function toggleSidebar() {
+      document.querySelector('.sidebar').classList.toggle('open');
+      document.querySelector('.sidebar-overlay').classList.toggle('active');
+    }
+
+    document.querySelectorAll('.sidebar nav a').forEach(function(link) {
+      link.addEventListener('click', function() {
+        if (window.innerWidth < 768) {
+          document.querySelector('.sidebar').classList.remove('open');
+          document.querySelector('.sidebar-overlay').classList.remove('active');
+        }
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/docs/x86-production/assets/style.css
+++ b/docs/x86-production/assets/style.css
@@ -1,0 +1,763 @@
+/* ============================================================
+   BCM v8.5 x86 Production Documentation — Dark Theme
+   Alfa Romeo 156 Headunit Project
+   ============================================================ */
+
+/* --- Reset & Base ------------------------------------------ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  scroll-behavior: smooth;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+  background: #0f0f0f;
+  color: #e0e0e0;
+  line-height: 1.65;
+  min-height: 100vh;
+  display: flex;
+}
+
+/* --- Links ------------------------------------------------- */
+
+a {
+  color: #d4a017;
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+a:hover,
+a:focus {
+  color: #f0c040;
+  text-decoration: underline;
+}
+
+a:visited {
+  color: #b8891a;
+}
+
+/* ============================================================
+   Sidebar Navigation
+   ============================================================ */
+
+.sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 220px;
+  height: 100vh;
+  background: #141414;
+  border-right: 1px solid #2a2a2a;
+  overflow-y: auto;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.25s ease;
+}
+
+.sidebar-header {
+  padding: 1.25rem 1rem 0.75rem;
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.sidebar-header .logo-text {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #d4a017;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.sidebar-header .logo-sub {
+  font-size: 0.7rem;
+  color: #888;
+  margin-top: 0.15rem;
+}
+
+.sidebar nav {
+  flex: 1;
+  padding: 0.5rem 0;
+}
+
+.sidebar nav ul {
+  list-style: none;
+}
+
+.sidebar nav ul li a {
+  display: block;
+  padding: 0.45rem 1rem;
+  font-size: 0.82rem;
+  color: #ccc;
+  border-left: 3px solid transparent;
+  transition: background 0.15s ease, border-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.sidebar nav ul li a:hover {
+  background: #1e1e1e;
+  color: #f0c040;
+  text-decoration: none;
+}
+
+.sidebar nav ul li a.active {
+  background: #1a1a1a;
+  color: #d4a017;
+  border-left-color: #d4a017;
+  font-weight: 600;
+}
+
+.sidebar nav ul li a .nav-num {
+  display: inline-block;
+  width: 1.6em;
+  color: #666;
+  font-size: 0.75rem;
+  font-weight: 400;
+}
+
+/* --- Hamburger toggle (mobile) ----------------------------- */
+
+.hamburger {
+  display: none;
+  position: fixed;
+  top: 0.75rem;
+  left: 0.75rem;
+  z-index: 200;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 4px;
+  color: #d4a017;
+  font-size: 1.4rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+/* ============================================================
+   Main Content
+   ============================================================ */
+
+.content {
+  margin-left: 220px;
+  flex: 1;
+  min-width: 0;
+}
+
+.content-inner {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2.5rem 2rem 4rem;
+}
+
+/* --- Typography -------------------------------------------- */
+
+h1, h2, h3, h4, h5, h6 {
+  color: #f0f0f0;
+  line-height: 1.3;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+}
+
+h1 {
+  font-size: 1.85rem;
+  border-bottom: 2px solid #d4a017;
+  padding-bottom: 0.5rem;
+  margin-top: 0;
+}
+
+h1 .subtitle {
+  display: block;
+  font-size: 0.95rem;
+  font-weight: 400;
+  color: #aaa;
+  margin-top: 0.35rem;
+}
+
+h2 {
+  font-size: 1.4rem;
+  border-bottom: 1px solid #2a2a2a;
+  padding-bottom: 0.35rem;
+}
+
+h3 {
+  font-size: 1.15rem;
+  color: #d4a017;
+}
+
+h4 {
+  font-size: 1rem;
+  color: #ccc;
+}
+
+p {
+  margin-bottom: 1rem;
+}
+
+ul, ol {
+  margin-bottom: 1rem;
+  padding-left: 1.5rem;
+}
+
+li {
+  margin-bottom: 0.3rem;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid #2a2a2a;
+  margin: 2rem 0;
+}
+
+strong {
+  color: #f0f0f0;
+}
+
+/* ============================================================
+   Tables
+   ============================================================ */
+
+.table-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin-bottom: 1.5rem;
+  border: 1px solid #2a2a2a;
+  border-radius: 4px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+  min-width: 500px;
+}
+
+thead th {
+  background: #222;
+  color: #d4a017;
+  font-weight: 600;
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 2px solid #d4a017;
+  white-space: nowrap;
+}
+
+tbody td {
+  padding: 0.55rem 0.75rem;
+  border-bottom: 1px solid #222;
+  vertical-align: top;
+}
+
+tbody tr:nth-child(even) {
+  background: #161616;
+}
+
+tbody tr:nth-child(odd) {
+  background: #1a1a1a;
+}
+
+tbody tr:hover {
+  background: #252520;
+}
+
+/* Cost / total rows */
+tfoot td,
+tr.total-row td {
+  background: #1e1e10;
+  font-weight: 700;
+  border-top: 2px solid #d4a017;
+}
+
+/* ============================================================
+   Code Blocks
+   ============================================================ */
+
+code {
+  font-family: "JetBrains Mono", "Fira Code", "Cascadia Code",
+    "Consolas", "Liberation Mono", monospace;
+  font-size: 0.85em;
+  background: #1a1a1a;
+  color: #e8c66a;
+  padding: 0.15em 0.4em;
+  border-radius: 3px;
+}
+
+pre {
+  background: #111;
+  border: 1px solid #2a2a2a;
+  border-radius: 4px;
+  padding: 1rem 1.25rem;
+  overflow-x: auto;
+  margin-bottom: 1.5rem;
+  line-height: 1.5;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+  color: #c8c8c8;
+  font-size: 0.82rem;
+}
+
+/* --- ASCII diagram blocks ---------------------------------- */
+
+pre.diagram,
+pre.ascii-art {
+  background: #0c0c0c;
+  border-color: #333;
+  color: #a0d0a0;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  letter-spacing: 0.01em;
+}
+
+pre.diagram code,
+pre.ascii-art code {
+  color: #a0d0a0;
+}
+
+/* ============================================================
+   Cards
+   ============================================================ */
+
+.card {
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  border-radius: 6px;
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.card h3 {
+  margin-top: 0;
+}
+
+/* ============================================================
+   Phase / Stage Badges (colored pills)
+   ============================================================ */
+
+.badge {
+  display: inline-block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.2em 0.65em;
+  border-radius: 999px;
+  vertical-align: middle;
+}
+
+.badge-stage1 {
+  background: #2b4a1e;
+  color: #8fce6a;
+  border: 1px solid #3d6e2a;
+}
+
+.badge-stage2 {
+  background: #1e3a4a;
+  color: #6ab8ce;
+  border: 1px solid #2a5a6e;
+}
+
+.badge-stage3 {
+  background: #4a3a1e;
+  color: #cead6a;
+  border: 1px solid #6e5a2a;
+}
+
+.badge-stage4 {
+  background: #3a1e4a;
+  color: #ad6ace;
+  border: 1px solid #5a2a6e;
+}
+
+.badge-stage5 {
+  background: #4a1e1e;
+  color: #ce6a6a;
+  border: 1px solid #6e2a2a;
+}
+
+.badge-done {
+  background: #1e4a2b;
+  color: #6ace8f;
+  border: 1px solid #2a6e3d;
+}
+
+.badge-wip {
+  background: #4a421e;
+  color: #ced06a;
+  border: 1px solid #6e682a;
+}
+
+.badge-planned {
+  background: #333;
+  color: #aaa;
+  border: 1px solid #555;
+}
+
+/* ============================================================
+   Warning / Info Boxes
+   ============================================================ */
+
+.box {
+  border-radius: 4px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.9rem;
+}
+
+.box p:last-child {
+  margin-bottom: 0;
+}
+
+.box-title {
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+}
+
+.box-warning {
+  background: #2a2510;
+  border-left: 4px solid #d4a017;
+  color: #e8d8a0;
+}
+
+.box-warning .box-title {
+  color: #d4a017;
+}
+
+.box-info {
+  background: #101a2a;
+  border-left: 4px solid #4a90d0;
+  color: #a8c8e8;
+}
+
+.box-info .box-title {
+  color: #6aadde;
+}
+
+.box-danger {
+  background: #2a1010;
+  border-left: 4px solid #d04a4a;
+  color: #e8a8a8;
+}
+
+.box-danger .box-title {
+  color: #e06060;
+}
+
+.box-success {
+  background: #102a15;
+  border-left: 4px solid #4ad060;
+  color: #a8e8b8;
+}
+
+.box-success .box-title {
+  color: #60e080;
+}
+
+/* ============================================================
+   Phase Overview Grid (index page)
+   ============================================================ */
+
+.phase-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.phase-card {
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+  border-top: 3px solid #333;
+}
+
+.phase-card.stage1 { border-top-color: #6ace6a; }
+.phase-card.stage2 { border-top-color: #6ab8ce; }
+.phase-card.stage3 { border-top-color: #cead6a; }
+.phase-card.stage4 { border-top-color: #ad6ace; }
+.phase-card.stage5 { border-top-color: #ce6a6a; }
+
+.phase-card h4 {
+  margin-top: 0;
+  margin-bottom: 0.4rem;
+}
+
+.phase-card .phase-cost {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #d4a017;
+}
+
+/* ============================================================
+   Comparison Table Highlights
+   ============================================================ */
+
+.winner {
+  color: #6ace6a;
+  font-weight: 600;
+}
+
+.neutral {
+  color: #ccc;
+}
+
+.downside {
+  color: #ce6a6a;
+}
+
+/* ============================================================
+   Footer
+   ============================================================ */
+
+.page-footer {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #2a2a2a;
+  font-size: 0.8rem;
+  color: #666;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.page-footer a {
+  color: #888;
+}
+
+.page-footer a:hover {
+  color: #d4a017;
+}
+
+/* Page nav (prev / next) */
+.page-nav {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 2.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid #2a2a2a;
+}
+
+.page-nav a {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  border: 1px solid #333;
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+
+.page-nav a:hover {
+  background: #1e1e1e;
+  border-color: #d4a017;
+  text-decoration: none;
+}
+
+/* ============================================================
+   Responsive (< 768px) — Sidebar collapses to hamburger
+   ============================================================ */
+
+@media (max-width: 768px) {
+  .hamburger {
+    display: flex;
+  }
+
+  .sidebar {
+    transform: translateX(-100%);
+  }
+
+  .sidebar.open {
+    transform: translateX(0);
+  }
+
+  /* Overlay behind open sidebar */
+  .sidebar-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    z-index: 90;
+  }
+
+  .sidebar-overlay.active {
+    display: block;
+  }
+
+  .content {
+    margin-left: 0;
+  }
+
+  .content-inner {
+    padding: 3.5rem 1rem 2rem;
+  }
+
+  h1 {
+    font-size: 1.4rem;
+  }
+
+  h2 {
+    font-size: 1.2rem;
+  }
+
+  table {
+    font-size: 0.8rem;
+  }
+
+  thead th,
+  tbody td {
+    padding: 0.4rem 0.5rem;
+  }
+
+  .phase-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .page-footer {
+    flex-direction: column;
+    text-align: center;
+  }
+}
+
+/* ============================================================
+   Print-friendly styles
+   ============================================================ */
+
+@media print {
+  body {
+    background: #fff;
+    color: #111;
+    display: block;
+  }
+
+  .sidebar,
+  .hamburger,
+  .sidebar-overlay {
+    display: none !important;
+  }
+
+  .content {
+    margin-left: 0;
+  }
+
+  .content-inner {
+    max-width: 100%;
+    padding: 0;
+  }
+
+  a {
+    color: #333;
+    text-decoration: underline;
+  }
+
+  a[href]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.8em;
+    color: #666;
+  }
+
+  nav a[href]::after {
+    content: none;
+  }
+
+  h1 {
+    border-bottom-color: #333;
+    color: #000;
+  }
+
+  h2 {
+    border-bottom-color: #ccc;
+    color: #111;
+  }
+
+  h3 {
+    color: #333;
+  }
+
+  table {
+    min-width: 0;
+  }
+
+  thead th {
+    background: #eee;
+    color: #111;
+    border-bottom-color: #333;
+  }
+
+  tbody tr:nth-child(even) {
+    background: #f5f5f5;
+  }
+
+  tbody tr:nth-child(odd) {
+    background: #fff;
+  }
+
+  tbody td {
+    border-bottom-color: #ddd;
+  }
+
+  pre,
+  code {
+    background: #f0f0f0;
+    border-color: #ccc;
+    color: #111;
+  }
+
+  pre.diagram code,
+  pre.ascii-art code {
+    color: #333;
+  }
+
+  .box-warning {
+    background: #fffbe6;
+    border-left-color: #b8860b;
+    color: #333;
+  }
+
+  .box-info {
+    background: #e6f0ff;
+    border-left-color: #336699;
+    color: #333;
+  }
+
+  .box-danger {
+    background: #fff0f0;
+    border-left-color: #cc3333;
+    color: #333;
+  }
+
+  .card,
+  .phase-card {
+    background: #f8f8f8;
+    border-color: #ccc;
+    page-break-inside: avoid;
+  }
+
+  .badge {
+    border-color: #999;
+    color: #333;
+    background: #eee;
+  }
+
+  .page-nav {
+    display: none;
+  }
+
+  .page-footer {
+    border-top-color: #ccc;
+    color: #999;
+  }
+}

--- a/docs/x86-production/index.html
+++ b/docs/x86-production/index.html
@@ -1,0 +1,586 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BCM v8.5 — Lenovo M910q Production Build</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+
+  <!-- Hamburger toggle (mobile only) -->
+  <button class="hamburger" aria-label="Toggle navigation" onclick="toggleSidebar()">&#9776;</button>
+
+  <!-- Overlay behind sidebar on mobile -->
+  <div class="sidebar-overlay" onclick="toggleSidebar()"></div>
+
+  <!-- ======== Sidebar Navigation ======== -->
+  <aside class="sidebar">
+    <div class="sidebar-header">
+      <div class="logo-text">BCM v8.5</div>
+      <div class="logo-sub">Lenovo M910q &middot; Alfa 156</div>
+    </div>
+    <nav aria-label="Documentation pages">
+      <ul>
+        <li><a href="index.html" class="active"><span class="nav-num"></span>Overview</a></li>
+        <li><a href="01-bom.html"><span class="nav-num">01</span>Bill of Materials</a></li>
+        <li><a href="02-power.html"><span class="nav-num">02</span>Power Supply</a></li>
+        <li><a href="03-os-install.html"><span class="nav-num">03</span>OS Installation</a></li>
+        <li><a href="04-packages.html"><span class="nav-num">04</span>System Packages</a></li>
+        <li><a href="05-bcm-install.html"><span class="nav-num">05</span>BCM Installation</a></li>
+        <li><a href="06-systemd.html"><span class="nav-num">06</span>Systemd Services</a></li>
+        <li><a href="07-boot.html"><span class="nav-num">07</span>Boot &amp; Splash</a></li>
+        <li><a href="08-kiosk.html"><span class="nav-num">08</span>Kiosk Display</a></li>
+        <li><a href="09-suspend.html"><span class="nav-num">09</span>Suspend / Wake</a></li>
+        <li><a href="10-wifi.html"><span class="nav-num">10</span>WiFi &amp; Android Auto</a></li>
+        <li><a href="11-arduino.html"><span class="nav-num">11</span>Arduino Wiring</a></li>
+        <li><a href="12-verification.html"><span class="nav-num">12</span>Verification</a></li>
+      </ul>
+    </nav>
+  </aside>
+
+  <!-- ======== Main Content ======== -->
+  <div class="content">
+    <div class="content-inner">
+
+      <header>
+        <h1>
+          BCM v8.5 &mdash; Lenovo M910q Production Build
+          <span class="subtitle">Complete guide for deploying BCM headunit in Alfa Romeo 156</span>
+        </h1>
+      </header>
+
+      <!-- ---- Project Overview ---- -->
+      <article>
+        <section>
+          <h2>Project Overview</h2>
+
+          <p>
+            <strong>BCM</strong> (Body Computer Module) is a custom head unit that replaces the
+            original Alfa Romeo 156 stereo and instrument cluster with a modern, Linux-based
+            infotainment and vehicle management system. It provides a dual-screen dashboard
+            (7" or 10" touchscreen + 4.3" status display), full body-computer functions
+            (fuel, temperatures, doors, OBD-II diagnostics), a 4.1 audio system with
+            10-band EQ, quad-camera DVR with auto-switching, Android Auto, GPS tracking,
+            and an integrated alarm/central-lock system.
+          </p>
+
+          <p>
+            The <strong>Lenovo ThinkCentre M910q Tiny</strong> is the recommended x86
+            production platform. It replaces the original Orange Pi 5 Pro SBC with a
+            full x86_64 mini-PC that fits inside the car dashboard (1-litre form factor).
+            The M910q offers dramatically more processing power, native VAAPI hardware
+            decode, NVMe storage, dual DisplayPort outputs, and runs standard Debian
+            without ARM kernel patching. Used units are widely available at competitive
+            prices, making this the most practical production build.
+          </p>
+
+          <div class="box box-info">
+            <div class="box-title">Why x86?</div>
+            <p>
+              An x86 mini-PC like the M910q removes every ARM-specific pain point:
+              no custom kernel builds, no display driver patches, no WiFi firmware
+              issues. Debian runs unmodified, VAAPI hardware decode works out of the
+              box, and suspend/resume (S3) is rock-solid. The only trade-off is
+              higher power draw (~15W idle vs ~5W for OPi), addressed by the 12V
+              AGM battery buffer described in the power supply section.
+            </p>
+          </div>
+        </section>
+
+        <!-- ---- Hardware Summary ---- -->
+        <section>
+          <h2>Hardware Summary</h2>
+
+          <h3>Lenovo M910q Tiny Specifications</h3>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Component</th>
+                  <th>Specification</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>CPU</td>
+                  <td>Intel Core i5-6400T (4C/4T, 2.2&ndash;2.8 GHz, Skylake)</td>
+                </tr>
+                <tr>
+                  <td>GPU</td>
+                  <td>Intel HD 530 &mdash; VAAPI hardware decode (H.264, H.265)</td>
+                </tr>
+                <tr>
+                  <td>RAM</td>
+                  <td>8 GB DDR4-2400 SO-DIMM</td>
+                </tr>
+                <tr>
+                  <td>Storage</td>
+                  <td>256 GB NVMe SSD (M.2 2242/2280)</td>
+                </tr>
+                <tr>
+                  <td>WiFi / BT</td>
+                  <td>Intel 8265 &mdash; 802.11ac 2&times;2 + BT 4.2 (built-in M.2)</td>
+                </tr>
+                <tr>
+                  <td>Display Outputs</td>
+                  <td>2&times; mini-DisplayPort (DP &rarr; HDMI adapters for car displays)</td>
+                </tr>
+                <tr>
+                  <td>USB</td>
+                  <td>6&times; USB 3.0 + 1&times; USB-C</td>
+                </tr>
+                <tr>
+                  <td>Power</td>
+                  <td>65 W external, 20 V barrel jack (12 V &rarr; 20 V step-up in car)</td>
+                </tr>
+                <tr>
+                  <td>Form Factor</td>
+                  <td>1-litre Tiny &mdash; 179 &times; 183 &times; 36 mm, fits behind dash</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>Key Peripherals</h3>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Device</th>
+                  <th>Model / Spec</th>
+                  <th>Role</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>WiFi upgrade (optional)</td>
+                  <td>Fenvi FU-AX1800 (Intel AX200, M.2 E-key)</td>
+                  <td>WiFi 6 + BT 5.0 for faster Android Auto wireless; replaces Intel 8265 if 5 GHz AP is unstable</td>
+                </tr>
+                <tr>
+                  <td>Main display</td>
+                  <td>7" IPS 1024&times;600 HDMI + USB touch (or 10" 1280&times;800)</td>
+                  <td>Primary BCM dashboard (port 5002)</td>
+                </tr>
+                <tr>
+                  <td>Small display</td>
+                  <td>4.3" TFT 800&times;480 HDMI (no touch)</td>
+                  <td>Status dashboard (port 5003), camera feeds</td>
+                </tr>
+                <tr>
+                  <td>USB DAC</td>
+                  <td>ES9038Q2M 32-bit module</td>
+                  <td>Hi-fi audio output &rarr; RCA &rarr; amplifiers</td>
+                </tr>
+                <tr>
+                  <td>Amplifiers</td>
+                  <td>TDA7388 (4&times;45 W) + TDA2050 (1&times;40 W sub)</td>
+                  <td>4.1 speaker system</td>
+                </tr>
+                <tr>
+                  <td>Camera set</td>
+                  <td>4&times; AHD 720p + 4-ch USB grabber</td>
+                  <td>Front / rear / left / right with auto-switching</td>
+                </tr>
+                <tr>
+                  <td>Input Arduino</td>
+                  <td>Pro Micro (ATmega32U4), 115200 baud</td>
+                  <td>SWC buttons, sensors, doors, ignition, parking</td>
+                </tr>
+                <tr>
+                  <td>Output Arduino</td>
+                  <td>Nano (ATmega328P), 9600 baud JSON</td>
+                  <td>Relays, central lock, lights, wipers, horn</td>
+                </tr>
+                <tr>
+                  <td>GPS</td>
+                  <td>u-blox NEO-M8N USB</td>
+                  <td>Position, speed, heading</td>
+                </tr>
+                <tr>
+                  <td>LTE modem</td>
+                  <td>Huawei E3372 HiLink</td>
+                  <td>Mobile data for weather, travel planner</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <!-- ---- Build Phases ---- -->
+        <section>
+          <h2>Build Phases Overview</h2>
+
+          <p>
+            The build is divided into five stages. Each stage is independently
+            functional &mdash; you can drive with Stage 1 alone and add the rest
+            over time. Prices are in <strong>PLN</strong> (Q1 2026 estimates,
+            Polish retailers). The M910q is typically 200&ndash;400 PLN used,
+            making Stage 1 significantly cheaper than the OPi 5 Pro build.
+          </p>
+
+          <div class="phase-grid">
+
+            <div class="phase-card stage1">
+              <h4><span class="badge badge-stage1">Stage 1</span> Core System</h4>
+              <p>M910q + dual displays + audio (DAC + TDA7388) + K-Line OBD-II + power supply + battery buffer</p>
+              <div class="phase-cost">~650 &ndash; 1 100 PLN</div>
+            </div>
+
+            <div class="phase-card stage2">
+              <h4><span class="badge badge-stage2">Stage 2</span> Cameras + Sensors</h4>
+              <p>4-way AHD camera set + USB grabber + parking sensors + DS18B20 + dashcam SSD</p>
+              <div class="phase-cost">~450 &ndash; 800 PLN</div>
+            </div>
+
+            <div class="phase-card stage3">
+              <h4><span class="badge badge-stage3">Stage 3</span> Input + Connectivity</h4>
+              <p>SWC dual-pod (24 buttons) + rotary encoder + USB mic + GPS + LTE modem</p>
+              <div class="phase-cost">~260 &ndash; 420 PLN</div>
+            </div>
+
+            <div class="phase-card stage4">
+              <h4><span class="badge badge-stage4">Stage 4</span> Audio Upgrades</h4>
+              <p>TDA2050 subwoofer amp + rain sensor + wiper relay</p>
+              <div class="phase-cost">~63 &ndash; 102 PLN</div>
+            </div>
+
+            <div class="phase-card stage5">
+              <h4><span class="badge badge-stage5">Stage 5</span> Security</h4>
+              <p>Central lock + 433 MHz RF + alarm (siren, PIR, shock, accelerometer) + backup battery</p>
+              <div class="phase-cost">~180 &ndash; 285 PLN</div>
+            </div>
+
+          </div>
+
+          <h3>Cost Summary</h3>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Stage</th>
+                  <th>What you get</th>
+                  <th>Min (PLN)</th>
+                  <th>Max (PLN)</th>
+                  <th>Cumulative</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><span class="badge badge-stage1">1</span></td>
+                  <td>Dashboard + Audio + OBD + dual displays + power</td>
+                  <td>650</td>
+                  <td>1 100</td>
+                  <td>650 &ndash; 1 100</td>
+                </tr>
+                <tr>
+                  <td><span class="badge badge-stage2">2</span></td>
+                  <td>4-way cameras, parking sensors, temperature, dashcam</td>
+                  <td>450</td>
+                  <td>800</td>
+                  <td>1 100 &ndash; 1 900</td>
+                </tr>
+                <tr>
+                  <td><span class="badge badge-stage3">3</span></td>
+                  <td>SWC dual-pod, GPS, LTE modem, microphone</td>
+                  <td>260</td>
+                  <td>420</td>
+                  <td>1 360 &ndash; 2 320</td>
+                </tr>
+                <tr>
+                  <td><span class="badge badge-stage4">4</span></td>
+                  <td>Subwoofer amp, rain sensor, wiper relay</td>
+                  <td>63</td>
+                  <td>102</td>
+                  <td>1 423 &ndash; 2 422</td>
+                </tr>
+                <tr>
+                  <td><span class="badge badge-stage5">5</span></td>
+                  <td>Alarm, central lock, battery backup, RF remote</td>
+                  <td>180</td>
+                  <td>285</td>
+                  <td>1 603 &ndash; 2 707</td>
+                </tr>
+              </tbody>
+              <tfoot>
+                <tr>
+                  <td colspan="2"><strong>Total (all stages)</strong></td>
+                  <td><strong>1 603</strong></td>
+                  <td><strong>2 707</strong></td>
+                  <td><strong>~1 600 &ndash; 2 700 PLN</strong></td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+
+          <div class="box box-warning">
+            <div class="box-title">Not included in estimates</div>
+            <p>
+              Car speakers (reuse existing or ~200&ndash;400 PLN), subwoofer driver
+              (~100&ndash;200 PLN), 12 V automotive wiring and connectors (~50&ndash;100 PLN),
+              DIN bracket or 3D-printed mount (~20&ndash;50 PLN), SIM card with data plan
+              (for LTE), and labour / installation time.
+            </p>
+          </div>
+        </section>
+
+        <!-- ---- Platform Comparison ---- -->
+        <section>
+          <h2>Platform Comparison</h2>
+
+          <p>
+            Three platforms have been tested for the BCM build. The M910q is the
+            recommended production platform for its reliability, performance, and
+            ease of setup. The OPi 5 Pro remains the primary ARM option. The OPi PC
+            is a bench-test rig only.
+          </p>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Feature</th>
+                  <th>Lenovo M910q (x86)</th>
+                  <th>OPi 5 Pro 4GB (ARM)</th>
+                  <th>OPi PC 1.2 (ARM)</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>SoC / CPU</td>
+                  <td class="winner">i5-6400T (4C/4T, 2.8 GHz)</td>
+                  <td>RK3588S (4+4 big.LITTLE)</td>
+                  <td class="downside">Allwinner H3 (4C, 1.3 GHz)</td>
+                </tr>
+                <tr>
+                  <td>RAM</td>
+                  <td class="winner">8 GB DDR4</td>
+                  <td>4 GB LPDDR4X</td>
+                  <td class="downside">1 GB DDR3</td>
+                </tr>
+                <tr>
+                  <td>Storage</td>
+                  <td class="winner">256 GB NVMe SSD</td>
+                  <td>64 GB microSD / NVMe</td>
+                  <td class="downside">16 GB microSD</td>
+                </tr>
+                <tr>
+                  <td>Display outputs</td>
+                  <td>2&times; DisplayPort (adapters needed)</td>
+                  <td class="winner">HDMI 2.1 + HDMI 2.0 (native)</td>
+                  <td class="downside">1&times; HDMI</td>
+                </tr>
+                <tr>
+                  <td>HW video decode</td>
+                  <td class="winner">VAAPI (Intel HD 530)</td>
+                  <td>rkmpp (RK3588 VPU)</td>
+                  <td class="downside">cedrus (limited)</td>
+                </tr>
+                <tr>
+                  <td>WiFi / BT</td>
+                  <td>Intel 8265 ac + BT 4.2 (upgradeable to AX200)</td>
+                  <td class="winner">WiFi 6 + BT 5.0 built-in</td>
+                  <td class="downside">None (USB dongles)</td>
+                </tr>
+                <tr>
+                  <td>USB ports</td>
+                  <td class="winner">6&times; USB 3.0 + 1&times; USB-C</td>
+                  <td>2&times; USB 3.0 + 1&times; USB 2.0</td>
+                  <td class="downside">3&times; USB 2.0</td>
+                </tr>
+                <tr>
+                  <td>GPIO</td>
+                  <td class="downside">None (USB Arduinos required)</td>
+                  <td>40-pin header (26 GPIO)</td>
+                  <td>40-pin header (28 GPIO)</td>
+                </tr>
+                <tr>
+                  <td>Suspend (S3)</td>
+                  <td class="winner">Native ACPI S3 (~0.2 A draw)</td>
+                  <td class="neutral">Software suspend (variable)</td>
+                  <td class="downside">Not reliable</td>
+                </tr>
+                <tr>
+                  <td>Power draw (idle)</td>
+                  <td class="downside">~15 W</td>
+                  <td class="winner">~5 W</td>
+                  <td class="winner">~3 W</td>
+                </tr>
+                <tr>
+                  <td>Power supply</td>
+                  <td>12 V &rarr; 20 V step-up + AGM buffer</td>
+                  <td>12 V &rarr; 5.1 V step-down</td>
+                  <td>12 V &rarr; 5 V step-down</td>
+                </tr>
+                <tr>
+                  <td>OS</td>
+                  <td class="winner">Debian 13 (standard amd64)</td>
+                  <td>Debian 13 / Armbian (arm64)</td>
+                  <td class="downside">Armbian (armhf, custom kernel)</td>
+                </tr>
+                <tr>
+                  <td>Cold boot time</td>
+                  <td class="winner">~12 s (splash at 4 s)</td>
+                  <td>~18 s</td>
+                  <td class="downside">~35 s</td>
+                </tr>
+                <tr>
+                  <td>SBC cost (used/new)</td>
+                  <td class="winner">200&ndash;400 PLN (used)</td>
+                  <td>350&ndash;450 PLN (new)</td>
+                  <td class="winner">80&ndash;120 PLN (used)</td>
+                </tr>
+                <tr>
+                  <td>Total build cost</td>
+                  <td class="winner">~1 600 &ndash; 2 700 PLN</td>
+                  <td>~1 950 &ndash; 3 165 PLN</td>
+                  <td>~942 &ndash; 1 592 PLN (bench only)</td>
+                </tr>
+                <tr>
+                  <td>Form factor</td>
+                  <td>179 &times; 183 &times; 36 mm (1 L)</td>
+                  <td class="winner">100 &times; 62 &times; 18 mm</td>
+                  <td>85 &times; 55 &times; 20 mm</td>
+                </tr>
+                <tr>
+                  <td>Production status</td>
+                  <td class="winner">Recommended</td>
+                  <td>Alternative (ARM)</td>
+                  <td class="downside">Bench test only</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="box box-info">
+            <div class="box-title">M910q advantages over OPi 5 Pro</div>
+            <p>
+              Standard Debian with no kernel patching. Native ACPI suspend/resume
+              (3-second wake). VAAPI hardware decode with no driver issues.
+              256 GB NVMe eliminates microSD reliability concerns. Six USB 3.0
+              ports remove the need for a hub in most configurations. Used units
+              at 200&ndash;400 PLN make it price-competitive with the OPi 5 Pro
+              at 350&ndash;450 PLN new.
+            </p>
+          </div>
+        </section>
+
+        <!-- ---- Documentation Map ---- -->
+        <section>
+          <h2>Documentation Map</h2>
+
+          <p>Follow the pages in order. Each section builds on the previous one.</p>
+
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Page</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>01</td>
+                  <td><a href="01-bom.html">Bill of Materials</a></td>
+                  <td>Complete parts list with prices, sourcing, and stage breakdown</td>
+                </tr>
+                <tr>
+                  <td>02</td>
+                  <td><a href="02-power.html">Power Supply</a></td>
+                  <td>12 V &rarr; 20 V converter, AGM battery buffer, LVD cutoff wiring</td>
+                </tr>
+                <tr>
+                  <td>03</td>
+                  <td><a href="03-os-install.html">OS Installation</a></td>
+                  <td>Debian 13 (Trixie) minimal install, partitioning, firmware</td>
+                </tr>
+                <tr>
+                  <td>04</td>
+                  <td><a href="04-packages.html">System Packages</a></td>
+                  <td>apt packages: X11, Chromium, VAAPI, PipeWire, ffmpeg, etc.</td>
+                </tr>
+                <tr>
+                  <td>05</td>
+                  <td><a href="05-bcm-install.html">BCM Installation</a></td>
+                  <td>Clone repo, Python venv, pip dependencies, first test</td>
+                </tr>
+                <tr>
+                  <td>06</td>
+                  <td><a href="06-systemd.html">Systemd Services</a></td>
+                  <td>Auto-start services, ignition watcher, power button handler</td>
+                </tr>
+                <tr>
+                  <td>07</td>
+                  <td><a href="07-boot.html">Boot &amp; Splash</a></td>
+                  <td>BIOS tuning, GRUB silencing, splash video on dual DRM outputs</td>
+                </tr>
+                <tr>
+                  <td>08</td>
+                  <td><a href="08-kiosk.html">Kiosk Display</a></td>
+                  <td>Dual-display xinitrc, autologin, Chromium kiosk, touch mapping</td>
+                </tr>
+                <tr>
+                  <td>09</td>
+                  <td><a href="09-suspend.html">Suspend / Wake</a></td>
+                  <td>ACPI S3 lifecycle, ignition-based suspend, 3-second resume</td>
+                </tr>
+                <tr>
+                  <td>10</td>
+                  <td><a href="10-wifi.html">WiFi &amp; Android Auto</a></td>
+                  <td>5 GHz AP with hostapd, wireless AA, optional openauto build</td>
+                </tr>
+                <tr>
+                  <td>11</td>
+                  <td><a href="11-arduino.html">Arduino Wiring</a></td>
+                  <td>Input/output Arduino pin maps, serial protocol, optoisolators</td>
+                </tr>
+                <tr>
+                  <td>12</td>
+                  <td><a href="12-verification.html">Verification</a></td>
+                  <td>Full checklist: displays, audio, cameras, suspend, boot time</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+      </article>
+
+      <!-- ---- Page Navigation ---- -->
+      <div class="page-nav">
+        <span></span>
+        <a href="01-bom.html">01 &mdash; Bill of Materials &rarr;</a>
+      </div>
+
+      <!-- ---- Footer ---- -->
+      <footer class="page-footer">
+        <span>BCM v8.5 &mdash; Alfa Romeo 156 Headunit</span>
+        <span>Lenovo M910q x86 Production Build</span>
+      </footer>
+
+    </div>
+  </div>
+
+  <!-- ======== Sidebar Toggle Script ======== -->
+  <script>
+    function toggleSidebar() {
+      document.querySelector('.sidebar').classList.toggle('open');
+      document.querySelector('.sidebar-overlay').classList.toggle('active');
+    }
+
+    // Close sidebar when a nav link is clicked (mobile)
+    document.querySelectorAll('.sidebar nav a').forEach(function(link) {
+      link.addEventListener('click', function() {
+        if (window.innerWidth < 768) {
+          document.querySelector('.sidebar').classList.remove('open');
+          document.querySelector('.sidebar-overlay').classList.remove('active');
+        }
+      });
+    });
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **Full x86 production documentation** — 12-page HTML guide (`docs/x86-production/`) covering BOM, assembly, OS install, software, K-Line/OBD, Arduino, sensors, WiFi/BT (Fenvi FU-AX1800), display/touch, power/suspend, Android Auto, and verification checklist. 9,705 lines total with dark theme CSS, responsive tables, sidebar navigation.

- **All-in-one setup script** (`config/scripts/setup-x86.sh`) — 14-phase automated installer: cleanup → packages → Python venv → vendor assets → splash videos → systemd services → kiosk → suspend → WiFi AP → LTE modem → GRUB → permissions → BT → test. Idempotent, safe to re-run.

- **Hardware fixes**: splash DRM wait loop (i915 driver timing), xrandr→DRM connector name translation (HDMI-1→HDMI-A-1), touch via xinput map-to-output, WiFi 2.4GHz fallback (Intel 8265 blocks 5GHz), BT retry loop + discoverable persistence, USB wake disable for suspend, LTE modem unbind before S3.

- **Production mode**: `system.simulation: false` config key disables demo data generators (fake OBD/BT/GPS) while keeping MockGPIO for x86 (no real GPIO). On-screen keyboard hide button added.

- **Cleanup script** (`config/scripts/cleanup-x86.sh`) for resetting all BCM configs before fresh install.

## Test plan

- [ ] Run `sudo bash config/scripts/setup-x86.sh` on clean Debian 13 M910q — completes all 14 steps
- [ ] Reboot → splash plays on 7" display → dashboard loads
- [ ] Touch accurate on main display (check `/tmp/bcm-xinput.log`)
- [ ] WiFi AP broadcasts ALFA_AA, phone gets DHCP IP
- [ ] `bluetoothctl show` shows Powered/Discoverable/Pairable = yes
- [ ] Power button → S3 suspend, stays sleeping until next press
- [ ] Open `docs/x86-production/index.html` — all 12 page links work
- [ ] K-Line adapter + ECU communication verified with engine running
- [ ] Android Auto connects via USB, touch forwarding works

https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf

---
_Generated by [Claude Code](https://claude.ai/code/session_01YWGHpcvFSF9MVA5zQNsKZf)_