### PR TITLE
MT7921 combo card: swap WiFi/BT defaults to MediaTek + drop Intel quirks

### DIFF
--- a/config/bcm_config.yaml
+++ b/config/bcm_config.yaml
@@ -161,10 +161,10 @@ wifi:
   ssid: ALFA
   password: 87654321
   mode: p2p_go
-  band: g
-  channel: 6
-  country: BO
-  regdom: BO
+  band: a
+  channel: 149
+  country: US
+  regdom: US
   share_internet: true
   interface: ''
   ip: 10.0.0.1
@@ -176,7 +176,7 @@ wifi:
     ssid: ALFA-NET
     password: AlfaRomeo156
     channel: 6
-    country: BO
+    country: US
     ip: 10.0.1.1
     netmask: 255.255.255.0
     dhcp_start: 10.0.1.10
@@ -254,5 +254,4 @@ tracking:
 multimedia:
   last_bt_device: C0:7A:D6:90:E9:CC
 bluetooth:
-  prefer_internal: false
   preferred_adapter: ''

--- a/config/bcm_config_opi_pc.yaml
+++ b/config/bcm_config_opi_pc.yaml
@@ -367,10 +367,6 @@ tracking:
   sms_number: ""
 
 bluetooth:
-  # Orange Pi PC test rig has no Intel 8087 — leave at default so a
-  # USB dongle is used. Flip to true if the target OPi 5 Plus board
-  # ships with an internal radio you want to force.
-  prefer_internal: false
   preferred_adapter: ""
 
 # OPi PC test rig specific

--- a/config/scripts/apply-fixes.sh
+++ b/config/scripts/apply-fixes.sh
@@ -22,34 +22,18 @@ install -m 0644 "$BCM_DIR/config/systemd/bcm-splash-small.service" /etc/systemd/
 systemctl disable bcm-splash-small.service 2>/dev/null || true
 rm -f /etc/systemd/system/multi-user.target.wants/bcm-splash-small.service
 
-echo "==> 2/6  Installing Bluetooth setup (Class=carkit + AlwaysPairable + drop internal Intel BT)"
+echo "==> 2/6  Installing Bluetooth setup (Class=carkit + AlwaysPairable)"
 install -m 0755 "$BCM_DIR/config/scripts/bcm-bluetooth-setup.sh" /usr/local/bin/bcm-bluetooth-setup.sh
 install -m 0644 "$BCM_DIR/config/systemd/bcm-bluetooth.service" /etc/systemd/system/bcm-bluetooth.service
 
-# Drop the integrated Intel 8087 controller so only the USB dongle is
-# visible to BlueZ. The script-level unbind catches it at service start;
-# the udev rule below kills it earlier, before bluetoothd ever sees it,
-# which avoids the race where bluetoothd grabs the Intel as default
-# adapter and the phone latches onto its (broken) BD_ADDR.
-mkdir -p /etc/default
-if [ ! -f /etc/default/bcm-bluetooth ] || ! grep -q "^BCM_BT_KEEP_INTERNAL=" /etc/default/bcm-bluetooth; then
-    echo "BCM_BT_KEEP_INTERNAL=0" >> /etc/default/bcm-bluetooth
+# Remove leftover Intel-disable artifacts from prior installs (M910q used
+# to ship with an Intel 8087 BT chip that we hard-disabled via udev; the
+# MT7921 combo card replaces it cleanly so the rule is no longer needed).
+rm -f /etc/udev/rules.d/81-bcm-disable-intel-bt.rules
+if [ -f /etc/default/bcm-bluetooth ]; then
+    sed -i '/^BCM_BT_KEEP_INTERNAL=/d;/^BCM_BT_PREFER_INTERNAL=/d' /etc/default/bcm-bluetooth
 fi
-# Also flip the legacy "prefer Intel" flag off — even with the unbind
-# we don't want userspace fallback to look for the Intel first.
-if grep -q "^BCM_BT_PREFER_INTERNAL=1" /etc/default/bcm-bluetooth 2>/dev/null; then
-    sed -i 's/^BCM_BT_PREFER_INTERNAL=1/BCM_BT_PREFER_INTERNAL=0/' /etc/default/bcm-bluetooth
-fi
-cat > /etc/udev/rules.d/81-bcm-disable-intel-bt.rules <<'UDEV'
-# Disable the integrated Intel 8087:0a2b Bluetooth controller (M910q etc).
-# The kernel writes "0" to /sys/bus/usb/devices/X/authorized on attach,
-# which prevents the btusb driver from binding. Re-enable by removing
-# this rule or echoing 1 to the device's authorized sysfs entry.
-SUBSYSTEM=="usb", ATTR{idVendor}=="8087", ATTR{idProduct}=="0a2b", ATTR{authorized}="0"
-UDEV
 udevadm control --reload-rules 2>/dev/null || true
-# Trigger now so any currently-bound Intel BT goes away without a reboot.
-udevadm trigger --action=add --attr-match=idVendor=8087 2>/dev/null || true
 
 # Apply BT main.conf changes now (the setup script also does this, but
 # running it here makes the result observable before reboot).
@@ -67,12 +51,10 @@ if [ -f /etc/bluetooth/main.conf ]; then
 fi
 systemctl restart bluetooth.service 2>/dev/null || true
 
-echo "==> 3/6  Writing hostapd config (2.4 GHz ch6, country US)"
-# Intel 8265 firmware locks every 5 GHz channel as NO-IR for AP mode
-# regardless of regdom — verified with `iw phy` after `iw reg set US`,
-# `iw reg set PL`, and hostapd country_code permutations. Don't bother
-# trying 5 GHz channels here; nothing software-side opens up the
-# transmit lockout. Stay on 2.4 GHz which works first try.
+echo "==> 3/6  Writing hostapd config (5 GHz ch149, country US)"
+# MT7921 exposes UNII-3 (ch149-165) at 30 dBm with the worldwide regdom
+# baked into firmware-mediatek, so the AP comes up on 5 GHz without any
+# regdom tricks. AA Wireless gets clean H.264 throughput over 80 MHz here.
 if [ -f /etc/hostapd/hostapd.conf ]; then
     cp /etc/hostapd/hostapd.conf /etc/hostapd/hostapd.conf.bak.$(date +%s)
     SSID=$(awk -F= '/^ssid=/{print $2; exit}' /etc/hostapd/hostapd.conf)
@@ -84,10 +66,15 @@ driver=nl80211
 ssid=${SSID:-ALFA_AA}
 country_code=US
 ieee80211d=1
-hw_mode=g
-channel=6
+ieee80211h=1
+hw_mode=a
+channel=149
 ieee80211n=1
-ht_capab=[HT40+][SHORT-GI-20][SHORT-GI-40][DSSS_CCK-40]
+ieee80211ac=1
+ht_capab=[HT40+][SHORT-GI-20][SHORT-GI-40]
+vht_capab=[SHORT-GI-80][MAX-MPDU-11454]
+vht_oper_chwidth=1
+vht_oper_centr_freq_seg0_idx=155
 wpa=2
 wpa_passphrase=${PASS:-AlfaRomeo156}
 wpa_key_mgmt=WPA-PSK

--- a/config/scripts/bcm-bluetooth-setup.sh
+++ b/config/scripts/bcm-bluetooth-setup.sh
@@ -24,55 +24,6 @@ if command -v rfkill >/dev/null 2>&1; then
     fi
 fi
 
-# Hard-disable the integrated Intel 8087 controller.
-# Why: on the M910q (and other NUC-class boards) both the internal Intel
-# 8087:0a2b and an external CSR/Realtek dongle land on hciX simultaneously,
-# and BlueZ happily advertises both — phones then see two carkits with the
-# same alias and pairing latches onto the Intel one which mid-session
-# `tx timeout`s and drops. Preferring the dongle in userspace isn't
-# enough: the Intel still publishes the advertising RA, A2DP-Sink endpoint
-# on the wrong BD_ADDR, and HFP profile that the phone may pick first.
-#
-# Unbind it from its USB driver so the kernel removes /sys/class/bluetooth/hciN
-# entirely. BlueZ then only sees the dongle.  Can be re-enabled by setting
-# BCM_BT_KEEP_INTERNAL=1 in /etc/default/bcm-bluetooth.
-[ -f /etc/default/bcm-bluetooth ] && . /etc/default/bcm-bluetooth
-if [ "${BCM_BT_KEEP_INTERNAL:-0}" != "1" ]; then
-    for hci_dir in /sys/class/bluetooth/hci*; do
-        [ -e "$hci_dir" ] || continue
-        hci=$(basename "$hci_dir")
-        dev_real=$(readlink -f "$hci_dir/device" 2>/dev/null || true)
-        [ -n "$dev_real" ] || continue
-        # Walk up to the USB interface node (has idVendor/bInterfaceNumber).
-        cur="$dev_real"
-        vendor=""
-        usb_iface=""
-        for _ in 1 2 3 4 5; do
-            if [ -f "$cur/idVendor" ]; then
-                vendor=$(cat "$cur/idVendor" 2>/dev/null | tr A-Z a-z)
-                usb_iface="$cur"
-                break
-            fi
-            parent=$(dirname "$cur")
-            [ "$parent" = "$cur" ] && break
-            cur="$parent"
-        done
-        if [ "$vendor" = "8087" ] && [ -n "$usb_iface" ]; then
-            # The USB *device* node (one level up from interface) is what
-            # we unbind from the usb driver. dev_real for hciX usually
-            # points to interface .0 of the device, e.g.
-            #   /sys/bus/usb/devices/1-7:1.0  →  parent device 1-7
-            usb_dev=$(dirname "$usb_iface")
-            usb_name=$(basename "$usb_dev")
-            echo "BT setup: unbinding internal Intel 8087 at $usb_name ($hci)"
-            hciconfig "$hci" down 2>/dev/null || true
-            if [ -e /sys/bus/usb/drivers/usb/unbind ]; then
-                echo "$usb_name" > /sys/bus/usb/drivers/usb/unbind 2>/dev/null || true
-            fi
-        fi
-    done
-fi
-
 # NOTE: do NOT touch /etc/bluetooth/main.conf here, and do NOT restart
 # bluetooth.service from within this script. The unit has
 # Requires=bluetooth.service, so bouncing the daemon makes systemd
