### PR TITLE
Add Nano output-controller firmware + Arduino setup guide (x86 backlight PWM)

### DIFF
--- a/arduino/output_controller/output_controller.ino
+++ b/arduino/output_controller/output_controller.ino
@@ -1,0 +1,376 @@
+/*
+ * BCM v8.5 — Output Controller (Arduino Nano, ATmega328P)
+ *
+ * Receives JSON commands over USB-serial from the M910q headunit and drives
+ * the vehicle output devices: relays, lights, horn, wipers, and the two
+ * LCD backlight PWM lines.
+ *
+ * USB: CH340 USB-UART bridge → /dev/ttyUSB0 on the host
+ * Baud: 9600
+ *
+ * --- Pin map (revised v8.5 — adds backlight PWM on D9/D10) ---
+ *
+ *   Relays / digital outputs (active-LOW for opto-isolated relay modules):
+ *     D2  Lock          (pulse 200 ms)
+ *     D3  Unlock        (pulse 200 ms)
+ *     D4  Trunk         (pulse 200 ms)
+ *     D5  Window up     (hold while active)
+ *     D6  Window down   (hold while active)
+ *     D7  Headlights    (on/off + optional auto-off timeout)
+ *     D8  Left blinker  (toggle on/off)
+ *     D11 Horn          (hold while active)
+ *     A0  Right blinker (toggle on/off)    ← relocated from D9 (freed for PWM)
+ *     A1  Wipers        (pulse, configurable duration) ← relocated from D10
+ *
+ *   PWM outputs (display backlight, drives M_PWM gate on Waveshare 7" LCD):
+ *     D9  Backlight LARGE (7" main display)     — Timer1, ~490 Hz PWM
+ *     D10 Backlight SMALL (4.3" dashboard)      — Timer1, ~490 Hz PWM
+ *
+ *   Optional inputs:
+ *     D12 RF receiver data (RXB6 433 MHz)       — disabled by default,
+ *                                                 see ENABLE_RF below
+ *
+ *   Status LED:
+ *     D13 Built-in LED — heartbeat + command-received flash
+ *
+ * --- JSON command protocol (one object per line, terminated by '\n') ---
+ *
+ *   {"cmd":"lock"}                                  D2 pulse 200 ms
+ *   {"cmd":"unlock"}                                D3 pulse 200 ms
+ *   {"cmd":"trunk"}                                 D4 pulse 200 ms
+ *   {"cmd":"window","dir":"up","state":1}           D5 hold while state=1
+ *   {"cmd":"window","dir":"down","state":1}         D6 hold while state=1
+ *   {"cmd":"lights","state":1,"timeout":60}         D7 on, auto-off in N s
+ *   {"cmd":"lights","state":0}                      D7 off
+ *   {"cmd":"blinker","side":"left","state":1}       D8 on/off
+ *   {"cmd":"blinker","side":"right","state":1}      A0 on/off
+ *   {"cmd":"horn","state":1}                        D11 hold while state=1
+ *   {"cmd":"wipers","duration":5}                   A1 active for 5 s
+ *   {"cmd":"blink","count":2}                       D8+A0 alternating blinks
+ *   {"cmd":"backlight","display":"large","brightness":80}
+ *                                                   D9 PWM duty (0..100 %)
+ *   {"cmd":"backlight","display":"small","brightness":40}
+ *                                                   D10 PWM duty (0..100 %)
+ *   {"cmd":"learn"}                                 Enter 10 s RF learn mode
+ *   {"cmd":"ping"}                                  → {"event":"pong"}
+ *
+ * --- JSON events emitted back to host ---
+ *
+ *   {"event":"locked"}            after lock pulse
+ *   {"event":"unlocked"}          after unlock pulse
+ *   {"event":"trunk"}             after trunk pulse
+ *   {"event":"rf_learned","code":12345678}
+ *   {"event":"rf_received","code":12345678}
+ *   {"event":"pong"}              health-check reply
+ *   {"event":"error","msg":"..."} unrecognised command or parse error
+ *
+ * --- Libraries required (install via Arduino IDE → Library Manager) ---
+ *
+ *   ArduinoJson  by Benoit Blanchon  (v7.x)
+ *   RCSwitch     by sui77            (only if ENABLE_RF = 1)
+ *
+ * See docs/ARDUINO_SETUP_GUIDE.md for the step-by-step beginner manual.
+ */
+
+#include <ArduinoJson.h>
+
+// --- Feature toggles ---------------------------------------------------------
+#define ENABLE_RF 0   // 1 → enable 433 MHz keyfob receiver on D12
+                      // requires RCSwitch library and a wired RXB6 module.
+                      // Disabled by default for the first beginner build.
+
+#if ENABLE_RF
+  #include <RCSwitch.h>
+  RCSwitch rfReceiver = RCSwitch();
+  bool rfLearnMode = false;
+  unsigned long rfLearnUntil = 0;
+#endif
+
+// --- Pin definitions ---------------------------------------------------------
+#define PIN_LOCK         2
+#define PIN_UNLOCK       3
+#define PIN_TRUNK        4
+#define PIN_WINDOW_UP    5
+#define PIN_WINDOW_DOWN  6
+#define PIN_HEADLIGHTS   7
+#define PIN_BLINKER_L    8
+#define PIN_BACKLIGHT_L  9    // 7" main display PWM
+#define PIN_BACKLIGHT_S  10   // 4.3" small dashboard PWM
+#define PIN_HORN         11
+#define PIN_RF_RX        12
+#define PIN_LED          13
+#define PIN_BLINKER_R    A0   // relocated from D9
+#define PIN_WIPERS       A1   // relocated from D10
+
+// --- Behaviour constants -----------------------------------------------------
+#define PULSE_MS         200      // lock / unlock / trunk pulse length
+#define BLINK_INTERVAL   400      // ms between blink toggles
+#define DEFAULT_LIGHTS_TIMEOUT 0  // 0 = no auto-off
+
+// Relay polarity: most cheap Chinese opto-isolated modules are ACTIVE-LOW
+// (the relay closes when the input is pulled to GND). Set RELAY_ACTIVE to LOW
+// for those, or HIGH if your module is the rarer active-high variant.
+#define RELAY_ACTIVE   LOW
+#define RELAY_INACTIVE HIGH
+
+// --- State -------------------------------------------------------------------
+// Non-blocking pulse timers (millis at which pin should return to INACTIVE)
+unsigned long lockOffAt    = 0;
+unsigned long unlockOffAt  = 0;
+unsigned long trunkOffAt   = 0;
+unsigned long wipersOffAt  = 0;
+unsigned long lightsOffAt  = 0;   // 0 = lights are off or have no timeout
+
+bool blinkerLeftOn  = false;
+bool blinkerRightOn = false;
+unsigned long lastBlinkToggle = 0;
+bool blinkerLeftPhase  = false;
+bool blinkerRightPhase = false;
+
+// Heartbeat LED
+unsigned long lastHeartbeat = 0;
+bool ledState = false;
+
+// Serial line buffer
+char lineBuf[160];
+uint8_t lineLen = 0;
+
+// Backlight current duty (0..100 %), reported back on demand
+uint8_t blDutyLarge = 80;
+uint8_t blDutySmall = 80;
+
+// --- Forward declarations ----------------------------------------------------
+void handleCommand(const JsonDocument& doc);
+void emitEvent(const char* name);
+void emitErrorMsg(const char* msg);
+void pulseRelay(int pin, unsigned long& offAt);
+void setRelay(int pin, bool active);
+void setBacklight(const char* display, int brightness);
+
+// =============================================================================
+void setup() {
+  // Outputs — all relays start INACTIVE
+  pinMode(PIN_LOCK,        OUTPUT); digitalWrite(PIN_LOCK,        RELAY_INACTIVE);
+  pinMode(PIN_UNLOCK,      OUTPUT); digitalWrite(PIN_UNLOCK,      RELAY_INACTIVE);
+  pinMode(PIN_TRUNK,       OUTPUT); digitalWrite(PIN_TRUNK,       RELAY_INACTIVE);
+  pinMode(PIN_WINDOW_UP,   OUTPUT); digitalWrite(PIN_WINDOW_UP,   RELAY_INACTIVE);
+  pinMode(PIN_WINDOW_DOWN, OUTPUT); digitalWrite(PIN_WINDOW_DOWN, RELAY_INACTIVE);
+  pinMode(PIN_HEADLIGHTS,  OUTPUT); digitalWrite(PIN_HEADLIGHTS,  RELAY_INACTIVE);
+  pinMode(PIN_BLINKER_L,   OUTPUT); digitalWrite(PIN_BLINKER_L,   RELAY_INACTIVE);
+  pinMode(PIN_BLINKER_R,   OUTPUT); digitalWrite(PIN_BLINKER_R,   RELAY_INACTIVE);
+  pinMode(PIN_HORN,        OUTPUT); digitalWrite(PIN_HORN,        RELAY_INACTIVE);
+  pinMode(PIN_WIPERS,      OUTPUT); digitalWrite(PIN_WIPERS,      RELAY_INACTIVE);
+
+  // Backlight PWM — start at 80 % so a freshly-flashed Nano lights the screens
+  pinMode(PIN_BACKLIGHT_L, OUTPUT);
+  pinMode(PIN_BACKLIGHT_S, OUTPUT);
+  analogWrite(PIN_BACKLIGHT_L, (blDutyLarge * 255L) / 100);
+  analogWrite(PIN_BACKLIGHT_S, (blDutySmall * 255L) / 100);
+
+  pinMode(PIN_LED, OUTPUT);
+
+#if ENABLE_RF
+  rfReceiver.enableReceive(digitalPinToInterrupt(PIN_RF_RX));
+#endif
+
+  Serial.begin(9600);
+  // Give the CH340 host driver a moment before printing the banner
+  delay(200);
+  Serial.println(F("{\"event\":\"ready\",\"fw\":\"bcm-output-v8.5\"}"));
+}
+
+// =============================================================================
+void loop() {
+  unsigned long now = millis();
+
+  // -------- 1. Read incoming serial line-by-line --------
+  while (Serial.available()) {
+    char c = Serial.read();
+    if (c == '\r') continue;
+    if (c == '\n') {
+      if (lineLen > 0) {
+        lineBuf[lineLen] = '\0';
+        JsonDocument doc;
+        DeserializationError err = deserializeJson(doc, lineBuf);
+        if (err) {
+          emitErrorMsg(err.c_str());
+        } else {
+          digitalWrite(PIN_LED, HIGH);   // brief activity flash
+          handleCommand(doc);
+        }
+        lineLen = 0;
+      }
+    } else if (lineLen < sizeof(lineBuf) - 1) {
+      lineBuf[lineLen++] = c;
+    } else {
+      // overflow — discard buffer
+      lineLen = 0;
+      emitErrorMsg("line too long");
+    }
+  }
+
+  // -------- 2. Service non-blocking timed outputs --------
+  if (lockOffAt   && now >= lockOffAt)   { setRelay(PIN_LOCK,   false); lockOffAt   = 0; emitEvent("locked");   }
+  if (unlockOffAt && now >= unlockOffAt) { setRelay(PIN_UNLOCK, false); unlockOffAt = 0; emitEvent("unlocked"); }
+  if (trunkOffAt  && now >= trunkOffAt)  { setRelay(PIN_TRUNK,  false); trunkOffAt  = 0; emitEvent("trunk");    }
+  if (wipersOffAt && now >= wipersOffAt) { setRelay(PIN_WIPERS, false); wipersOffAt = 0; }
+  if (lightsOffAt && now >= lightsOffAt) { setRelay(PIN_HEADLIGHTS, false); lightsOffAt = 0; }
+
+  // -------- 3. Blinker toggling --------
+  if ((blinkerLeftOn || blinkerRightOn) && (now - lastBlinkToggle) >= BLINK_INTERVAL) {
+    lastBlinkToggle = now;
+    if (blinkerLeftOn)  { blinkerLeftPhase  = !blinkerLeftPhase;  setRelay(PIN_BLINKER_L, blinkerLeftPhase);  }
+    if (blinkerRightOn) { blinkerRightPhase = !blinkerRightPhase; setRelay(PIN_BLINKER_R, blinkerRightPhase); }
+  }
+
+  // -------- 4. RF receiver poll (optional) --------
+#if ENABLE_RF
+  if (rfReceiver.available()) {
+    unsigned long code = rfReceiver.getReceivedValue();
+    rfReceiver.resetAvailable();
+    if (code != 0) {
+      if (rfLearnMode && now < rfLearnUntil) {
+        Serial.print(F("{\"event\":\"rf_learned\",\"code\":"));
+        Serial.print(code); Serial.println(F("}"));
+        rfLearnMode = false;
+      } else {
+        Serial.print(F("{\"event\":\"rf_received\",\"code\":"));
+        Serial.print(code); Serial.println(F("}"));
+      }
+    }
+  }
+  if (rfLearnMode && now > rfLearnUntil) {
+    rfLearnMode = false;
+    emitEvent("rf_learn_timeout");
+  }
+#endif
+
+  // -------- 5. Activity LED off / heartbeat --------
+  // The brief flash on command receipt is undone here on the next loop pass.
+  // Slow 1 Hz heartbeat blink so you can see the Nano is alive.
+  if ((now - lastHeartbeat) >= 1000) {
+    lastHeartbeat = now;
+    ledState = !ledState;
+    digitalWrite(PIN_LED, ledState ? HIGH : LOW);
+  }
+}
+
+// =============================================================================
+// Command dispatch
+// =============================================================================
+void handleCommand(const JsonDocument& doc) {
+  const char* cmd = doc["cmd"] | "";
+
+  if (!strcmp(cmd, "lock")) {
+    pulseRelay(PIN_LOCK, lockOffAt);
+
+  } else if (!strcmp(cmd, "unlock")) {
+    pulseRelay(PIN_UNLOCK, unlockOffAt);
+
+  } else if (!strcmp(cmd, "trunk")) {
+    pulseRelay(PIN_TRUNK, trunkOffAt);
+
+  } else if (!strcmp(cmd, "window")) {
+    const char* dir = doc["dir"] | "";
+    int state = doc["state"] | 0;
+    int pin = !strcmp(dir, "up") ? PIN_WINDOW_UP : PIN_WINDOW_DOWN;
+    setRelay(pin, state ? true : false);
+
+  } else if (!strcmp(cmd, "lights")) {
+    int state   = doc["state"]   | 0;
+    long tmo    = doc["timeout"] | (long)DEFAULT_LIGHTS_TIMEOUT;
+    setRelay(PIN_HEADLIGHTS, state ? true : false);
+    lightsOffAt = (state && tmo > 0) ? millis() + (unsigned long)tmo * 1000UL : 0;
+
+  } else if (!strcmp(cmd, "blinker")) {
+    const char* side = doc["side"] | "";
+    int state = doc["state"] | 0;
+    if (!strcmp(side, "left")) {
+      blinkerLeftOn = state ? true : false;
+      if (!blinkerLeftOn) { blinkerLeftPhase = false; setRelay(PIN_BLINKER_L, false); }
+    } else if (!strcmp(side, "right")) {
+      blinkerRightOn = state ? true : false;
+      if (!blinkerRightOn) { blinkerRightPhase = false; setRelay(PIN_BLINKER_R, false); }
+    }
+
+  } else if (!strcmp(cmd, "horn")) {
+    int state = doc["state"] | 0;
+    setRelay(PIN_HORN, state ? true : false);
+
+  } else if (!strcmp(cmd, "wipers")) {
+    long dur = doc["duration"] | 5L;
+    setRelay(PIN_WIPERS, true);
+    wipersOffAt = millis() + (unsigned long)dur * 1000UL;
+
+  } else if (!strcmp(cmd, "blink")) {
+    // Acknowledgement flash on both blinker outputs (e.g. after lock).
+    int count = doc["count"] | 2;
+    for (int i = 0; i < count; i++) {
+      setRelay(PIN_BLINKER_L, true); setRelay(PIN_BLINKER_R, true);
+      delay(150);
+      setRelay(PIN_BLINKER_L, false); setRelay(PIN_BLINKER_R, false);
+      delay(150);
+    }
+
+  } else if (!strcmp(cmd, "backlight")) {
+    const char* display = doc["display"] | "large";
+    int brightness = doc["brightness"] | -1;
+    if (brightness >= 0) setBacklight(display, brightness);
+
+  } else if (!strcmp(cmd, "learn")) {
+#if ENABLE_RF
+    rfLearnMode = true;
+    rfLearnUntil = millis() + 10000UL;
+    emitEvent("rf_learn_start");
+#else
+    emitErrorMsg("RF disabled (set ENABLE_RF=1 and rebuild)");
+#endif
+
+  } else if (!strcmp(cmd, "ping")) {
+    emitEvent("pong");
+
+  } else {
+    emitErrorMsg("unknown cmd");
+  }
+}
+
+// =============================================================================
+void pulseRelay(int pin, unsigned long& offAt) {
+  setRelay(pin, true);
+  offAt = millis() + PULSE_MS;
+}
+
+void setRelay(int pin, bool active) {
+  digitalWrite(pin, active ? RELAY_ACTIVE : RELAY_INACTIVE);
+}
+
+void setBacklight(const char* display, int brightness) {
+  if (brightness < 0)   brightness = 0;
+  if (brightness > 100) brightness = 100;
+  int duty = (brightness * 255L) / 100;
+  if (!strcmp(display, "large")) {
+    blDutyLarge = brightness;
+    analogWrite(PIN_BACKLIGHT_L, duty);
+  } else if (!strcmp(display, "small")) {
+    blDutySmall = brightness;
+    analogWrite(PIN_BACKLIGHT_S, duty);
+  } else if (!strcmp(display, "both") || !strcmp(display, "all")) {
+    blDutyLarge = blDutySmall = brightness;
+    analogWrite(PIN_BACKLIGHT_L, duty);
+    analogWrite(PIN_BACKLIGHT_S, duty);
+  } else {
+    emitErrorMsg("unknown display");
+  }
+}
+
+void emitEvent(const char* name) {
+  Serial.print(F("{\"event\":\""));
+  Serial.print(name);
+  Serial.println(F("\"}"));
+}
+
+void emitErrorMsg(const char* msg) {
+  Serial.print(F("{\"event\":\"error\",\"msg\":\""));
+  Serial.print(msg);
+  Serial.println(F("\"}"));
+}