@@ -102,62 +53,29 @@ for i in $(seq 1 30); do
     sleep 1
 done
 
-# Pick the preferred adapter. On the M910q the integrated Intel 8087:0a2b
-# (BT 4.2 on paper, vs the typical CSR dongle's 4.0) is the *spec-better*
-# choice but the hardware is documented-broken: dmesg shows repeated
-# `Bluetooth: hciX: command 0xNNNN tx timeout` followed by
-# `Resetting usb device.` after ~15 min, after which the controller
-# vanishes from sysfs entirely. So default to a non-8087 (CSR/Realtek/
-# Broadcom) USB dongle when one is plugged in. To force a specific
-# controller MAC anyway, set BCM_BT_ADAPTER in /etc/default/bcm-bluetooth.
+# Pick the adapter to advertise as the carkit. With the MT7921 combo card
+# there's a single hci0 in normal operation; BCM_BT_ADAPTER can still
+# pin a specific BD_ADDR if a USB dongle is added later.
 PREFERRED_ADDR=""
-NON_INTEL_ADDR=""
-INTEL_ADDR=""
 FIRST_ADDR=""
 # shellcheck source=/dev/null
 [ -f /etc/default/bcm-bluetooth ] && . /etc/default/bcm-bluetooth
 for hci_dir in $(ls -d /sys/class/bluetooth/hci* 2>/dev/null | sort); do
     [ -e "$hci_dir" ] || continue
     hci=$(basename "$hci_dir")
-    dev_real=$(readlink -f "$hci_dir/device" 2>/dev/null || true)
-    vendor=""
-    cur="$dev_real"
-    for _ in 1 2 3 4; do
-        if [ -f "$cur/idVendor" ]; then
-            vendor=$(cat "$cur/idVendor" 2>/dev/null | tr A-Z a-z)
-            break
-        fi
-        parent=$(dirname "$cur")
-        [ "$parent" = "$cur" ] && break
-        cur="$parent"
-    done
     addr=$(hciconfig "$hci" 2>/dev/null | awk '/BD Address/{print $3; exit}')
     [ -n "$addr" ] || continue
     [ -z "$FIRST_ADDR" ] && FIRST_ADDR="$addr"
-    if [ "$vendor" = "8087" ]; then
-        [ -z "$INTEL_ADDR" ] && INTEL_ADDR="$addr"
-    elif [ -n "$vendor" ] && [ -z "$NON_INTEL_ADDR" ]; then
-        NON_INTEL_ADDR="$addr"
-        echo "BT setup: non-Intel candidate $hci ($addr, vendor $vendor)"
-    fi
 done
 if [ -n "${BCM_BT_ADAPTER:-}" ]; then
     PREFERRED_ADDR="$BCM_BT_ADAPTER"
     echo "BT setup: explicit override BCM_BT_ADAPTER=$PREFERRED_ADDR"
-elif [ "${BCM_BT_PREFER_INTERNAL:-0}" = "1" ] && [ -n "$INTEL_ADDR" ]; then
-    PREFERRED_ADDR="$INTEL_ADDR"
-    echo "BT setup: BCM_BT_PREFER_INTERNAL=1 — using Intel $PREFERRED_ADDR"
-elif [ -n "$NON_INTEL_ADDR" ]; then
-    PREFERRED_ADDR="$NON_INTEL_ADDR"
 elif [ -n "$FIRST_ADDR" ]; then
     PREFERRED_ADDR="$FIRST_ADDR"
-    echo "BT setup: no preferred adapter, falling back to $PREFERRED_ADDR"
 fi
 
 # Find the hciX index for the chosen address — used for hciconfig fallback
-# when bluetoothctl property writes get racy (Intel adapters often need a
-# power cycle before discoverable-timeout commits, which interactive
-# bluetoothctl doesn't sequence reliably).
+# when bluetoothctl property writes get racy.
 PREFERRED_HCI=""
 if [ -n "$PREFERRED_ADDR" ]; then
     for hci_dir in /sys/class/bluetooth/hci*; do

--- a/config/scripts/setup-x86.sh
+++ b/config/scripts/setup-x86.sh
@@ -29,17 +29,9 @@ MAIN_H=600
 SMALL_W=800
 SMALL_H=480
 
-# WiFi AP — 2.4 GHz channel 6, country US.
-# 5 GHz is HARDWARE-blocked on the M910q's Intel 8265: `iw phy` lists
-# every 5 GHz channel as "(no IR)" regardless of regdom (`iw reg set US`,
-# kernel regdb, hostapd country_code= — none of them open it). Intel's
-# iwlwifi firmware self-manages regulatory data and refuses to *transmit*
-# in 5 GHz, so AP mode is firmware-locked off there. STA mode (joining
-# 5 GHz APs) still works fine — but we're the AP here.
-# 5 GHz AP would need different hardware (USB Realtek RTL88x2BU,
-# MediaTek MT7612U, or non-Intel mPCIe like Atheros AR9462).
-# 2.4 GHz ch6 with country=US works first try and is what the unit ships
-# with. AA Wireless H.264 video runs fine over 802.11n 40 MHz on 2.4 GHz.
+# WiFi AP — 5 GHz channel 149, country US. MT7921 (mt7921e) exposes
+# UNII-3 (ch149-165) at 30 dBm with the worldwide regdom in
+# firmware-mediatek, so AP/P2P-GO on 5 GHz works first try.
 WIFI_IFACE="wlp2s0"
 WIFI_SSID="ALFA_AA"
 WIFI_PASS="AlfaRomeo156"
@@ -49,7 +41,7 @@ WIFI_PASS="AlfaRomeo156"
 # for older deployments that flip wifi.mode back to "hostapd" in YAML.
 WIFI_CHANNEL="149"
 WIFI_HW_MODE="a"
-WIFI_COUNTRY="BO"
+WIFI_COUNTRY="US"
 # ─────────────────────────────────────────────────────────────────
 
 RED='\033[0;31m'
@@ -149,7 +141,7 @@ apt-get install -y -qq \
     pipewire pipewire-pulse wireplumber alsa-utils mpv \
     gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
     gstreamer1.0-plugins-bad gstreamer1.0-libav \
-    firmware-iwlwifi bluez bluez-tools rfkill network-manager modemmanager hostapd dnsmasq iw wireless-tools wpasupplicant iptables \
+    firmware-mediatek bluez bluez-tools rfkill network-manager modemmanager hostapd dnsmasq iw wireless-tools wpasupplicant iptables \
     ffmpeg v4l-utils \
     acpid \
     zram-tools \
@@ -542,21 +534,16 @@ Name=p2p-*
 Unmanaged=yes
 EOF
 
-    # Best-effort regdom hint at module load: iwlwifi 8265 has a
-    # self-managed PHY pinned to country 00, which makes ch149/153
-    # (U-NII-3, normally OK in US) read NO-IR for AP mode. This is
-    # not a guaranteed fix — the firmware sometimes still ignores it
-    # — but it costs nothing and is the right starting point if/when
-    # someone moves the AP to 5 GHz. See memory:
-    # project_wifi_intel_7265_ch149.md for the full story.
+    # Default regdom hint at module load. MT7921 doesn't need it (the
+    # firmware-mediatek worldwide regdom already opens UNII-3 at 30 dBm),
+    # but cfg80211 reads this on first attach so older deployments stay
+    # consistent.
     mkdir -p /etc/modprobe.d
     echo "options cfg80211 ieee80211_regdom=US" > /etc/modprobe.d/cfg80211.conf
 
-    # hostapd — 2.4 GHz ch6, country=US. ieee80211ac is omitted because
-    # we're not on 5 GHz (Intel 8265 firmware blocks 5 GHz AP entirely;
-    # see the WIFI_* comment block at the top of this script). The
-    # remaining ieee80211n + ht_capab gives us 802.11n 40 MHz on 2.4 GHz
-    # which is what AA Wireless H.264 video needs.
+    # hostapd — 5 GHz ch149 (UNII-3), 80 MHz VHT. MT7921 supports up to
+    # 802.11ac on this PHY, which is what AA Wireless wants for clean
+    # H.264 throughput.
     mkdir -p /etc/hostapd
     cat > /etc/hostapd/hostapd.conf <<EOF
 interface=$WIFI_IFACE
@@ -566,8 +553,13 @@ hw_mode=$WIFI_HW_MODE
 channel=$WIFI_CHANNEL
 country_code=$WIFI_COUNTRY
 ieee80211d=1
+ieee80211h=1
 ieee80211n=1
-ht_capab=[HT40+][SHORT-GI-20][SHORT-GI-40][DSSS_CCK-40]
+ieee80211ac=1
+ht_capab=[HT40+][SHORT-GI-20][SHORT-GI-40]
+vht_capab=[SHORT-GI-80][MAX-MPDU-11454]
+vht_oper_chwidth=1
+vht_oper_centr_freq_seg0_idx=155
 wmm_enabled=1
 wpa=2
 wpa_passphrase=$WIFI_PASS
@@ -902,27 +894,14 @@ cp "$BCM_DIR/config/scripts/bcm-bluetooth-setup.sh" /usr/local/bin/
 chmod +x /usr/local/bin/bcm-bluetooth-setup.sh
 cp "$BCM_DIR/config/systemd/bcm-bluetooth.service" /etc/systemd/system/
 
-# Drop the integrated Intel 8087 BT entirely — its tx-timeout pattern
-# under load drops calls/AA mid-session, and when both internal and USB
-# dongle are present BlueZ advertises both with the same alias which
-# confuses phones during pairing. The udev rule below deauthorizes the
-# Intel USB device on attach so btusb never binds; the bluetooth setup
-# oneshot also unbinds it at service start as a safety net for systems
-# where udev rules aren't reloaded.
-mkdir -p /etc/default
-if ! grep -q "^BCM_BT_KEEP_INTERNAL=" /etc/default/bcm-bluetooth 2>/dev/null; then
-    echo "BCM_BT_KEEP_INTERNAL=0" >> /etc/default/bcm-bluetooth
+# Clean up Intel-8087 disable artifacts from prior installs (the MT7921
+# combo card replaces the old internal Intel BT so the udev rule and
+# BCM_BT_KEEP_INTERNAL/PREFER_INTERNAL flags are no longer needed).
+rm -f /etc/udev/rules.d/81-bcm-disable-intel-bt.rules
+if [ -f /etc/default/bcm-bluetooth ]; then
+    sed -i '/^BCM_BT_KEEP_INTERNAL=/d;/^BCM_BT_PREFER_INTERNAL=/d' /etc/default/bcm-bluetooth
 fi
-# Make sure any prior BCM_BT_PREFER_INTERNAL=1 from older installs is off.
-if grep -q "^BCM_BT_PREFER_INTERNAL=1" /etc/default/bcm-bluetooth 2>/dev/null; then
-    sed -i 's/^BCM_BT_PREFER_INTERNAL=1/BCM_BT_PREFER_INTERNAL=0/' /etc/default/bcm-bluetooth
-fi
-cat > /etc/udev/rules.d/81-bcm-disable-intel-bt.rules <<'UDEV'
-# Disable the integrated Intel 8087:0a2b Bluetooth controller (M910q etc).
-SUBSYSTEM=="usb", ATTR{idVendor}=="8087", ATTR{idProduct}=="0a2b", ATTR{authorized}="0"
-UDEV
 udevadm control --reload-rules 2>/dev/null || true
-udevadm trigger --action=add --attr-match=idVendor=8087 2>/dev/null || true
 
 # Persist BT rfkill unblock across boots — without this many baremetal
 # boards (M910q, OPi 5 Pro) come up with bluetooth soft-blocked even

--- a/docs/X86_PLATFORM_SETUP.md
+++ b/docs/X86_PLATFORM_SETUP.md
@@ -28,8 +28,8 @@ order — each builds on the previous one.
 | GPU | Intel HD 530 (VAAPI hardware decode) |
 | RAM | 8 GB DDR4 2400 |
 | Storage | 256 GB NVMe SSD |
-| WiFi | Intel 8265 2×2 802.11ac (built-in) |
-| Bluetooth | Intel 8265 BT 4.2 (built-in) |
+| WiFi | MediaTek MT7921 2×2 802.11ax (M.2 Key E, replaces stock Intel 8265) |
+| Bluetooth | MediaTek MT7921 BT 5.2 (USB side of the same M.2 combo card) |
 | Display | **2× DisplayPort** (mini-DP) |
 | USB | 6× USB 3.0 + 1× USB-C |
 | Power | 65W external 20V barrel jack |
@@ -52,10 +52,18 @@ for f in /sys/class/drm/card*-*/status; do echo "$f: $(cat $f)"; done
 
 ### 1.3 WiFi and Bluetooth
 
-Intel 8265 provides both. For wireless Android Auto you need 5GHz AP:
-- Intel 8265 supports AP on 5GHz non-DFS channels — test in §10
-- Fallback: USB WiFi dongle (RTL8812BU) if Intel AP fails
-- BT 4.2 built-in is sufficient for AA pairing — no dongle needed
+MT7921 combo card (PCIe `[14c3:7961]` + USB BT `[0489:e0cd]`) replaces
+the stock Intel 8265 in the M.2 Key E slot. Both radios need the
+`firmware-mediatek` package (Debian non-free-firmware) — without it,
+`mt7921e` reports `hardware init failed` and BT reports
+`Failed to load firmware file (-2)`.
+
+- MT7921 supports P2P-GO on 5GHz ch149 at 80MHz VHT, 30 dBm — first try.
+- BT 5.2 (HCI version 5.2, Manufacturer: MediaTek, Inc.) handles AA
+  pairing + A2DP + HFP cleanly. No tx-timeout reset like the old Intel 8087.
+- Fallback: USB WiFi dongle (RTL8812BU) only needed if you want
+  ALFA-NET concurrent with AA Wireless (single radio can't host both —
+  MT7921 advertises `#{AP, P2P-GO} <= 1`).
 
 ### 1.4 USB device layout
 
@@ -270,9 +278,9 @@ sudo apt install -y \
 sudo apt install -y \
     pipewire pipewire-pulse wireplumber alsa-utils mpv
 
-# Intel WiFi + Bluetooth
+# MediaTek MT7921 WiFi + Bluetooth (replaces firmware-iwlwifi)
 sudo apt install -y \
-    firmware-iwlwifi bluez bluez-tools network-manager hostapd dnsmasq
+    firmware-mediatek bluez bluez-tools network-manager hostapd dnsmasq
 
 # Camera / video
 sudo apt install -y \
@@ -602,43 +610,54 @@ journalctl -u bcm-resume --no-pager -n5
 
 ## 10. WiFi Access Point (for Wireless Android Auto)
 
-### 10.1 Test Intel 8265 AP mode
+### 10.1 Test MT7921 AP / P2P-GO mode
 
-The M910q's WiFi interface is `wlp2s0`:
+The M910q's WiFi interface (under `mt7921e`) is `wlp2s0`. The card
+exposes ch36-165 with the worldwide regdom in `firmware-mediatek`;
+ch149 (UNII-3) is available at 30 dBm with no NO-IR flag.
 
 ```bash
-# Verify AP mode is supported
-iw list | grep -A5 "Supported interface modes"
+# Verify the right card + driver loaded
+lspci -nn | grep -i mediatek                       # expect [14c3:7961]
+iw list | grep -A5 "Supported interface modes"     # expect AP, P2P-GO
+iw phy phy1 info | grep -A1 5745                   # expect (30.0 dBm)
 
-# Set country code
-sudo iw reg set PL
+# Set country code (worldwide default already works; this is belt+braces)
+sudo iw reg set US
 
-# Test AP on 5GHz channel 149
-sudo tee /tmp/test-ap.conf >/dev/null <<EOF
-interface=wlp2s0
-driver=nl80211
-ssid=ALFA_AA
-hw_mode=a
-channel=149
-ieee80211n=1
-ieee80211ac=1
-wpa=2
-wpa_passphrase=AlfaRomeo156
-wpa_key_mgmt=WPA-PSK
-rsn_pairwise=CCMP
-wpa_pairwise=CCMP
-country_code=PL
+# Quick P2P-GO sanity test on ch149 (BCM production mode)
+sudo systemctl stop wpa_supplicant.service NetworkManager
+sudo rfkill unblock wifi
+sudo mkdir -p /tmp/p2p-test/ctrl
+sudo tee /tmp/p2p-test/wpa.conf >/dev/null <<EOF
+ctrl_interface=DIR=/tmp/p2p-test/ctrl GROUP=netdev
+update_config=1
+country=US
+device_name=MT7921-Test
+device_type=8-0050F204-2
+p2p_go_intent=15
+p2p_go_ht40=1
+p2p_go_vht=1
 EOF
+sudo wpa_supplicant -B -i wlp2s0 -D nl80211 -c /tmp/p2p-test/wpa.conf
+sudo wpa_cli -p /tmp/p2p-test/ctrl -i wlp2s0 p2p_group_add freq=5745 persistent
+sleep 2
+iw dev   # expect Interface p2p-wlp2s0-0, type P2P-GO, channel 149, width: 80 MHz
 
-sudo hostapd /tmp/test-ap.conf
+# Cleanup + restart system services
+sudo wpa_cli -p /tmp/p2p-test/ctrl -i wlp2s0 p2p_group_remove p2p-wlp2s0-0
+sudo pkill -f "wpa_supplicant.*p2p-test"
+sudo rm -rf /tmp/p2p-test
+sudo systemctl start NetworkManager wpa_supplicant.service
 ```
 
-If your phone can see "ALFA_AA" — Intel works. If connection fails,
-try different channels: 36, 40, 44, 48, 149, 153, 157, 161.
+Alternative: regular hostapd ch149 80MHz VHT (the static fallback
+written by `setup-x86.sh` — see `/etc/hostapd/hostapd.conf`).
 
 ### 10.2 USB dongle fallback (RTL8812BU)
 