--- a/docs/ARDUINO_SETUP_GUIDE.md
+++ b/docs/ARDUINO_SETUP_GUIDE.md
@@ -1,0 +1,366 @@
+# Arduino Setup Guide — Beginner Walkthrough
+
+This guide walks you through flashing the two Arduino boards used by the
+BCM headunit on the x86 (Lenovo M910q) platform, from a completely fresh
+start. **No prior Arduino experience required.**
+
+You will end up with:
+
+| Board | Role | Sketch | USB device |
+|-------|------|--------|------------|
+| **Arduino Pro Micro** (ATmega32U4) | Inputs — buttons, rotary encoder, SWC, light sensor, fuel sender | `arduino/rotary_encoder/rotary_encoder.ino` | `/dev/ttyACM0` (also USB HID keyboard) |
+| **Arduino Nano** (ATmega328P, CH340) | Outputs — relays, lights, horn, wipers, **display backlight PWM** | `arduino/output_controller/output_controller.ino` | `/dev/ttyUSB0` |
+
+Both plug into the powered USB hub described in `docs/X86_PLATFORM_SETUP.md`.
+
+---
+
+## 1. What you need
+
+### Hardware
+- 1 × Arduino Pro Micro (ATmega32U4, 5 V / 16 MHz). Genuine SparkFun or
+  any of the very common clones. Avoid 3.3 V variants.
+- 1 × Arduino Nano (ATmega328P) with a **CH340** USB-UART chip — the
+  classic blue-PCB clone. The FTDI variant works too.
+- 1 × Micro-USB cable (Pro Micro) and 1 × Mini-USB cable (most Nanos
+  use mini-USB; some clones use micro). Both must be **data cables**
+  — charge-only cables look identical and will not enumerate.
+- Your computer for flashing (the same M910q is fine, or any laptop).
+
+### Software
+- **Arduino IDE 2.x** — the modern editor with built-in board/library
+  manager. Download from <https://www.arduino.cc/en/software>.
+- **CH340 driver** — only needed on Windows / macOS. On Linux the
+  driver (`ch341`) ships with the kernel; nothing to install.
+
+### Tools (only the IDE — no soldering iron needed yet for the flashing step)
+- Arduino IDE
+- Serial Monitor (built into the IDE, accessed by the magnifying-glass icon)
+- A USB port on your computer (any one — you can flash both boards
+  one after the other from a single port)
+
+---
+
+## 2. Install the Arduino IDE
+
+### Linux (Debian / Ubuntu — the M910q itself)
+
+```bash
+# Easiest: use the AppImage from arduino.cc
+cd ~/Downloads
+wget https://downloads.arduino.cc/arduino-ide/arduino-ide_latest_Linux_64bit.AppImage
+chmod +x arduino-ide_latest_Linux_64bit.AppImage
+./arduino-ide_latest_Linux_64bit.AppImage
+```
+
+You also need to be in the `dialout` group so the IDE can open the serial
+ports without `sudo`:
+
+```bash
+sudo usermod -aG dialout $USER
+```
+
+Then **log out and back in** (or reboot). This step is the single most
+common cause of "permission denied /dev/ttyACM0" errors later.
+
+### Windows
+
+1. Download the Windows installer from <https://www.arduino.cc/en/software>.
+2. Run it, accept the defaults (it will offer to install USB drivers — say yes).
+3. Separately install the CH340 driver:
+   <https://www.wch-ic.com/downloads/CH341SER_EXE.html> — run, reboot if asked.
+
+### macOS
+
+1. Download the .dmg from <https://www.arduino.cc/en/software>.
+2. Drag Arduino IDE into Applications.
+3. CH340 driver: <https://github.com/adrianmihalko/ch340g-ch34g-ch34x-mac-os-x-driver>
+   — follow the README for your macOS version.
+
+---
+
+## 3. First launch — open the project sketches
+
+1. Start the Arduino IDE.
+2. **File → Open…** and navigate to the cloned repo:
+   - For the Pro Micro: `arduino/rotary_encoder/rotary_encoder.ino`
+   - For the Nano:      `arduino/output_controller/output_controller.ino`
+
+   You can have both open at once — the IDE will create a window per
+   sketch.
+
+> **Tip:** Arduino requires every sketch file to live inside a folder
+> with the **same name** as the `.ino`. The repo already follows this —
+> just don't rename the folders.
+
+---
+
+## 4. Install the required libraries
+
+Open **Tools → Manage Libraries…** (or `Ctrl+Shift+I`). In the search
+box, install each of these one at a time — click the entry, then
+**Install** (use the latest version unless noted):
+
+| Library | Used by | Notes |
+|---------|---------|-------|
+| **HID-Project** by NicoHood | Pro Micro | Provides `Consumer.write(MEDIA_*)` — media-key HID support |
+| **ArduinoJson** by Benoit Blanchon | Nano | **Version 7.x** (the sketch uses the v7 `JsonDocument` API) |
+| **RCSwitch** by sui77 | Nano *(optional)* | Only needed if you set `ENABLE_RF = 1` for 433 MHz keyfobs |
+
+The IDE downloads and installs them into `~/Arduino/libraries/`.
+
+---
+
+## 5. Flash the Pro Micro (input controller)
+
+### 5.1 Select the board
+
+In Arduino IDE, with the **Pro Micro sketch window active**:
+
+1. **Tools → Board → Arduino AVR Boards → Arduino Leonardo**
+   - The Pro Micro is not in the default list. It uses the same chip
+     (ATmega32U4) as the Leonardo, so the Leonardo profile flashes it
+     correctly. If you want the proper name, install the SparkFun
+     boards package: Tools → Boards Manager → search "SparkFun AVR" →
+     install → then select **SparkFun Pro Micro (5 V, 16 MHz)**.
+
+### 5.2 Plug in the Pro Micro and select the port
+
+1. Connect the Pro Micro via USB. The on-board LED should light up.
+2. **Tools → Port** — pick the new port:
+   - Linux: `/dev/ttyACM0` (or `ttyACM1`)
+   - Windows: `COM3`, `COM4`, …
+   - macOS: `/dev/cu.usbmodem*`
+
+If you don't see any port, the cable is charge-only — swap it.
+
+### 5.3 Compile and upload
+
+1. Click the **checkmark** (Verify) in the toolbar. It compiles the
+   sketch. The first compile takes ~30 s; subsequent ones are fast.
+   Expect a clean "Done compiling" message — warnings about unused
+   variables are harmless.
+2. Click the **arrow** (Upload). The IDE compiles again, then flashes.
+
+> **Pro Micro tip — the "double-tap reset" trick.** If upload fails with
+> `avrdude: butterfly_recv(): programmer is not responding`, the
+> bootloader window timed out. Click Upload, then quickly tap the RST
+> pad on the Pro Micro to GND **twice in <750 ms** — the IDE will then
+> find the bootloader. Some clones expose RST on a labelled pad you can
+> short with a wire; on others you bridge RST↔GND with tweezers.
+
+After upload the Pro Micro re-enumerates as both a USB keyboard
+**and** a serial port — that's normal. Don't be alarmed if your mouse
+suddenly types `H` once — that's a stray HID event during reset.
+
+### 5.4 Verify it's alive
+
+Open **Tools → Serial Monitor**. Set baud to **115200** (bottom-right
+dropdown). You should see:
+
+```
+BCM v7 Input Controller ready (encoder + buttons + SWC + music + brightness)
+LIGHT:512
+LIGHT:513
+…
+```
+
+The `LIGHT:` line repeats every 2 s — that's the LDR sensor (or a
+floating value if you haven't wired one yet).
+
+### 5.5 Optional — SWC calibration
+
+The Pro Micro stores SWC button thresholds in EEPROM. If you have the
+steering-wheel control pods wired, calibrate them once:
+
+1. **Unplug** the Pro Micro.
+2. Press and **hold HOME + BACK** buttons.
+3. Plug the USB back in (keep holding).
+4. Open Serial Monitor at 115200.
+5. Release the buttons and follow the on-screen prompt — it asks for
+   each of the 24 buttons (Pod 1 × 12, Pod 2 × 12). Press one,
+   release, wait for "→ ADC = …".
+6. Done — values are saved to EEPROM and survive power cycles.
+
+You can skip this step now and do it later — the sketch falls back to
+sane defaults.
+
+---
+
+## 6. Flash the Nano (output controller)
+
+### 6.1 Select the board
+
+With the **Nano sketch window active**:
+
+1. **Tools → Board → Arduino AVR Boards → Arduino Nano**
+2. **Tools → Processor → ATmega328P** *(try this first)*
+   - If upload fails later with `stk500_recv(): programmer is not
+     responding`, change to **ATmega328P (Old Bootloader)** and retry.
+     About half of the cheap clones use the old bootloader.
+
+### 6.2 Plug in the Nano and select the port
+
+1. Connect via USB. The on-board red power LED lights up.
+2. **Tools → Port** — pick the new port:
+   - Linux: `/dev/ttyUSB0` (CH340 → `ch341` driver)
+   - Windows: `COM*` (whatever appears)
+   - macOS: `/dev/cu.wchusbserial*`
+
+If no port appears on Linux, run `dmesg | tail` after plugging in —
+you should see `ch341-uart converter now attached to ttyUSB0`. If not,
+your cable is charge-only.
+
+### 6.3 Compile and upload
+
+Click **Verify** (checkmark), then **Upload** (arrow). The on-board RX
+and TX LEDs flicker during flashing. On success the IDE prints
+`avrdude done. Thank you.`.
+
+### 6.4 Verify it's alive
+
+Open **Tools → Serial Monitor** — **change baud to 9600** (different
+from the Pro Micro). You should see immediately after reset:
+
+```
+{"event":"ready","fw":"bcm-output-v8.5"}
+```
+
+And the on-board LED (D13) starts blinking once per second — that's
+the heartbeat.
+
+Now type a test command into the Serial Monitor input box. Make sure
+the line-ending dropdown is set to **Newline**, then send:
+
+```
+{"cmd":"ping"}
+```
+
+Reply:
+
+```
+{"event":"pong"}
+```
+
+Try the lock relay (it will pulse for 200 ms — even with no relay
+wired you'll see the D13 LED flash and the receive activity):
+
+```
+{"cmd":"lock"}
+```
+
+Reply:
+
+```
+{"event":"locked"}
+```
+
+Try the 7" display backlight (PWM 50 %). With nothing wired you can't
+see anything change, but no error means the firmware accepted it:
+
+```
+{"cmd":"backlight","display":"large","brightness":50}
+```
+
+---
+
+## 7. Wiring quick-reference — Arduino Nano
+
+When you're ready to connect actual hardware, here are the pins. Wire
+relay/input pins only as you build out each subsystem; you don't need
+them all at once.
+
+| Pin | Function | Wire to |
+|-----|----------|---------|
+| D2  | Lock relay (pulse 200 ms)              | Relay module IN1 |
+| D3  | Unlock relay (pulse 200 ms)            | Relay module IN2 |
+| D4  | Trunk release relay                    | Relay module IN3 |
+| D5  | Window UP relay (hold)                 | Relay module IN4 |
+| D6  | Window DOWN relay (hold)               | Relay module IN5 |
+| D7  | Headlights relay                       | Relay module IN6 |
+| D8  | Left blinker relay (toggle)            | Relay module IN7 |
+| **D9**  | **7" display backlight PWM**       | **Display "PWM" pad** |
+| **D10** | **4.3" display backlight PWM**     | **Display PWM pin (M_PWM)** |
+| D11 | Horn relay (hold)                      | Relay module IN8 |
+| D12 | RF receiver data (optional)            | RXB6 DATA pin |
+| D13 | Status LED (on-board, no wiring)       | — |
+| A0  | Right blinker relay (toggle)           | Relay module IN9 |
+| A1  | Wipers relay (pulse, duration)         | Relay module IN10 |
+| 5V  | Logic supply                           | Relay module VCC, RXB6 VCC |
+| GND | Ground (common!)                       | Relay module GND, **display GND pad**, RXB6 GND |
+
+> **Important — common ground:** the display's `GND` pad **must** be
+> tied to the Nano's GND, otherwise the M_PWM gate has no reference
+> and the backlight won't respond. Run a single wire from any Nano GND
+> pin to the display GND pad.
+
+> **5 V logic on the display PWM input:** the 7" Waveshare-style
+> Display-D board has an N-MOSFET on `M_PWM`. The Nano outputs 0–5 V
+> logic on D9/D10, which is well above the MOSFET's gate threshold.
+> No level shifter needed.
+
+---
+
+## 8. Plugging both Arduinos into the M910q
+
+Once both sketches are flashed and verified:
+
+1. Plug both Arduinos into the **powered USB hub** (not directly into
+   the M910q if you can avoid it — the hub provides clean 5 V and
+   makes the wiring tidier under the dash).
+2. Confirm they enumerate:
+
+   ```bash
+   ls -l /dev/ttyACM* /dev/ttyUSB*
+   # /dev/ttyACM0 → Pro Micro
+   # /dev/ttyUSB0 → Nano
+   ```
+
+3. Confirm permissions (you should be in `dialout`):
+
+   ```bash
+   groups | grep dialout
+   ```
+
+4. The BCM Python code auto-detects both ports on startup
+   (`src/input/arduino_serial.py` and `src/vehicle/central_lock.py`).
+   Check `journalctl -u bcm-headunit | grep -i arduino` after boot.
+
+---
+
+## 9. Common errors and fixes
+
+| Symptom | Cause / fix |
+|---------|-------------|
+| Upload fails: `avrdude: ser_open(): can't open device '/dev/ttyACM0': Permission denied` | You aren't in the `dialout` group, or you haven't logged out/in since adding yourself. Run `sudo usermod -aG dialout $USER`, then **reboot**. |
+| Upload fails: `avrdude: stk500_recv(): programmer is not responding` (Nano) | Wrong bootloader. **Tools → Processor → ATmega328P (Old Bootloader)** and retry. |
+| Upload fails: `avrdude: butterfly_recv(): programmer is not responding` (Pro Micro) | Bootloader window closed. Click Upload, then double-tap RST→GND on the Pro Micro within 750 ms. |
+| Serial Monitor shows garbage characters | Wrong baud rate. Pro Micro = **115200**, Nano = **9600**. |
+| `Library ArduinoJson not found` at compile time | Open Library Manager and install the ArduinoJson package (v7.x). |
+| `JsonDocument has no member named …` at compile time | You installed ArduinoJson **v6** instead of **v7**. Uninstall and install the latest. |
+| Nano not detected on Linux (no `/dev/ttyUSB0`) | Cable is charge-only; or the CH340 didn't enumerate. Run `dmesg \| tail` after plugging in. |
+| Nano not detected on Windows | Install the CH340 driver from WCH (link in §2). |
+| 7" display brightness doesn't change when you send `backlight` commands | Check the GND wire between Nano and display PWM pad. Check D9 is going to the display PWM pad (multimeter, ~2.5 V at 50 % duty). |
+| Pro Micro acts as a keyboard and types stuff into your editor | Normal during reset — it's a feature, not a bug. Switch focus to Serial Monitor while testing. |
+
+---
+
+## 10. What to do next
+
+Once both Arduinos are flashed and verified:
+
+- Wire the display PWM pads to **Nano D9 (large 7") and D10 (small 4.3")**
+  plus a common GND, then verify in Serial Monitor with
+  `{"cmd":"backlight","display":"large","brightness":20}` and watch the
+  screen dim.
+- Add a Python-side consumer in the BCM (forwarding
+  `power.backlight_brightness` events to the Nano serial port). This
+  is the last piece needed to wire the existing
+  `src/power/brightness.py` controller — the auto-brightness, stalk
+  button cycle, and Settings screen will all then drive the real
+  hardware. *(Ask Claude to write this — it's a ~40-line module.)*
+- Build out the relay outputs (lock, lights, etc.) one at a time as
+  you have hardware on the bench.
+
+You now have a working, debuggable two-Arduino bridge between the
+M910q and the car. Have fun.

--- a/docs/x86-production/06-arduino.html
+++ b/docs/x86-production/06-arduino.html
@@ -371,14 +371,14 @@
                   <td>On/off toggle</td>
                 </tr>
                 <tr>
-                  <td>Right blinker</td>
+                  <td>Backlight LARGE (7" main)</td>
                   <td>D9</td>
-                  <td>On/off toggle</td>
+                  <td>PWM ~490 Hz, drives display M_PWM gate (0&ndash;100&nbsp;%)</td>
                 </tr>
                 <tr>
-                  <td>Wipers</td>
+                  <td>Backlight SMALL (4.3" dashboard)</td>
                   <td>D10</td>
-                  <td>Pulse (duration-controlled)</td>
+                  <td>PWM ~490 Hz, drives display M_PWM gate (0&ndash;100&nbsp;%)</td>
                 </tr>
                 <tr>
                   <td>Horn</td>
@@ -386,12 +386,34 @@
                   <td>Hold while active</td>
                 </tr>
                 <tr>
-                  <td>RF receiver</td>
+                  <td>RF receiver (optional)</td>
                   <td>D12</td>
-                  <td>RXB6 433 MHz receiver (data input)</td>
+                  <td>RXB6 433 MHz receiver (data input). Disabled by default &mdash; set <code>ENABLE_RF&nbsp;=&nbsp;1</code> in the sketch.</td>
+                </tr>
+                <tr>
+                  <td>Right blinker</td>
+                  <td>A0</td>
+                  <td>On/off toggle (relocated from D9 to free hardware PWM)</td>
+                </tr>
+                <tr>
+                  <td>Wipers</td>
+                  <td>A1</td>
+                  <td>Pulse, duration-controlled (relocated from D10 to free hardware PWM)</td>
                 </tr>
               </tbody>
             </table>
+          </div>
+
+          <div class="box box-info">
+            <div class="box-title">Why D9/D10 are now backlight outputs</div>
+            <p>
+              On x86 the M910q has no GPIO header, so the display backlight
+              PWM must come from one of the USB Arduinos. The Nano's hardware
+              PWM channels are on D3/D5/D6/D9/D10/D11 &mdash; D9 and D10 sit
+              on Timer1 which doesn't conflict with <code>millis()</code>,
+              making them the cleanest choice. The right blinker and wipers
+              (which don't need PWM) move to A0/A1.
+            </p>
           </div>
 
           <h3>JSON Command Protocol</h3>
@@ -434,7 +456,7 @@
                 <tr>
                   <td>Wipers</td>
                   <td><code>{"cmd":"wipers","duration":5}</code></td>
-                  <td>D10 active for 5 s</td>
+                  <td>A1 active for 5 s</td>
                 </tr>
                 <tr>
                   <td>Horn</td>
@@ -444,26 +466,47 @@
                 <tr>
                   <td>Blinkers</td>
                   <td><code>{"cmd":"blinker","side":"left","state":1}</code></td>
-                  <td>D8 or D9 on/off</td>
+                  <td>D8 (left) or A0 (right) on/off, software-blinked at ~1.25 Hz</td>
                 </tr>
                 <tr>
                   <td>Window</td>
                   <td><code>{"cmd":"window","dir":"up","state":1}</code></td>
                   <td>D5 or D6 hold while state=1</td>
                 </tr>
+                <tr>
+                  <td>Backlight</td>
+                  <td><code>{"cmd":"backlight","display":"large","brightness":80}</code></td>
+                  <td>PWM duty on D9 (large/7") or D10 (small/4.3"); accepts <code>"both"</code> too</td>
+                </tr>
+                <tr>
+                  <td>Blink ack</td>
+                  <td><code>{"cmd":"blink","count":2}</code></td>
+                  <td>Brief alternating flash on both blinker outputs (e.g. after lock)</td>
+                </tr>
+                <tr>
+                  <td>RF learn</td>
+                  <td><code>{"cmd":"learn"}</code></td>
+                  <td>10 s 433 MHz capture window (requires <code>ENABLE_RF=1</code>)</td>
+                </tr>
+                <tr>
+                  <td>Health-check</td>
+                  <td><code>{"cmd":"ping"}</code></td>
+                  <td>Reply: <code>{"event":"pong"}</code></td>
+                </tr>
               </tbody>
             </table>
           </div>
 
-          <div class="box box-warning">
-            <div class="box-title">Nano firmware not in repo yet</div>
+          <div class="box box-info">
+            <div class="box-title">Nano firmware location</div>
             <p>
-              The output Arduino Nano firmware is not yet committed to the repository.
-              The protocol documented above is the <strong>expected interface</strong>
-              that the BCM Python code will send. When implementing the Nano firmware,
-              use <code>ArduinoJson</code> to parse incoming serial data and drive
-              the relay module pins accordingly. The RF receiver (D12) should use
-              the <code>RCSwitch</code> library to decode 433 MHz keyfob signals.
+              The output controller sketch is
+              <code>arduino/output_controller/output_controller.ino</code>.
+              See <a href="../ARDUINO_SETUP_GUIDE.md">ARDUINO_SETUP_GUIDE.md</a>
+              for a step-by-step beginner walkthrough covering IDE install,
+              required libraries (<code>ArduinoJson</code> v7,
+              <code>RCSwitch</code>), board selection, port permissions, and
+              first-run verification.
             </p>
           </div>
         </section>


### PR DESCRIPTION
## Summary

The Nano output-controller firmware was previously *documented* (HTML doc spelled out its serial protocol) but never written. This PR adds the complete sketch and a beginner-friendly setup guide for flashing both Arduinos from scratch — the missing piece needed to manage the 7" and 4.3" display brightness via PWM on the x86 (M910q) platform, where there's no GPIO header.

## What's in here

- **`arduino/output_controller/output_controller.ino`** — full Nano sketch:
  - JSON command parsing via ArduinoJson v7
  - Non-blocking pulse timers (lock/unlock/trunk/wipers/headlights)
  - Software-blinked turn signals (~1.25 Hz)
  - Optional 433 MHz RF receiver gated by `ENABLE_RF`
  - **Hardware PWM on D9 / D10 driving the displays' `M_PWM` gates** (the Display-D board has its own on-board N-MOSFET — Nano logic level drives it directly)
  - Status LED heartbeat + activity flash
  - Emits `{"event":...}` JSON replies that `src/vehicle/central_lock.py` already knows how to consume

- **`docs/ARDUINO_SETUP_GUIDE.md`** — newbie walkthrough:
  - IDE install for Linux/Windows/macOS, dialout group, CH340 driver
  - Required libraries (HID-Project, ArduinoJson v7, RCSwitch optional)
  - Board / port / processor selection for both boards
  - The Pro Micro double-tap-reset workaround
  - SWC calibration walk-through
  - Serial Monitor verification commands
  - Common errors + fixes
  - Wiring quick-reference

- **`docs/x86-production/06-arduino.html`** — updated pin map to reflect the PWM relocation and added `backlight` / `blink` / `learn` / `ping` rows to the JSON protocol table, replacing the "firmware not in repo yet" warning with a link to the sketch.

## Pin remap (Nano)

To fit two hardware-PWM backlight outputs without losing any documented function, two non-PWM-requiring relays moved off `D9` / `D10`:

| Pin | Before | After |
|-----|--------|-------|
| D9  | Right blinker | **Backlight LARGE 7" (PWM)** |
| D10 | Wipers | **Backlight SMALL 4.3" (PWM)** |
| A0  | — | Right blinker (relocated) |
| A1  | — | Wipers (relocated) |

D9/D10 are on Timer1 so `analogWrite` doesn't interfere with `millis()`.

## Next step (separate PR)

The Python side of the existing `src/power/brightness.py` controller still doesn't forward `power.backlight_brightness` events to the Nano serial port on x86. A small consumer (~40 lines) writing JSON `{"cmd":"backlight",…}` to `/dev/ttyUSB0` will close the loop and make the stalk-button cycle + auto-brightness drive real hardware. Not in this PR to keep the firmware change reviewable on its own.

## Test plan

- [ ] Open `arduino/output_controller/output_controller.ino` in Arduino IDE 2.x, install ArduinoJson v7, select **Arduino Nano** + **ATmega328P** (try "Old Bootloader" if upload fails), upload to a Nano clone.
- [ ] Open Serial Monitor at **9600 baud**, expect `{"event":"ready","fw":"bcm-output-v8.5"}` on reset and a 1 Hz heartbeat on D13.
- [ ] Send `{"cmd":"ping"}` → expect `{"event":"pong"}`.
- [ ] Send `{"cmd":"lock"}` → expect `{"event":"locked"}` ~200 ms later; D2 should pulse LOW.
- [ ] Send `{"cmd":"backlight","display":"large","brightness":50}` → D9 PWM duty ≈ 50 % (multimeter ~2.5 V average).
- [ ] Wire D9 → display PWM pad + common GND, repeat above and verify screen dims.
- [ ] Open `arduino/rotary_encoder/rotary_encoder.ino` (no functional change — just confirm it still compiles after the doc/HTML edits).
- [ ] Walk through `docs/ARDUINO_SETUP_GUIDE.md` end-to-end on a fresh machine to confirm nothing's missing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJDci5sk8rqLEfLYuZBm7f)_