-If Intel 8265 can't hold connections on 5GHz:
+Only needed if you want `ALFA-NET` to broadcast concurrently with
+the AA Wireless P2P-GO group (MT7921 admits one AP role per radio):
 ```bash
 sudo apt install -y dkms bc linux-headers-$(uname -r)
 cd /tmp

--- a/docs/x86-production/08-wifi-bt.html
+++ b/docs/x86-production/08-wifi-bt.html
@@ -46,7 +46,7 @@
       <header>
         <h1>
           08 &mdash; WiFi &amp; Bluetooth
-          <span class="subtitle">Fenvi FU-AX1800 (MediaTek MT7921) &mdash; Dual-SSID AP &amp; BT Pairing</span>
+          <span class="subtitle">MediaTek MT7921 combo card &mdash; P2P-GO AA Wireless &amp; BT 5.2 carkit</span>
         </h1>
       </header>
 
@@ -57,23 +57,28 @@
           <h2>Overview</h2>
 
           <p>
-            The <strong>Fenvi FU-AX1800</strong> (MediaTek MT7921 chipset) replaces the
-            stock Intel 8265 wireless card in the Lenovo M910q. While the Intel 8265
-            provides basic WiFi and Bluetooth, it cannot reliably operate as a 5&nbsp;GHz
-            access point &mdash; a requirement for wireless Android Auto. The Fenvi
-            FU-AX1800 resolves this with full WiFi&nbsp;6 (802.11ax) support on both
-            2.4&nbsp;GHz and 5&nbsp;GHz bands, plus Bluetooth&nbsp;5.2.
+            The kiosk uses a <strong>MediaTek MT7921 M.2 combo card</strong> for both
+            WiFi and Bluetooth. The PCIe side (<code>[14c3:7961]</code>) drives WiFi 6
+            via the mainline <code>mt7921e</code> driver; the USB side
+            (<code>[0489:e0cd]</code>, MediaTek/Foxconn) provides Bluetooth 5.2 through
+            the standard <code>btusb</code>+<code>btmtk</code> stack. Both come up from
+            a single M.2 Key E slot with shared antennas, and both need the
+            <code>firmware-mediatek</code> package (Debian non-free-firmware repo) to
+            load &mdash; without it, the WiFi reports <code>hardware init failed</code>
+            and BT reports <code>Failed to load firmware file (-2)</code>.
           </p>
 
           <div class="box box-info">
-            <div class="box-title">Why replace the Intel 8265?</div>
+            <div class="box-title">Why MT7921 over the original Intel combo</div>
             <p>
-              The Intel 8265 uses the <code>iwlwifi</code> driver, which does not
-              support 5&nbsp;GHz AP mode. Android Auto wireless requires a 5&nbsp;GHz
-              access point for acceptable latency and bandwidth. The MT7921 driver
-              (<code>mt7921e</code>) is mainline since kernel 5.18 and supports both
-              AP mode on 5&nbsp;GHz and dual-SSID virtual interfaces, making it the
-              ideal upgrade.
+              The M910q ships with an Intel 8265 (WiFi) + Intel 8087 (BT) combo. The
+              8265 has a self-managed regdom pinned to country 00 that flags every
+              5&nbsp;GHz channel as <code>NO-IR</code> for AP mode regardless of
+              <code>iw reg set</code>, and the 8087 has a documented tx-timeout that
+              resets the controller mid-pair after ~15 minutes uptime. MT7921 has
+              neither problem &mdash; 5&nbsp;GHz ch149 P2P-GO at 80&nbsp;MHz VHT comes
+              up first try, and BT 5.2 sessions are stable. See
+              <a href="https://wireless.wiki.kernel.org/en/users/drivers/mediatek">wireless.wiki.kernel.org</a>.
             </p>
           </div>
 
@@ -82,40 +87,40 @@
               <thead>
                 <tr>
                   <th>Feature</th>
-                  <th>Intel 8265</th>
-                  <th>Fenvi FU-AX1800 (MT7921)</th>
+                  <th>Intel 8265 + 8087 (original)</th>
+                  <th>MediaTek MT7921 (current)</th>
                 </tr>
               </thead>
               <tbody>
                 <tr>
-                  <td>WiFi Standard</td>
+                  <td>WiFi standard</td>
                   <td>802.11ac (WiFi 5)</td>
-                  <td class="winner">802.11ax (WiFi 6)</td>
+                  <td class="winner">802.11ax (WiFi 6), 80&nbsp;MHz VHT</td>
                 </tr>
                 <tr>
-                  <td>5 GHz AP Mode</td>
-                  <td class="downside">Not supported</td>
-                  <td class="winner">Supported</td>
-                </tr>
-                <tr>
-                  <td>Dual-SSID (virtual interfaces)</td>
-                  <td class="downside">Not supported</td>
-                  <td class="winner">Supported</td>
+                  <td>5&nbsp;GHz AP / P2P-GO</td>
+                  <td class="downside">Firmware-locked off (self-managed country 00, NO-IR on UNII-1/3)</td>
+                  <td class="winner">ch149 first try at 30&nbsp;dBm</td>
                 </tr>
                 <tr>
                   <td>Bluetooth</td>
-                  <td>BT 4.2</td>
-                  <td class="winner">BT 5.2</td>
+                  <td class="downside">BT 4.2 &mdash; tx-timeout after ~15&nbsp;min, controller resets</td>
+                  <td class="winner">BT 5.2 &mdash; stable</td>
                 </tr>
                 <tr>
-                  <td>Linux Driver</td>
-                  <td>iwlwifi</td>
-                  <td>mt7921e (mainline &ge; 5.18)</td>
+                  <td>WiFi driver</td>
+                  <td><code>iwlwifi</code> + <code>firmware-iwlwifi</code></td>
+                  <td><code>mt7921e</code> + <code>firmware-mediatek</code></td>
                 </tr>
                 <tr>
-                  <td>Form Factor</td>
-                  <td>M.2 Key E (2230)</td>
-                  <td>M.2 Key E (2230)</td>
+                  <td>BT driver</td>
+                  <td><code>btusb</code> + <code>btintel</code></td>
+                  <td><code>btusb</code> + <code>btmtk</code></td>
+                </tr>
+                <tr>
+                  <td>Form factor</td>
+                  <td>M.2 Key E 2230</td>
+                  <td>M.2 Key E 2230 (compatible)</td>
                 </tr>
               </tbody>
             </table>
@@ -130,20 +135,20 @@
           <ol>
             <li>Power off the M910q and unplug all cables.</li>
             <li>Remove the top cover (single thumbscrew on the back).</li>
-            <li>Locate the M.2 Key E slot &mdash; the Intel 8265 card is held by a single screw.</li>
+            <li>Locate the M.2 Key E slot &mdash; the original Intel 8265 card is held by a single screw.</li>
             <li>Disconnect the two IPEX/U.FL antenna pigtails from the Intel card.</li>
             <li>Remove the mounting screw, slide out the Intel 8265.</li>
-            <li>Insert the Fenvi FU-AX1800 into the same M.2 Key E slot at a 30&deg; angle, press down, and secure with the screw.</li>
-            <li>Reconnect both IPEX/U.FL antenna pigtails to the Fenvi card.</li>
+            <li>Insert the MT7921 M.2 Key E card at a 30&deg; angle, press down, and secure with the screw.</li>
+            <li>Reconnect both IPEX/U.FL antenna pigtails to the MT7921 card (MAIN + AUX).</li>
           </ol>
 
           <h3>Antenna Pigtails</h3>
           <p>
-            The Fenvi FU-AX1800 uses <strong>2&times; IPEX/U.FL</strong> connectors, same
-            as the Intel 8265. Reuse the existing antenna pigtails if they are in good
-            condition. For best WiFi and Bluetooth range, route the antenna cables toward
-            the windshield &mdash; metal bodywork behind the dashboard attenuates the signal
-            significantly.
+            MT7921 M.2 modules use <strong>2&times; IPEX/U.FL</strong> connectors,
+            identical to the Intel 8265 they replace. Reuse the existing antenna
+            pigtails if they are in good condition. For best WiFi and Bluetooth range,
+            route the antenna cables toward the windshield &mdash; metal bodywork behind
+            the dashboard attenuates the signal significantly.
           </p>
 
           <div class="box box-warning">
@@ -162,45 +167,61 @@
           <h2>Driver Setup</h2>
 
           <p>
-            The MT7921 driver (<code>mt7921e</code>) is included in the mainline Linux
-            kernel since version 5.18. Debian 13 (Trixie) ships with kernel 6.x, so the
-            driver is available out of the box. Only the firmware package needs to be
-            installed.
+            The MT7921 driver (<code>mt7921e</code> for WiFi, <code>btmtk</code> for BT)
+            is included in the mainline Linux kernel since version 5.18. Debian 13
+            (Trixie) ships with kernel 6.x, so the drivers load automatically.
+            <strong>Both</strong> radios need the <code>firmware-mediatek</code> package
+            &mdash; otherwise the WiFi reports <code>hardware init failed</code> and
+            BT reports <code>Failed to load firmware file (-2)</code> in dmesg.
           </p>
 
-          <pre><code># MT7921 driver is mainline (kernel 5.18+, Debian 13 has it)
+          <pre><code># Install firmware (pulls WIFI_MT7961_*.bin + BT_RAM_CODE_MT7961_*.bin
+# into /lib/firmware/mediatek/). Debian trixie non-free-firmware repo
+# is enabled by default on the NETINST-with-firmware ISO.
 apt install firmware-mediatek
 
-# Blacklist Intel WiFi (prevent conflicts if Intel 8265 is still detected)
-echo "blacklist iwlwifi" &gt; /etc/modprobe.d/blacklist-intel-wifi.conf
+# Reload drivers without a reboot (or just reboot)
+modprobe -r mt7921e mt7921_common mt792x_lib mt76_connac_lib mt76
+modprobe mt7921e
+modprobe -r btusb btmtk
+modprobe btusb
 
-# Verify the card is detected
-lspci | grep -i mediatek
-ip link show | grep wl
-iw dev</code></pre>
+# Verify the card is detected and firmware loaded
+lspci -nn | grep -i mediatek          # expect: [14c3:7961]
+lsusb | grep -iE 'mediatek|0489:e0cd' # expect: Foxconn/MediaTek BT
+dmesg | grep -E 'mt7921|btmtk' | grep -iE 'firmware|version'
+iw dev                                 # expect wlp2s0, type managed
+hciconfig -a                           # expect hci0 UP RUNNING, Manufacturer: MediaTek</code></pre>
 
           <p>
-            After installing the firmware and rebooting, <code>lspci</code> should show the
-            MediaTek MT7921 device, and <code>ip link</code> should list a <code>wlan0</code>
-            interface. The <code>iw dev</code> command confirms the wireless interface is
-            operational.
+            Successful output shows <code>mt7921e ... WM Firmware Version: ...</code>
+            in dmesg, the interface renamed from <code>wlan0</code> to
+            <code>wlp2s0</code>, and <code>hciconfig</code> reporting
+            <code>HCI Version: 5.2 ... Manufacturer: MediaTek, Inc.</code>. The WiFi
+            and BT MAC addresses are sequential (offset +1) because both radios share
+            the combo card's vendor MAC block.
           </p>
         </section>
 
-        <!-- ---- 4. WiFi AP — Dual SSID Configuration ---- -->
+        <!-- ---- 4. WiFi AP — P2P-GO for Android Auto Wireless ---- -->
         <section>
-          <h2>WiFi AP &mdash; Dual SSID Configuration</h2>
+          <h2>WiFi AP &mdash; P2P-GO for Android Auto Wireless</h2>
 
           <p>
-            The BCM build uses <strong>two SSIDs</strong> on a single physical interface
-            via hostapd BSS (Basic Service Set) support. This allows dedicated networks for
-            Android Auto and general connectivity without a second wireless adapter.
+            Production BCM brings up the AA Wireless hotspot as a <strong>Wi-Fi Direct
+            P2P-GO group</strong>, not a regular hostapd AP. The protocol Android speaks
+            for wireless AA <em>is</em> Wi-Fi Direct internally, so P2P-GO is what the
+            stock car-kits use &mdash; it's protocol-correct, not a workaround. The
+            BCM Python code (<code>src/multimedia/wifi_ap.py:_start_p2p_go</code>) runs
+            <code>wpa_supplicant</code> + <code>wpa_cli p2p_group_add freq=5745
+            persistent</code> on boot.
           </p>
 
           <div class="table-wrap">
             <table>
               <thead>
                 <tr>
+                  <th>Mode</th>
                   <th>SSID</th>
                   <th>Band</th>
                   <th>Purpose</th>
@@ -209,79 +230,100 @@ iw dev</code></pre>
               </thead>
               <tbody>
                 <tr>
-                  <td><code>ALFA_AA</code></td>
-                  <td>5 GHz (channel 36 or 149)</td>
+                  <td><code>p2p_go</code> (default)</td>
+                  <td><code>DIRECT-XX</code> (auto by wpa_supplicant)</td>
+                  <td>5&nbsp;GHz ch149, 80&nbsp;MHz VHT</td>
                   <td>Android Auto wireless &mdash; low latency, high throughput</td>
-                  <td>192.168.44.0/24</td>
+                  <td>10.0.0.0/24</td>
                 </tr>
                 <tr>
-                  <td><code>ALFA_NET</code></td>
-                  <td>2.4 GHz</td>
-                  <td>General connectivity &mdash; phone hotspot relay, SSH access</td>
-                  <td>192.168.45.0/24</td>
+                  <td><code>hostapd</code> (fallback)</td>
+                  <td><code>ALFA</code></td>
+                  <td>5&nbsp;GHz ch149</td>
+                  <td>Alternative if P2P-GO fails (e.g. STA-only firmware)</td>
+                  <td>10.0.0.0/24</td>
+                </tr>
+                <tr>
+                  <td><code>ALFA-NET</code> (optional)</td>
+                  <td><code>ALFA-NET</code></td>
+                  <td>2.4&nbsp;GHz ch6 (USB dongle only)</td>
+                  <td>General connectivity &mdash; SSH, phone hotspot relay</td>
+                  <td>10.0.1.0/24</td>
                 </tr>
               </tbody>
             </table>
           </div>
 
-          <h3>hostapd Configuration</h3>
+          <h3>YAML Configuration (<code>config/bcm_config.yaml</code>)</h3>
+          <pre><code>wifi:
+  enabled: true
+  ssid: ALFA           # used only in hostapd mode; P2P-GO advertises DIRECT-XX
+  password: 87654321
+  mode: p2p_go         # P2P-GO (Wi-Fi Direct) — correct mode for AA Wireless
+  band: a              # 5 GHz
+  channel: 149         # UNII-3, 30 dBm on MT7921 worldwide regdom
+  country: US
+  regdom: US
+  share_internet: true
+  ip: 10.0.0.1
+  netmask: 255.255.255.0
+  dhcp_start: 10.0.0.10
+  dhcp_end: 10.0.0.50
+  alfa_net:
+    enabled: true     # requires second radio (USB WiFi dongle)
+    ssid: ALFA-NET
+    password: AlfaRomeo156
+    channel: 6        # 2.4 GHz
+    country: US</code></pre>
+
           <p>
-            Create or edit <code>/etc/hostapd/hostapd.conf</code>:
+            P2P-GO auto-generates a <code>DIRECT-XX</code> SSID + random WPA2 PSK each
+            boot. <code>wifi_ap.py</code> reads them back from
+            <code>wpa_cli p2p_get_passphrase</code> and writes the real values into
+            <code>wifi.ssid_runtime</code> / <code>wifi.password_runtime</code> so the
+            BT bootstrap hands the phone the right SSID over the AA pairing handshake.
           </p>
 
-          <pre><code>interface=wlan0
-driver=nl80211
+          <div class="box box-warning">
+            <div class="box-title">MT7921 interface_combinations: <code>#{AP, P2P-GO} &le; 1</code></div>
+            <p>
+              MT7921 advertises only one AP-or-GO role per radio. The secondary
+              ALFA-NET SSID cannot share the same PHY as the active P2P-GO group
+              &mdash; <code>_maybe_start_alfa_net()</code> falls back to a USB WiFi
+              dongle, or skips ALFA-NET entirely with a log warning. Verify with
+              <code>iw phy phy1 info | grep -A2 'valid interface combinations'</code>.
+            </p>
+          </div>
 
-# Primary BSS — 5GHz for Android Auto
+          <h3>Static hostapd Fallback</h3>
+          <p>
+            <code>setup-x86.sh</code> writes a 5&nbsp;GHz ch149 hostapd.conf to
+            <code>/etc/hostapd/hostapd.conf</code> and masks the system
+            <code>hostapd.service</code> &mdash; only re-enable it if you flip
+            <code>wifi.mode</code> back to <code>hostapd</code> in YAML.
+            <code>apply-fixes.sh</code> rewrites the same file in place for
+            already-deployed boxes:
+          </p>
+
+          <pre><code>interface=wlp2s0
+driver=nl80211
 ssid=ALFA_AA
+country_code=US
+ieee80211d=1
+ieee80211h=1
 hw_mode=a
-channel=36
+channel=149
 ieee80211n=1
 ieee80211ac=1
-ieee80211ax=1
+ht_capab=[HT40+][SHORT-GI-20][SHORT-GI-40]
+vht_capab=[SHORT-GI-80][MAX-MPDU-11454]
+vht_oper_chwidth=1
+vht_oper_centr_freq_seg0_idx=155
 wpa=2
 wpa_passphrase=AlfaRomeo156
 wpa_key_mgmt=WPA-PSK
 rsn_pairwise=CCMP
-country_code=PL
-
-# Secondary BSS — 2.4GHz general
-bss=wlan0_1
-ssid=ALFA_NET
-wpa=2
-wpa_passphrase=AlfaNet2026
-wpa_key_mgmt=WPA-PSK
-rsn_pairwise=CCMP</code></pre>
-
-          <div class="box box-warning">
-            <div class="box-title">Dual-SSID requires virtual interface support</div>
-            <p>
-              Dual-SSID depends on the MT7921 supporting virtual interfaces. Verify
-              with <code>iw list | grep -A5 "valid interface combinations"</code>.
-              The output should list support for multiple APs. If not supported by
-              your firmware version, fall back to a single SSID
-              (<code>ALFA_AA</code> on 5&nbsp;GHz) and use the phone's mobile hotspot
-              for general internet connectivity.
-            </p>
-          </div>
-
-          <h3>dnsmasq Configuration</h3>
-          <p>
-            Configure DHCP for both interfaces in <code>/etc/dnsmasq.d/bcm-wifi.conf</code>:
-          </p>
-
-          <pre><code>interface=wlan0
-interface=wlan0_1
-bind-interfaces
-dhcp-range=interface:wlan0,192.168.44.10,192.168.44.50,255.255.255.0,24h
-dhcp-range=interface:wlan0_1,192.168.45.10,192.168.45.50,255.255.255.0,24h</code></pre>
-
-          <p>
-            This assigns IPs in the <code>192.168.44.x</code> range for the Android Auto
-            network and <code>192.168.45.x</code> for the general network. The
-            <code>bind-interfaces</code> directive ensures dnsmasq only listens on the
-            specified interfaces, avoiding conflicts with other network services.
-          </p>
+wmm_enabled=1</code></pre>
         </section>
 
         <!-- ---- 5. Bluetooth Setup ---- -->
@@ -356,24 +398,42 @@ dhcp-range=interface:wlan0_1,192.168.45.10,192.168.45.50,255.255.255.0,24h</code
         <section>
           <h2>Verification</h2>
 
-          <h3>WiFi AP</h3>
-          <pre><code># Check hostapd is running
-sudo systemctl status hostapd
+          <h3>Firmware + Driver</h3>
+          <pre><code># Both blobs must exist in /lib/firmware/mediatek/
+ls /lib/firmware/mediatek/ | grep -E 'MT7961|MT7922'
+# expect: BT_RAM_CODE_MT7961_*.bin, WIFI_MT7961_patch_mcu_*.bin, WIFI_RAM_CODE_MT7961_*.bin
 
-# Verify AP mode on wlan0
-iw dev wlan0 info  # should show type AP
+# Driver load sequence in dmesg
+sudo dmesg | grep -E 'mt7921|btmtk' | grep -iE 'firmware|version|hardware'
+# expect: "WM Firmware Version: ..." and "Device setup in ... usecs"</code></pre>
 
-# List connected clients
-iw dev wlan0 station dump</code></pre>
+          <h3>WiFi (P2P-GO mode)</h3>
+          <pre><code># Confirm BCM created the P2P group
+iw dev
+# expect:
+#   Interface p2p-wlp2s0-0
+#     type P2P-GO
+#     channel 149 (5745 MHz), width: 80 MHz, center1: 5775 MHz
+#     ssid DIRECT-XX
+
+# Verify worldwide regdom opened UNII-3 at full power
+iw phy phy1 info | grep -A1 '5745\|5765\|5785'
+# expect: (30.0 dBm)  not (disabled) and not (no IR)
+
+# Check BCM populated the runtime SSID + PSK for the BT bootstrap
+grep -E 'wifi.ssid_runtime|wifi.password_runtime' /opt/bcm/config/bcm_config.yaml</code></pre>
 
           <h3>Bluetooth</h3>
-          <pre><code># Check BT adapter state
-bluetoothctl show | grep -E "Powered|Discoverable|Pairable"
+          <pre><code># Adapter up, MediaTek HCI 5.2
+hciconfig -a | grep -E 'BD Address|UP RUNNING|HCI Version|Manufacturer'
+# expect: UP RUNNING, HCI Version: 5.2, Manufacturer: MediaTek, Inc.
 
-# Verify BluetoothManager initialized in BCM
-grep "BluetoothManager initialized" /opt/bcm/logs/bcm.log | tail -3
+# Carkit Class-of-Device (0x620420 = AudioVideo / Carkit)
+bluetoothctl show | grep -E 'Powered|Discoverable|Pairable|Class'
+# expect: Class: 0x620420, Powered: yes, Discoverable: yes, Pairable: yes
 
-# List paired devices
+# BCM pairing agent registered + last paired device tracked
+grep -E 'pairing agent registered|BluetoothManager initialized' /opt/bcm/logs/bcm.log | tail -5
 bluetoothctl devices Paired</code></pre>
         </section>
 
@@ -392,34 +452,44 @@ bluetoothctl devices Paired</code></pre>
               </thead>
               <tbody>
                 <tr>
-                  <td>hostapd fails: <code>Channel 36 not allowed</code></td>
-                  <td>Regulatory domain blocks the channel</td>
-                  <td>Set <code>country_code=PL</code> in hostapd.conf and run <code>iw reg set PL</code>. Try channel 149 as an alternative. Verify with <code>iw list | grep -A20 "Frequencies"</code>.</td>
+                  <td><code>mt7921e ... hardware init failed</code> in dmesg</td>
+                  <td><code>firmware-mediatek</code> not installed &mdash; driver loads but firmware blob is missing</td>
+                  <td>Install: <code>apt install firmware-mediatek</code>. Reload: <code>modprobe -r mt7921e; modprobe mt7921e</code>. Verify <code>ls /lib/firmware/mediatek/WIFI_MT7961*</code> finds the blobs.</td>
                 </tr>
                 <tr>
-                  <td>Dual-SSID not working</td>
-                  <td>MT7921 firmware does not support multiple virtual APs</td>
-                  <td>Run <code>iw list | grep -A5 "valid interface combinations"</code>. If only 1 AP is listed, remove the <code>bss=wlan0_1</code> block from hostapd.conf and use a single SSID. Update firmware: <code>apt update &amp;&amp; apt upgrade firmware-mediatek</code>.</td>
+                  <td><code>bluetooth hci0: Failed to load firmware file (-2)</code> + <code>bluetoothctl</code> segfaults</td>
+                  <td>Same root cause as above &mdash; BT side of the combo also needs <code>firmware-mediatek</code></td>
+                  <td>Install <code>firmware-mediatek</code>, then <code>modprobe -r btusb; modprobe btusb</code>. <code>hciconfig hci0 up</code> should bring the BD Address out of <code>00:00:00:00:00:00</code>.</td>
                 </tr>
                 <tr>
-                  <td>Bluetooth not discoverable</td>
-                  <td><code>bcm-bluetooth.service</code> failed or adapter not powered</td>
-                  <td>Check <code>systemctl status bcm-bluetooth</code>. Manually run <code>bluetoothctl power on</code> and <code>bluetoothctl discoverable on</code>. Verify adapter exists with <code>hciconfig -a</code>.</td>
+                  <td><code>p2p_group_add</code> returns FAIL on ch149</td>
+                  <td>System <code>wpa_supplicant.service</code> is holding <code>wlp2s0</code> in <code>type managed</code> via D-Bus &mdash; <code>pkill</code> misses it</td>
+                  <td>Stop the unit first: <code>systemctl stop wpa_supplicant.service</code>. BCM's <code>wifi_ap.py</code> does this automatically when <code>wifi.mode=p2p_go</code>; only relevant for manual testing.</td>
                 </tr>
                 <tr>
-                  <td>Pairing request times out</td>
-                  <td>BCM polling missed the D-Bus signal or agent not registered</td>
-                  <td>Check BCM logs: <code>grep -i "pairing\|agent" /opt/bcm/logs/bcm.log | tail -20</code>. Restart BCM: <code>systemctl restart bcm</code>. Ensure <code>BluetoothManager</code> is enabled in BCM config.</td>
+                  <td>P2P-GO comes up on the wrong frequency</td>
+                  <td>Channel-to-MHz mapping mismatch &mdash; <code>freq=2437</code> = ch6 (2.4&nbsp;GHz), <code>freq=5745</code> = ch149 (5&nbsp;GHz)</td>
+                  <td>Set <code>wifi.channel: 149</code> in YAML for the 80&nbsp;MHz VHT path. <code>wifi_ap.py</code> auto-derives freq: 2.4&nbsp;GHz uses <code>2407+5*ch</code>, 5&nbsp;GHz uses <code>5000+5*ch</code>.</td>
                 </tr>
                 <tr>
-                  <td>No audio over A2DP</td>
-                  <td>PipeWire not routing BT audio to the DAC</td>
-                  <td>Check PipeWire status: <code>wpctl status</code>. Ensure the BT source is connected: <code>pactl list sources short</code>. Restart PipeWire: <code>systemctl --user restart pipewire wireplumber</code>.</td>
+                  <td>ALFA-NET not broadcasting alongside AA Wireless</td>
+                  <td>MT7921's <code>interface_combinations</code> advertises <code>#{AP, P2P-GO} &le; 1</code> &mdash; one AP role per radio</td>
+                  <td>Plug a USB WiFi dongle on a free port. <code>_maybe_start_alfa_net()</code> detects the second PHY and parks ALFA-NET there. Without a dongle, ALFA-NET is unavailable while AA is active.</td>
                 </tr>
                 <tr>
-                  <td>WiFi interface not appearing after reboot</td>
-                  <td>Missing firmware or driver not loaded</td>
-                  <td>Verify firmware installed: <code>dpkg -l firmware-mediatek</code>. Check kernel module: <code>lsmod | grep mt7921</code>. Load manually: <code>modprobe mt7921e</code>. Check dmesg: <code>dmesg | grep mt7921</code>.</td>
+                  <td>Bluetooth not discoverable after boot</td>
+                  <td><code>bcm-bluetooth.service</code> failed, rfkill soft-block, or adapter not powered</td>
+                  <td>Check <code>systemctl status bcm-bluetooth</code>. Unblock: <code>rfkill unblock bluetooth</code>. Power: <code>bluetoothctl power on &amp;&amp; bluetoothctl discoverable on</code>. <code>hciconfig -a</code> should show <code>UP RUNNING</code>.</td>
+                </tr>
+                <tr>
+                  <td>Pairing PIN popup never appears on dashboard</td>
+                  <td>BCM venv missing <code>dbus-python</code> &rarr; D-Bus pairing agent never registers</td>
+                  <td>Recreate venv with system site-packages: <code>python3 -m venv --system-site-packages .venv</code>. Check: <code>grep "pairing agent" /opt/bcm/logs/bcm.log</code>.</td>
+                </tr>
+                <tr>
+                  <td>No audio over A2DP after pairing</td>
+                  <td>PipeWire not routing BT audio, or <code>libspa-0.2-bluetooth</code> missing</td>
+                  <td>Install: <code>apt install libspa-0.2-bluetooth pipewire-audio</code>. Check routing: <code>wpctl status</code>, <code>pactl list sources short</code>. Restart: <code>systemctl --user restart pipewire wireplumber</code>.</td>
                 </tr>
               </tbody>
             </table>

--- a/src/multimedia/bluetooth.py
+++ b/src/multimedia/bluetooth.py
@@ -569,37 +569,12 @@ def _start_pairing_agent() -> bool:
         return False
 
 
-_PREFER_INTERNAL = False
-
-
-def set_prefer_internal(flag: bool) -> None:
-    """Flip vendor-8087 preference. False (default) prefers the USB dongle
-    (working-around the documented M910q tx-timeout); True forces the
-    integrated Intel adapter even when a dongle is present."""
-    global _PREFER_INTERNAL, _PREFERRED_ADAPTER
-    _PREFER_INTERNAL = bool(flag)
-    _PREFERRED_ADAPTER = ""   # force re-resolve
-
-
 def _find_preferred_adapter() -> str:
-    """Find the best BT adapter address for headunit use.
+    """Find the BT adapter address for headunit use.
 
-    Default policy (M910q workaround): the integrated Intel 8087:0a2b
-    (BT 4.2 on paper) is documented-broken — dmesg captures
-    ``command 0xNNNN tx timeout`` → ``Resetting usb device.`` after
-    ~15 minutes uptime, after which the controller disappears from
-    sysfs entirely. So when both the Intel and a USB dongle
-    (CSR/Realtek/Broadcom) are present, prefer the dongle even though
-    it's BT 4.0 — it survives.
-
-    Override policy (``bluetooth.prefer_internal: true`` in YAML):
-    flips the bias so the Intel 8087 is picked even with a dongle
-    present. Pairs with the hci watchdog in BluetoothManager which
-    auto-bounces the Intel adapter on tx-timeout so the user-facing
-    impact of the reset is minimised.
-
-    An explicit ``bluetooth.preferred_adapter`` MAC in config still wins
-    over both policies (lets the user pin a specific controller).
+    With the MT7921 combo card there is only one hci device. An explicit
+    ``bluetooth.preferred_adapter`` MAC in config still wins, in case a
+    USB dongle is added later and the user wants to pin a specific one.
     """
     try:
         result = subprocess.run(
@@ -615,83 +590,6 @@ def _find_preferred_adapter() -> str:
                 controllers.append(parts[1])
         if not controllers:
             return ""
-        if len(controllers) == 1:
-            return controllers[0]
-
-        # Map controller MAC -> hciX via hciconfig output.
-        addr_to_hci: dict[str, str] = {}
-        try:
-            hc = subprocess.run(
-                ["hciconfig"],
-                capture_output=True, text=True, timeout=5.0,
-            )
-            if hc.returncode == 0:
-                current_hci = None
-                for line in hc.stdout.splitlines():
-                    if line and not line[0].isspace() and ":" in line:
-                        current_hci = line.split(":")[0].strip()
-                    if current_hci and "BD Address" in line:
-                        bd = line.split("BD Address:")[1].strip().split()[0]
-                        addr_to_hci[bd] = current_hci
-        except Exception:
-            pass
-
-        # For each hciX, read USB vendor id from sysfs. Intel = 8087 is
-        # the documented-broken radio on this hardware; prefer anything
-        # else. The walk-up loop is needed because hciX/device on USB
-        # combo chips points at the USB *interface*, and idVendor lives
-        # one or two parents up at the USB device node.
-        import os as _os
-
-        def _hci_index(addr: str) -> int:
-            hci = addr_to_hci.get(addr, "hci999")
-            try:
-                return int(hci[3:])
-            except ValueError:
-                return 999
-
-        intel: list[str] = []
-        non_intel: list[str] = []
-        for addr in controllers:
-            hci = addr_to_hci.get(addr)
-            if not hci:
-                continue
-            try:
-                base = _os.path.realpath(f"/sys/class/bluetooth/{hci}/device")
-                vendor = ""
-                cur = base
-                for _ in range(4):
-                    vpath = _os.path.join(cur, "idVendor")
-                    if _os.path.isfile(vpath):
-                        with open(vpath) as f:
-                            vendor = f.read().strip().lower()
-                        break
-                    parent = _os.path.dirname(cur)
-                    if parent == cur:
-                        break
-                    cur = parent
-                if vendor == "8087":
-                    intel.append(addr)
-                elif vendor:
-                    non_intel.append(addr)
-            except Exception:
-                pass
-
-        if _PREFER_INTERNAL and intel:
-            intel.sort(key=_hci_index)
-            log.info("BT: preferring INTERNAL Intel 8087 adapter %s "
-                     "(prefer_internal=true) — %d controllers seen",
-                     intel[0], len(controllers))
-            return intel[0]
-
-        if non_intel:
-            non_intel.sort(key=_hci_index)
-            log.info("BT: preferring non-Intel adapter %s (USB dongle) over "
-                     "internal Intel — %d controllers seen",
-                     non_intel[0], len(controllers))
-            return non_intel[0]
-        # Only Intel(s) available — use the lowest-index one.
-        controllers.sort(key=_hci_index)
         return controllers[0]
     except Exception:
         pass
@@ -803,17 +701,6 @@ class BluetoothManager:
         # Disconnect tap doesn't immediately bring the device back.
         # Cleared on connect() and on remove().
         self._user_disconnect_addr: Optional[str] = None
-
-        # Force internal Intel 8087 (overrides default "prefer USB dongle"
-        # bias) — paired with the hci watchdog that bounces the adapter
-        # on tx-timeout.
-        try:
-            prefer_internal = bool(config.get("bluetooth.prefer_internal", False))
-        except Exception:
-            prefer_internal = False
-        if prefer_internal:
-            set_prefer_internal(True)
-            log.info("BT: prefer_internal=true — using integrated Intel adapter")
 
         # Optional explicit adapter override from config — pin a specific
         # USB BT dongle MAC if auto-detect picks the wrong one.
@@ -1484,63 +1371,6 @@ class BluetoothManager:
         self._start_media_monitor()
         # Register HFP call command handlers
         self._init_hfp_commands()
-        # Watchdog for the documented Intel 8087 tx-timeout — only
-        # engaged when the user has asked for the internal adapter.
-        if _PREFER_INTERNAL:
-            threading.Thread(
-                target=self._hci_watchdog, daemon=True, name="bt-hci-watchdog",
-            ).start()
-
-    def _hci_watchdog(self) -> None:
-        """Recover from Intel 8087 tx-timeout by bouncing the hci device.
-
-        Only runs when ``bluetooth.prefer_internal`` is set. dmesg shows
-        ``command 0x… tx timeout`` followed by ``Resetting usb device.``
-        after which BlueZ stops reporting the controller. ``hciconfig
-        hciX down/up`` restores it without a kernel-level USB reset.
-        """
-        miss = 0
-        while self._running:
-            time.sleep(15)
-            if not self._available:
-                continue
-            rc, out, _ = _run_btctl(["show"])
-            if rc == 0 and "Controller" in out:
-                miss = 0
-                continue
-            miss += 1
-            if miss < 2:
-                continue
-            # Two consecutive misses → controller gone. Find the hci by
-            # the adapter address we resolved and bounce it.
-            addr = _get_adapter_addr()
-            hci = None
-            try:
-                hc = subprocess.run(
-                    ["hciconfig"], capture_output=True, text=True, timeout=3,
-                )
-                current = None
-                for line in hc.stdout.splitlines():
-                    if line and not line[0].isspace() and ":" in line:
-                        current = line.split(":")[0].strip()
-                    if current and addr and addr in line:
-                        hci = current
-                        break
-            except Exception:
-                pass
-            if not hci:
-                hci = "hci0"
-            log.warning("BT hci watchdog: controller missing — bouncing %s", hci)
-            for cmd in (["rfkill", "unblock", "bluetooth"],
-                        ["hciconfig", hci, "down"],
-                        ["hciconfig", hci, "up"]):
-                try:
-                    subprocess.run(cmd, capture_output=True, timeout=4)
-                except Exception:
-                    pass
-            time.sleep(2)
-            self._check_availability()
-            miss = 0
 
     def stop_monitor(self) -> None:
         """Stop the connection monitor."""

--- a/src/multimedia/openauto.py
+++ b/src/multimedia/openauto.py
@@ -194,7 +194,7 @@ TouchscreenHeight={height}
 [WiFi]
 SSID={ssid}
 Password={password}
-MAC={wifi_mac}
+AdapterMAC={wifi_mac}
 """
     with open(config_path, "w") as f:
         f.write(config_content)

--- a/src/multimedia/wifi_ap.py
+++ b/src/multimedia/wifi_ap.py
@@ -120,10 +120,10 @@ class WiFiAPManager:
         self._dnsmasq_proc: Optional[subprocess.Popen] = None
         self._wpa_proc: Optional[subprocess.Popen] = None
         # Secondary AP ("ALFA-NET" internet share) — only spun up when
-        # the radio admits two concurrent VIFs (Intel 8265 typically
-        # supports one P2P-GO + one AP at the same time on the same
-        # channel). On phys that reject the combo we fall back to
-        # time-multiplexing.
+        # the radio admits two concurrent VIFs. On phys that reject the
+        # combo (MT7921 and most consumer chips advertise
+        # `#{AP, P2P-GO} <= 1`) we fall back to time-multiplexing or a
+        # USB dongle.
         self._net_iface: Optional[str] = None
         self._net_hostapd_proc: Optional[subprocess.Popen] = None
         self._net_dnsmasq_proc: Optional[subprocess.Popen] = None
@@ -255,14 +255,11 @@ class WiFiAPManager:
                 capture_output=True, timeout=5,
             )
 
-            # Default to 2.4 GHz channel 6. The Intel 8265 firmware
-            # rejects every 5 GHz frequency under country=PL with
-            # "Frequency NNNN not allowed for AP mode, flags: NO-IR"
-            # — both UNII-3 ch149 and UNII-1 ch36/40/44/48 fail. 2.4 GHz
-            # ch1/6/11 always works and AA Wireless H.264 video runs
-            # fine over 802.11n 40 MHz on 2.4 GHz.
-            channel = self._config.get("wifi.channel", 6)
-            band = self._config.get("wifi.band", "bg")
+            # MT7921 exposes UNII-3 at 30 dBm under the firmware-mediatek
+            # worldwide regdom, so default to 5 GHz ch149 for AA Wireless
+            # throughput. wifi.channel/band in YAML override per-deploy.
+            channel = self._config.get("wifi.channel", 149)
+            band = self._config.get("wifi.band", "a")
             result = subprocess.run(
                 [
                     "nmcli", "device", "wifi", "hotspot",
@@ -550,27 +547,19 @@ class WiFiAPManager:
     def _start_hostapd(self) -> bool:
         """Generate hostapd config and start the daemon.
 
-        Verbatim from the user's tested known-good config for the M910q
-        Intel 7265 — extras like ieee80211d/wmm_enabled/macaddr_acl have
-        repeatedly broken broadcast on this card, while this exact set
-        comes up first try.
-
         When ``wifi.alfa_net.enabled`` is true, appends a second BSS
         section so hostapd broadcasts BOTH ``ALFA`` and ``ALFA-NET`` on
-        the same channel from the same radio — Intel 8265's
+        the same channel from the same radio — MT7921's
         interface_combinations rejects AP+P2P-GO concurrent but allows
         multi-BSS within a single AP role.
         """
         config_path = os.path.join(RUNTIME_DIR, "hostapd.conf")
         # Channel/band/country are sourced from wifi.* in the YAML so the
         # BCM-internal AP path stays in sync with what setup-x86.sh wrote
-        # to /etc/hostapd/hostapd.conf — defaults are 2.4 GHz ch6,
-        # hw_mode=g, country=PL. The Intel 8265 firmware rejects every
-        # 5 GHz frequency under PL regdom (NO-IR), so 5 GHz isn't usable
-        # on this hardware regardless of how non-DFS the channel is.
-        channel = self._config.get("wifi.channel", 6)
-        hw_mode = self._config.get("wifi.band", "g")
-        country = self._config.get("wifi.country", "PL")
+        # to /etc/hostapd/hostapd.conf.
+        channel = self._config.get("wifi.channel", 149)
+        hw_mode = self._config.get("wifi.band", "a")
+        country = self._config.get("wifi.country", "US")
         is_5ghz = hw_mode == "a"
         config_content = (
             f"interface={self._interface}\n"
@@ -633,9 +622,9 @@ class WiFiAPManager:
         with open(config_path, "w") as f:
             f.write(config_content)
 
-        # Unblock rfkill before hostapd — the radio comes up soft-blocked
-        # on the M910q at cold boot and hostapd reports rc=0 on a blocked
-        # interface, just never broadcasts.
+        # Unblock rfkill before hostapd — the radio can come up soft-blocked
+        # at cold boot and hostapd reports rc=0 on a blocked interface,
+        # just never broadcasts.
         try:
             subprocess.run(["rfkill", "unblock", "wifi"],
                            capture_output=True, timeout=3)
@@ -671,19 +660,19 @@ class WiFiAPManager:
         if _launch(config_path):
             return True
 
-        # Multi-BSS failure recovery: iwlwifi 8265's interface_combinations
-        # admits exactly ONE AP role on this radio (`#{AP, P2P-client,
-        # P2P-GO} <= 1`), so the `bss=` secondary trips
-        # "Could not set interface wlp2s0_net flags (UP): Device or
+        # Multi-BSS failure recovery: the driver may admit only ONE AP
+        # role on this radio (MT7921's interface_combinations advertises
+        # `#{AP, P2P-GO} <= 1`), so the `bss=` secondary trips
+        # "Could not set interface ..._net flags (UP): Device or
         # resource busy". If we asked for ALFA-NET and the dual-BSS
         # launch failed, retry single-BSS so the primary ALFA still
         # comes up; ALFA-NET is unavailable on this hardware without
         # a second radio (USB dongle).
         if self._net_iface and self._config.get("wifi.alfa_net.enabled", True):
-            log.warning("Multi-BSS rejected by iwlwifi (8265 admits 1 AP "
-                        "only) — retrying ALFA single-BSS without "
-                        "ALFA-NET. Plug a USB WiFi dongle to get the "
-                        "second SSID concurrently.")
+            log.warning("Multi-BSS rejected by driver (single AP only) — "
+                        "retrying ALFA single-BSS without ALFA-NET. Plug "
+                        "a USB WiFi dongle to get the second SSID "
+                        "concurrently.")
             single_bss = config_content.split("\n# Secondary BSS")[0]
             with open(config_path, "w") as f:
                 f.write(single_bss)
@@ -822,11 +811,8 @@ class WiFiAPManager:
 
         Channel is config-driven (``wifi.channel``). The AA Wireless
         protocol the phone speaks is Wi-Fi Direct internally, so P2P-GO
-        is the natural mode. The Intel 8265 self-managed regdom blocks
-        regular AP role on 5 GHz with NO-IR; P2P-GO sidesteps that on
-        2.4 GHz where the firmware accepts active TX. 5 GHz P2P-GO
-        also FAILs under self-managed country 00 — patch regdb if you
-        need it.
+        is the natural mode. MT7921 accepts P2P-GO on UNII-3 (ch149+)
+        out of the box with the worldwide regdom in firmware-mediatek.
         """
         # Make sure NetworkManager isn't holding the interface — wpa_s
         # P2P refuses to bind otherwise.
@@ -837,11 +823,11 @@ class WiFiAPManager:
             )
             time.sleep(0.3)
 
-        # Best-effort regdom kick. User waived country compliance so we
-        # try a country that the iwlwifi 8265 firmware admits is OK on
-        # ch149 (BO/JP/IN have historically worked). `iw reg set` is a
-        # no-op on self-managed PHYs but costs nothing to attempt.
-        regdom = self._config.get("wifi.regdom", "BO")
+        # Set regdom so the country code propagates into the P2P-GO
+        # beacon. MT7921 honours `iw reg set`; the worldwide default
+        # already exposes ch149 at 30 dBm but explicit US/PL keeps the
+        # country IE consistent across reboots.
+        regdom = self._config.get("wifi.regdom", "US")
         for cmd in (["rfkill", "unblock", "wifi"],
                     ["rfkill", "unblock", "all"],
                     ["iw", "reg", "set", regdom]):
@@ -924,9 +910,7 @@ class WiFiAPManager:
         # Start a persistent P2P group. Channel→freq mapping differs
         # between bands: 2.4 GHz ch1-13 uses 2407+5*N (and ch14 is the
         # special-case 2484 MHz for JP), while 5 GHz uses 5000+5*N.
-        # Picking the wrong formula sends ch6 to 5030 MHz which is
-        # NO-IR on the Intel 8265 firmware — silent `p2p_group_add: FAIL`.
-        channel = int(self._config.get("wifi.channel", 6))
+        channel = int(self._config.get("wifi.channel", 149))
         if channel <= 14:
             freq = 2484 if channel == 14 else 2407 + 5 * channel
         else:
@@ -1092,10 +1076,10 @@ class WiFiAPManager:
              exists (USB dongle), park ALFA-NET there.
           2. **Concurrent VIF on same phy** — iw add interface __ap;
              only succeeds when the driver advertises an AP/GO + AP
-             combination. iwlwifi 8265 advertises ``#{AP, P2P-GO} <= 1``
-             which means it does NOT — adding an AP VIF on the same
-             PHY as an active P2P-GO group collapses the GO. The
-             concurrent-VIF check below catches that and skips.
+             combination. MT7921 advertises ``#{AP, P2P-GO} <= 1`` so
+             adding an AP VIF on the same PHY as an active P2P-GO
+             group collapses the GO. The concurrent-VIF check below
+             catches that and skips.
           3. **Skip** — log a warning and require a USB dongle for
              ALFA-NET. Time-multiplexing is intentionally NOT done
              here because the AA P2P-GO group is the primary mission
@@ -1147,18 +1131,17 @@ class WiFiAPManager:
                 self._net_iface = candidate
                 return
 
-        # Path 2: concurrent VIF on same PHY. Intel 8265's
-        # interface_combinations advertises `#{AP, P2P-GO} <= 1`, so
-        # adding an AP VIF while a P2P-GO group is active will
-        # silently collapse the GO. The `iw phy ... interface add`
-        # command often returns rc=0 anyway, then hostapd starts and
-        # knocks AA off the air. Skip this path entirely when the
-        # primary is p2p_go to keep AA up.
+        # Path 2: concurrent VIF on same PHY. MT7921 (and most consumer
+        # chips) advertise `#{AP, P2P-GO} <= 1` in interface_combinations,
+        # so adding an AP VIF while a P2P-GO group is active will silently
+        # collapse the GO. The `iw phy ... interface add` command often
+        # returns rc=0 anyway, then hostapd starts and knocks AA off the
+        # air. Skip this path entirely when the primary is p2p_go.
         if self._method == "p2p_go":
             log.warning(
-                "ALFA-NET disabled — primary AP is P2P-GO and the "
-                "Intel 8265 PHY can't host AA + ALFA-NET concurrently. "
-                "Plug a USB WiFi dongle for ALFA-NET."
+                "ALFA-NET disabled — primary AP is P2P-GO and the PHY "
+                "can't host AA + ALFA-NET concurrently. Plug a USB WiFi "
+                "dongle for ALFA-NET."
             )
             return
 
@@ -1213,7 +1196,7 @@ class WiFiAPManager:
         # 2.4 GHz ch6 — works everywhere, doesn't share the main 5 GHz
         # frequency unless the radio forces it.
         channel = int(self._config.get("wifi.alfa_net.channel", 6))
-        country = self._config.get("wifi.alfa_net.country", "BO")
+        country = self._config.get("wifi.alfa_net.country", "US")
         conf = (
             f"interface={iface}\n"
             f"driver=nl80211\n"


### PR DESCRIPTION
## Summary
- Hardware swap: Intel 8265 (WiFi) + 8087 (BT) **out**, MediaTek MT7921 M.2 combo (PCIe `[14c3:7961]` WiFi 6 + USB `[0489:e0cd]` BT 5.2) **in**.
- Drops all the Intel-specific workarounds (8087 tx-timeout udev/unbind/watchdog, 8265 self-managed regdom NO-IR fallback to ch6).
- Defaults flip to **5GHz ch149 P2P-GO @ 80MHz VHT** — what AA Wireless actually wants — because MT7921 accepts it first try with the worldwide regdom in `firmware-mediatek`.

## Live verification on target hardware
- `dmesg` shows `mt7921e ... WM Firmware Version: ____010000` + `Bluetooth: hci0: Device setup in 3333436 usecs` after `apt install firmware-mediatek`.
- `iw phy phy1 info` reports ch149 at **30 dBm** (no NO-IR, no IR-CONCURRENT).
- `wpa_cli p2p_group_add freq=5745 persistent` → OK, `iw dev` shows `Interface p2p-wlp2s0-0, type P2P-GO, channel 149 (5745 MHz), width: 80 MHz, center1: 5775 MHz`.
- `hciconfig -a` reports `UP RUNNING`, `HCI Version: 5.2`, `Manufacturer: MediaTek, Inc.` after the firmware install.
- MT7921 still advertises `#{AP, P2P-GO} <= 1` in interface_combinations, so the single-BSS fallback + same-PHY VIF guard for ALFA-NET are **kept** (ALFA-NET concurrent with AA Wireless still needs a USB dongle).

## Files changed (9 total, +373/−592 — net deletion)
- `config/scripts/setup-x86.sh` — `firmware-iwlwifi` → `firmware-mediatek`; default ch149/VHT80 hostapd; cleanup of Intel-disable artifacts.
- `config/scripts/apply-fixes.sh` — same hostapd rewrite + cleanup for already-deployed boxes.
- `config/scripts/bcm-bluetooth-setup.sh` — drop the 50-line `vendor==8087` sysfs unbind loop and the prefer-non-Intel adapter selection branch.
- `src/multimedia/bluetooth.py` — drop `set_prefer_internal()`, `_PREFER_INTERNAL`, the `vendor=="8087"` hardcode in `_find_preferred_adapter()`, and the `_hci_watchdog()` Intel-tx-timeout recovery thread (~180 lines gone).
- `src/multimedia/wifi_ap.py` — defaults to 5GHz ch149; comments cleaned of Intel-specific explanations; ALFA-NET fallback logic generalised but **kept** (still correct for MT7921).
- `config/bcm_config.yaml` + `config/bcm_config_opi_pc.yaml` — `wifi: band=a, channel=149, country=US, regdom=US`; drop `bluetooth.prefer_internal`.
- `docs/x86-production/08-wifi-bt.html` + `docs/X86_PLATFORM_SETUP.md` — rewritten for MT7921: install steps (firmware-mediatek for both radios), P2P-GO production path, live verification commands, troubleshooting matched to actual dmesg failure modes.

## Test plan
- [ ] Reboot the unit and confirm `wlp2s0` + `hci0` come up without manual intervention (no `hardware init failed` in dmesg)
- [ ] Confirm BCM brings the AA Wireless P2P-GO group up on ch149 — `iw dev` shows `p2p-wlp2s0-0` type `P2P-GO` at 80MHz width
- [ ] Pair a phone over BT, verify CoD = `0x620420` and AA Wireless launches (BT bootstrap hands phone the runtime SSID/PSK)
- [ ] Verify A2DP audio + HFP call routing still work
- [ ] No regressions in splash boot timing, AA Wireless reconnect, or LTE NAT

🤖 Generated with [Claude Code](https://claude.com/claude-code)