### PR TITLE
Replace the DIY TDA amplifier chain with an off-the-shelf car amplifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ BCM v8.5 — custom head unit for Alfa Romeo 156 1.9 JTD 8V, built on a
 **Lenovo ThinkCentre M910q Tiny** (x86) with a buffered 12 V SLA supply.
 
 - Body computer functions (fuel consumption, fuel level, temperatures, weather, service notifications)
-- 4.1 audio system with 10-band EQ, spectrum visualizer (ES9038Q2M DAC + TDA7388 amp)
+- 4-channel audio with 10-band EQ and spectrum visualizer — ES9038Q2M USB DAC
+  into an off-the-shelf car amplifier fed straight from the starter battery
 - Dual DVR (front + rear) + 4-camera auto-switching (reverse, blinkers)
 - Ultrasonic parking sensors with buzzer
 - Android Auto (kiosk mode, integrated in dashboard)

--- a/config/bcm_config.yaml
+++ b/config/bcm_config.yaml
@@ -107,8 +107,10 @@ audio:
   balance: 0
   spectrum_enabled: true
   dac: ES9038Q2M
-  amp_main: TDA7388
-  amp_sub: TDA2050
+  # Opisowe, nieczytane przez kod. Wzmacniacz to gotowy moduł samochodowy
+  # na osobnej gałęzi 12 V — patrz docs/ZASILANIE_BUFOROWANE.md § 2.
+  amp_main: car-amp-4ch
+  amp_sub: none
   mic_phone: ''
   voice_duck_pct: 40
   voice_listen_sec: 8

--- a/docs/SCHEMATY_POLACZEN.md
+++ b/docs/SCHEMATY_POLACZEN.md
@@ -174,18 +174,31 @@ dioda TVS 1.5KE33CA równolegle oraz kondensator 470 µF / 35 V równolegle.
 > przetwornicy **nie da się użyć jako wyłącznika** komputera: boost przepuszcza
 > napięcie wejściowe, więc odcina wyłącznie przekaźnik zapłonu (poz. 32).
 
-### 2.6 Gałąź wzmacniaczy (niezależna)
+### 2.6 Gałąź wzmacniacza (niezależna)
+
+Wzmacniacz to **gotowy moduł samochodowy** z wejściami RCA, nie układ DIY.
+Podłącza się go jak radio samochodowe: zasilanie wprost z akumulatora, własna
+masa, wyzwalanie sygnałem REM.
 
 | # | Skąd | Dokąd | Przewód | Zabezpieczenie |
 |---|------|-------|---------|----------------|
-| 44 | Akumulator „+” | TDA7388 **+12V** | 4 mm² | 20 A przy klemie |
-| 45 | TDA7388 **GND** | masa lokalna, przy wzmacniaczu | 4 mm² | — |
-| 46 | Przekaźnik **87** | TDA7388 **REM/standby** | 0,5 mm² | przez 1 kΩ |
-| 47 | TDA7388 **+12V** | TDA2050 **+12V** | 2,5 mm² | wspólny z poz. 44 |
+| 44 | Akumulator „+” | Wzmacniacz **+12V** | 6 mm² | wg karty modułu, przy klemie |
+| 45 | Wzmacniacz **GND** | masa lokalna, przy wzmacniaczu | 6 mm² | — |
+| 46 | Przekaźnik **87** | Wzmacniacz **REM** | 0,75 mm² | 2 A |
 
-> **Masa wzmacniaczy osobno.** To jedyny obwód, który **nie** idzie do
+> **Bezpiecznik dobierz wg karty wzmacniacza**, nie „na oko". Typowy moduł
+> 4 × 50 W RMS ma na płytce bezpiecznik 20–30 A i tyle samo powinien mieć
+> przy klemie. Przewód 6 mm² wynika ze spadku napięcia na trasie do bagażnika
+> (~4 m), nie z samego prądu.
+
+> **Masa wzmacniacza osobno.** To jedyny obwód mocy, który **nie** idzie do
 > punktu gwiazdowego — wspólna masa z komputerem daje pętlę i przydźwięk
-> alternatora.
+> alternatora. Masa krótka (do 1 m), do gołego metalu, tym samym przekrojem
+> co „+”.
+
+> **REM bez rezystora szeregowego.** Wejście REM gotowego wzmacniacza jest
+> wysokoomowe (10–20 kΩ) i ma własne wyciszanie startu — rezystor 1 kΩ był
+> potrzebny tylko przy płytce DIY.
 
 ---
 
@@ -357,15 +370,27 @@ z wykryciem ekranu.
 
 | Skąd | Dokąd | Kabel |
 |------|-------|-------|
-| DAC **RCA L/R** | TDA7388 **IN1–IN4** | RCA ekranowany |
-| DAC **RCA L/R** | TDA2050 **IN** (suma L+R) | RCA ekranowany |
-| TDA7388 **CH1** | głośnik przód lewy (4 Ω) | 1,5 mm² |
-| TDA7388 **CH2** | głośnik przód prawy | 1,5 mm² |
-| TDA7388 **CH3** | głośnik tył lewy | 1,5 mm² |
-| TDA7388 **CH4** | głośnik tył prawy | 1,5 mm² |
-| TDA2050 **OUT** | subwoofer (4 Ω, bagażnik) | 2,5 mm² |
+| DAC **RCA L/R** | Wzmacniacz, wejścia RCA przód | RCA ekranowany |
+| DAC **RCA L/R** | Wzmacniacz, wejścia RCA tył (rozgałęźnik Y) | RCA ekranowany |
+| Wzmacniacz **CH1** | głośnik przód lewy (4 Ω) | 1,5 mm² |
+| Wzmacniacz **CH2** | głośnik przód prawy | 1,5 mm² |
+| Wzmacniacz **CH3** | głośnik tył lewy | 1,5 mm² |
+| Wzmacniacz **CH4** | głośnik tył prawy | 1,5 mm² |
 
-Zasilanie i REM wzmacniaczy — §2.6.
+Zasilanie i REM — §2.6.
+
+> **Kabel RCA prowadź po przeciwnej stronie auta niż kabel zasilania
+> wzmacniacza.** Równoległy przebieg to najprostszy sposób na przydźwięk.
+
+> **Pętla masy.** DAC ma masę przez USB (punkt gwiazdowy pod deską),
+> wzmacniacz ma masę lokalną w bagażniku, a ekran RCA łączy oba punkty.
+> Jeżeli słychać buczenie zmieniające się z obrotami silnika: najpierw popraw
+> masę wzmacniacza, potem przetrasuj RCA, i dopiero na końcu sięgaj po
+> izolator pętli masy — pogarsza pasmo.
+
+**Ustawienie wzmocnienia:** głośność systemu ~75 %, EQ płasko, gain
+wzmacniacza na minimum; podnoś do pierwszych zniekształceń i cofnij o krok.
+Bez subwoofera włącz filtr górnoprzepustowy ok. 80 Hz na wszystkich kanałach.
 
 ### 5.5 Kamery
 
@@ -386,7 +411,7 @@ brak**. Sygnały wyzwalające wchodzą przez PC817 na Nano #2.
 | Wartość | Gdzie | Chroni |
 |---------|-------|--------|
 | 30 A | przy klemie „+”, ≤ 30 cm | cały tor główny |
-| 20 A | przy klemie „+”, osobno | gałąź wzmacniaczy |
+| wg karty modułu (20–30 A) | przy klemie „+”, osobno | gałąź wzmacniacza |
 | 10 A × 5 | na „+” każdego pakietu banku | zwarcie pojedynczego pakietu |
 | 30 A | listwa, obwód 2 | domena B |
 | 5 A | wyjście step-up, przed wtykiem | M910q |
@@ -399,7 +424,7 @@ brak**. Sygnały wyzwalające wchodzą przez PC817 na Nano #2.
 
 Wszystkie w listwie dystrybucyjnej ATO/ATC z pokrywą, w miejscu dostępnym
 bez demontażu deski rozdzielczej. Wyjątek: bezpiecznik główny 30 A i 20 A
-gałęzi wzmacniaczy — w oprawkach przy klemie akumulatora.
+gałęzi wzmacniacza — w oprawkach przy klemie akumulatora.
 
 ---
 
@@ -415,7 +440,7 @@ gałęzi wzmacniaczy — w oprawkach przy klemie akumulatora.
 
 **Dwa wyjątki:**
 
-1. **Masa wzmacniaczy** — osobno, blisko wzmacniaczy. Wspólna z komputerem
+1. **Masa wzmacniacza** — osobno, blisko wzmacniacza. Wspólna z komputerem
    daje pętlę masy i przydźwięk alternatora.
 2. **Masa pojazdu po stronie PC817** — celowo odizolowana od masy Arduino.
    To sens optoizolacji.

--- a/docs/WDROZENIE_M910Q.md
+++ b/docs/WDROZENIE_M910Q.md
@@ -121,8 +121,8 @@ wspornik. Wszystkie kable spinaj opaskami, bo na dziurach będzie grzechotać.
 | 5 | Wyświetlacz mały | 4,3" TFT 800×480 HDMI, bez dotyku | 1 | 150–250 |
 | 6 | Przejściówki DP → HDMI | pasywne, kablowe | 2 | 20–30 |
 | 7 | DAC USB | ES9038Q2M, wyjście RCA | 1 | 45–75 |
-| 8 | Wzmacniacz | TDA7388 (4 × 45 W klasa AB) | 1 | 45–70 |
-| 9 | Radiator | aluminiowy do TDA7388 | 1 | 10–15 |
+| 8 | Wzmacniacz | **gotowy 4-kanałowy samochodowy**, wejścia RCA, klasa D, 4 × 50–75 W RMS | 1 | 250–600 |
+| 9 | Kabel zasilający wzmacniacza | 6 mm² + oprawka bezpiecznika przy klemie | kpl. | 40–80 |
 | 10 | Interfejs K-Line | CP2102 (USB-UART) + L9637D + rezystor 510 Ω | 1 | 25–40 |
 | 11 | Hub USB | 7-portowy USB 3.0 **z własnym zasilaniem** | 1 | 40–60 |
 | 12 | Kable | 2× DP-HDMI, USB-A, zasilanie, RCA | — | 50–80 |
@@ -748,8 +748,12 @@ journalctl -u bcm-headunit | grep -i openauto
 
 ## 14. Audio
 
-Tor: **ES9038Q2M (DAC USB) → RCA → TDA7388 (4 × 45 W) + TDA2050 (subwoofer)
-→ układ 4.1**. Schemat: [`../schematics/audio_system.svg`](../schematics/audio_system.svg).
+Tor: **ES9038Q2M (DAC USB) → RCA → gotowy wzmacniacz samochodowy →
+głośniki 4 Ω**. Schemat: [`../schematics/audio_system.svg`](../schematics/audio_system.svg).
+
+Wzmacniacz to **kupiony moduł samochodowy**, nie układ DIY: 4 kanały,
+wejścia RCA, klasa D, 4 × 50–75 W RMS na 4 Ω. Podłączany jak radio —
+zasilanie wprost z akumulatora rozruchowego, własna masa, wyzwalanie REM.
 
 Software: PipeWire + WirePlumber, 10-pasmowy EQ, analizator widma, ducking
 (`src/audio/`). Profil EQ: `config/pipewire/eq-profile.json`.
@@ -759,13 +763,19 @@ Bluetooth: profil HFP przez oFono (`config/systemd/ofono.service.d/`,
 BR/EDR (`config/scripts/bt-prefer-bredr.sh`) — BLE-only powodowało problemy
 z parowaniem telefonów.
 
-> **Zasilanie wzmacniaczy idzie osobną gałęzią** prosto z akumulatora
-> rozruchowego (bezpiecznik 20 A), **nie z banku buforowego** — patrz
-> [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) §2. TDA7388 klasy AB
-> ciągnie 6–8 A przy średniej głośności, do 20 A w szczytach.
+> **Zasilanie wzmacniacza idzie osobną gałęzią** prosto z akumulatora
+> rozruchowego (bezpiecznik wg karty modułu, zwykle 20–30 A), **nie z banku
+> buforowego** — patrz [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) §2.
+> Szczyty 20–30 A rozłożyłyby bank AGM w kilkanaście minut i przekroczyły
+> przekaźnik LVD.
 
-Masę wzmacniaczy prowadź osobno, blisko wzmacniaczy — wspólna masa
+Z systemem buforowanym łączy wzmacniacz wyłącznie **sygnał REM z zacisku 87
+i ekran kabla RCA**. Masę prowadź lokalnie, przy wzmacniaczu — wspólna masa
 z komputerem daje pętlę i przydźwięk alternatora.
+
+Kabel RCA prowadź **po przeciwnej stronie auta niż kabel zasilania**.
+Kolejność diagnozy przy buczeniu i procedura ustawiania wzmocnienia:
+[`SCHEMATY_POLACZEN.md`](SCHEMATY_POLACZEN.md) §5.4.
 
 ---
 
@@ -961,7 +971,22 @@ Liczba w `X86_PLATFORM_SETUP.md` § 2.3 pochodzi z pełnego rozładowania banku,
 mimo adnotacji o ograniczeniu do 50 % DoD. Poprawione wartości:
 [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) §9.2.
 
-### 19.5 Limit poboru CPU jest wymagany, nie opcjonalny
+### 19.5 Tor audio: gotowy wzmacniacz zamiast układów TDA
+
+Projekt rezygnuje z budowania wzmacniacza na TDA7388 + TDA2050 na rzecz
+**gotowego 4-kanałowego wzmacniacza samochodowego** z wejściami RCA,
+zasilanego wprost z akumulatora rozruchowego i odseparowanego od systemu
+buforowanego (§14, [`../schematics/audio_system.svg`](../schematics/audio_system.svg)).
+
+Dokumenty źródłowe wciąż pokazują starą ścieżkę DIY:
+`x86-production/01-bom.html`, `02-assembly.html`, `10-power-suspend.html`,
+`index.html` oraz `bcm_v85_docs.html`. Zostają jako referencja historyczna;
+**obowiązuje opis z §14 i schemat toru audio**.
+
+Po stronie software'u nic się nie zmienia — PipeWire widzi wyłącznie DAC USB,
+a co jest za gniazdem RCA, jest dla niego niewidoczne.
+
+### 19.6 Limit poboru CPU jest wymagany, nie opcjonalny
 
 Zasilanie M910q idzie przez posiadany moduł **XL6019**, którego realna
 obciążalność to ok. **45 W** (limit prądu klucza 5 A), a nie 65 W ze znamionowej
@@ -969,7 +994,7 @@ mocy zasilacza. Usługa `bcm-power-cap` ograniczająca pakiet CPU do 28 W jest
 częścią wdrożenia, nie optymalizacją — instrukcja w
 [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) §3.5a.
 
-### 19.6 Nazewnictwo jednostki `bcm-headunit.service`
+### 19.7 Nazewnictwo jednostki `bcm-headunit.service`
 
 Plik `config/systemd/bcm-headunit.service` był **wariantem Orange Pi PC**,
 mimo neutralnej nazwy. Został zarchiwizowany jako

--- a/docs/X86_PLATFORM_SETUP.md
+++ b/docs/X86_PLATFORM_SETUP.md
@@ -75,7 +75,7 @@ M910q USB ports
   │     ├── USB GPS (NEO-M8N)
   │     ├── USB LTE modem (Huawei E3372)
   │     └── USB microphone
-  ├── USB DAC (ES9038Q2M) → RCA → TDA7388 + TDA2050
+  ├── USB DAC (ES9038Q2M) → RCA → off-the-shelf 4-channel car amplifier
   └── USB 4-ch AHD grabber (cameras)
 ```
 

--- a/docs/ZASILANIE_BUFOROWANE.md
+++ b/docs/ZASILANIE_BUFOROWANE.md
@@ -67,11 +67,18 @@ przetwornic, zero ryzyka, że coś obudzi maszynę na parkingu. BCM budzi się
 zimnym startem na ACC — startuje w ~15 s, co przy samochodzie jest
 akceptowalne.
 
-**Wzmacniacze idą osobną gałęzią** prosto z akumulatora rozruchowego
-(bezpiecznik 20 A, przewód 4 mm²). TDA7388 przy średniej głośności ciągnie
-6–8 A, w szczytach do 15–20 A — taki prąd rozłożyłby bank AGM w kilka
-minut i całkowicie zniweczył jego rolę. Sygnał REM/standby wzmacniaczy bierz
-z domeny B, żeby nie trzaskało w głośnikach przy załączaniu.
+**Wzmacniacz idzie osobną gałęzią** prosto z akumulatora rozruchowego —
+gotowy moduł samochodowy, podłączany jak radio: własny bezpiecznik przy klemie
+(wg karty modułu, zwykle 20–30 A), przewód 6 mm², **własna masa lokalna**
+i wyzwalanie sygnałem REM z domeny B.
+
+Powód: 4 × 50 W RMS to w szczytach 20–30 A. Taki prąd rozłożyłby bank AGM
+w kilkanaście minut i przekroczyłby przekaźnik LVD (20 A). Z systemem
+buforowanym łączy wzmacniacz wyłącznie **sygnał REM i ekran kabla RCA** —
+żaden prąd mocy przez bank nie przechodzi.
+
+Tor audio, pętla masy i ustawianie wzmocnienia:
+[`../schematics/audio_system.svg`](../schematics/audio_system.svg).
 
 ---
 
@@ -684,7 +691,7 @@ Moduł montuj **za bankiem, przed rozgałęzieniem domen** — patrz
 | Wyjście step-up | 5 A | między przetwornicą a wtykiem M910q |
 | Odgałęzienie domeny A | 3 A | przed buckiem 12 → 5 V |
 | Odgałęzienie wyświetlaczy | 3 A | przed buckiem 12 → 5 V domeny B |
-| Gałąź wzmacniaczy | 20 A | osobno, przy klemie akumulatora rozruchowego |
+| Gałąź wzmacniacza | wg karty modułu (20–30 A) | osobno, przy klemie akumulatora rozruchowego |
 
 Bezpiecznik główny **przy klemie**, nie przy urządzeniu — zwarcie przewodu
 o karoserię w połowie trasy ma być przerwane przy źródle, inaczej cały
@@ -703,7 +710,7 @@ Dla trasy ok. 3 m (komora silnika → deska rozdzielcza) przy spadku < 3 %:
 | Szyna → LVD → przekaźnik → step-up | do 7 A | 2,5 mm² |
 | Step-up → M910q | 3,5 A @ 19 V | 1,5 mm² |
 | Odgałęzienie domeny A | < 1 A | 0,75 mm² |
-| Gałąź wzmacniaczy | do 20 A | 4 mm² |
+| Gałąź wzmacniacza | wg karty modułu | 6 mm² (trasa ~4 m do bagażnika) |
 | Masa do nadwozia | — | **6 mm²** |
 
 Przewody samochodowe (FLRY/FLY), nie instalacyjne YDY — potrzebna jest
@@ -716,7 +723,7 @@ linka, nie drut, i izolacja odporna na temperaturę i oleje.
   i lakieru, po dokręceniu zabezpieczona wazeliną techniczną,
 - masa banku, masa M910q, masa Arduino i masa audio schodzą się **w tym
   jednym punkcie**,
-- masa wzmacniaczy osobno, blisko wzmacniaczy — inaczej dostaniesz pętlę
+- masa wzmacniacza osobno, blisko wzmacniacza — inaczej dostaniesz pętlę
   masy i przydźwięk alternatora w głośnikach.
 
 ### 8.4 Praktyka montażowa
@@ -1094,7 +1101,26 @@ z listy zalecanych zakupów (poz. 26).
 
 ---
 
-### 13.5 Ograniczenia wynikające z posiadanych modułów
+### 13.5 Gałąź audio — gotowy wzmacniacz
+
+Wcześniejsze wersje dokumentacji zakładały samodzielnie zbudowany tor
+TDA7388 + TDA2050. Projekt używa teraz **gotowego wzmacniacza samochodowego**,
+co dla zasilania buforowanego zmienia trzy rzeczy:
+
+| | Poprzednio (DIY TDA) | Teraz (gotowy moduł) |
+|---|---|---|
+| Bezpiecznik gałęzi | 20 A | **wg karty modułu**, zwykle 20–30 A |
+| Przekrój przewodu | 4 mm² | **6 mm²** (spadek na trasie ~4 m do bagażnika) |
+| Sygnał REM | przez rezystor 1 kΩ | **wprost z zacisku 87** — wejście REM jest wysokoomowe |
+
+Sama zasada nie zmienia się wcale: gałąź audio idzie prosto z akumulatora
+rozruchowego, ma własną masę lokalną i **nie dotyka banku, LVD ani listwy
+dystrybucyjnej**.
+
+Dokumenty źródłowe (`x86-production/*.html`, `bcm_v85_docs.html`) wciąż
+opisują wariant DIY — zostają jako referencja historyczna.
+
+### 13.6 Ograniczenia wynikające z posiadanych modułów
 
 Dwa moduły są już kupione i projekt jest dopasowany pod nie, a nie odwrotnie.
 Wynikają z tego dwa realne ograniczenia:

--- a/schematics/README.md
+++ b/schematics/README.md
@@ -19,7 +19,7 @@ M910q Tiny**.
 | [`power_buffered_m910q.svg`](power_buffered_m910q.svg) | **Tor główny zasilania** — od klemy akumulatora, przez rozdział ładowania, ładowarkę CC-CV, blokadę przeładowania, bank CSB HR1221W i LVD, po przekaźnik zapłonu, przetwornicę step-up 19 V i M910q. Zawiera tabelę przekrojów przewodów i bezpieczników. |
 | [`charging_lvd.svg`](charging_lvd.svg) | **Ładowanie i ochrona banku** — cztery warstwy (VSR → CC-CV → rozłącznik nadnapięciowy → LVD), komplet nastaw dla **CSB HR1221W (AGM)**, dwie tabele kompensacji temperaturowej, wpływ temperatury na żywotność, przebieg CC → CV → float. |
 | [`power_domains_m910q.svg`](power_domains_m910q.svg) | **Domeny A/B** — rozdział obciążeń między część zawsze zasilaną a część załączaną zapłonem, bezpieczniki odgałęzień, budżet poboru spoczynkowego, tabela czasu postoju, osobna gałąź wzmacniaczy. |
-| [`audio_system.svg`](audio_system.svg) | **Tor audio** — ES9038Q2M (USB DAC) → TDA7388 4 × 45 W + TDA2050 (subwoofer) → układ głośników 4.1. Niezależny od platformy — obowiązuje bez zmian. |
+| [`audio_system.svg`](audio_system.svg) | **Tor audio** — ES9038Q2M (USB DAC) → RCA → **gotowy wzmacniacz samochodowy** → głośniki 4 Ω. Wzmacniacz zasilany wprost z akumulatora rozruchowego, z własną masą — całkowicie odseparowany od systemu buforowanego. |
 
 ### Schematy połączeniowe — montaż
 

--- a/schematics/audio_system.svg
+++ b/schematics/audio_system.svg
@@ -1,115 +1,176 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 480" font-family="monospace" font-size="11">
-  <title>BCM v7 — Audio System Wiring (Class AB)</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="1240" height="960" viewBox="0 0 1240 960" font-family="DejaVu Sans, Verdana, sans-serif">
+  <title>BCM v8.5 — Tor audio: DAC USB → gotowy wzmacniacz samochodowy → głośniki</title>
   <style>
-    .box { fill: #f8f8f8; stroke: #333; stroke-width: 2; rx: 6; }
-    .wire { stroke: #333; stroke-width: 1.5; fill: none; }
-    .audio { stroke: #906; stroke-width: 2; fill: none; }
-    .power { stroke: #c00; stroke-width: 2; fill: none; }
-    .label { font-size: 11px; fill: #333; text-anchor: middle; }
-    .title { font-size: 14px; font-weight: bold; fill: #111; }
-    .pin { font-size: 9px; fill: #666; text-anchor: middle; }
-    .comp { font-size: 10px; fill: #06c; text-anchor: middle; }
-    .note { font-size: 9px; fill: #666; text-anchor: start; }
+    .bg    { fill: #ffffff; }
+    .mod   { fill: #f7f9fb; stroke: #2b3a45; stroke-width: 2; rx: 6; }
+    .modB  { fill: #eef2fa; stroke: #2b4a8a; stroke-width: 2; rx: 6; }
+    .modC  { fill: #fbeff1; stroke: #97324a; stroke-width: 2; rx: 6; }
+    .modS  { fill: #fdf3e6; stroke: #a8621a; stroke-width: 2; rx: 6; }
+    .waud  { stroke: #97324a; stroke-width: 2.6; fill: none; }
+    .wusb  { stroke: #2d6a2d; stroke-width: 2.6; fill: none; }
+    .wpwr  { stroke: #c0392b; stroke-width: 3; fill: none; }
+    .wspk  { stroke: #5c3a8a; stroke-width: 2.2; fill: none; }
+    .wsig  { stroke: #2b4a8a; stroke-width: 1.8; fill: none; stroke-dasharray: 5 3; }
+    .minus { stroke: #222831; stroke-width: 2.4; fill: none; }
+    .ttl   { font-size: 19px; font-weight: bold; fill: #10202b; }
+    .sub   { font-size: 12px; fill: #5a6b78; }
+    .mt    { font-size: 13px; font-weight: bold; fill: #10202b; text-anchor: middle; }
+    .ms    { font-size: 10.5px; fill: #5a6b78; text-anchor: middle; }
+    .tl    { font-size: 10.5px; fill: #33424e; }
+    .tb    { font-size: 10.5px; font-weight: bold; fill: #10202b; }
+    .note  { font-size: 10.5px; fill: #6a7a86; }
+    .warn  { font-size: 10.5px; font-weight: bold; fill: #a8321a; }
+    .sec   { font-size: 13px; font-weight: bold; fill: #2d4150; }
+    .wl    { font-size: 10px; fill: #4a5a66; }
   </style>
 
-  <text x="480" y="25" class="title" text-anchor="middle">Audio System — ES9038Q2M DAC → TDA7388 (4ch) + TDA2050 (sub) → 4.1 Speakers</text>
+  <defs>
+    <g id="gnd3">
+      <path stroke="#222831" stroke-width="2.4" fill="none" d="M-11 0 L11 0"/>
+      <path stroke="#222831" stroke-width="2.4" fill="none" d="M-7 5 L7 5"/>
+      <path stroke="#222831" stroke-width="2.4" fill="none" d="M-3 10 L3 10"/>
+    </g>
+  </defs>
 
-  <!-- PipeWire (software) -->
-  <rect x="20" y="80" width="130" height="80" class="box" fill="#f0e0ff"/>
-  <text x="85" y="100" class="label" font-weight="bold">PipeWire</text>
-  <text x="85" y="118" class="pin">Audio routing</text>
-  <text x="85" y="133" class="pin">10-band EQ</text>
-  <text x="85" y="148" class="pin">Ducking mixer</text>
+  <rect class="bg" x="0" y="0" width="1240" height="960"/>
+  <text class="ttl" x="24" y="32">Tor audio — DAC USB → gotowy wzmacniacz samochodowy</text>
+  <text class="sub" x="24" y="52">Wzmacniacz odseparowany od systemu buforowanego: zasilanie wprost z akumulatora rozruchowego, własna masa, własny bezpiecznik</text>
+  <line x1="24" y1="62" x2="1216" y2="62" stroke="#c8d2da" stroke-width="1.5"/>
 
-  <!-- Sources -->
-  <rect x="20" y="185" width="130" height="90" class="box" fill="#e0e0ff"/>
-  <text x="85" y="205" class="label" font-weight="bold">Sources</text>
-  <text x="85" y="223" class="pin">Android Auto</text>
-  <text x="85" y="238" class="pin">BT A2DP</text>
-  <text x="85" y="253" class="pin">FM Radio (RTL-SDR)</text>
-  <text x="85" y="268" class="pin">System TTS/Beeps</text>
-  <line x1="85" y1="185" x2="85" y2="160" class="wire" stroke="#906"/>
+  <!-- ================= SIGNAL CHAIN ================= -->
+  <text class="sec" x="60" y="92">Tor sygnałowy</text>
 
-  <!-- USB DAC -->
-  <rect x="195" y="85" width="140" height="70" class="box" fill="#fff0ff"/>
-  <text x="265" y="107" class="label" font-weight="bold">ES9038Q2M</text>
-  <text x="265" y="122" class="pin">USB DAC Module</text>
-  <text x="265" y="137" class="pin">32-bit / 129dB SNR</text>
-  <text x="265" y="149" class="pin">~45-75 PLN</text>
-  <line x1="150" y1="120" x2="195" y2="120" class="audio"/>
-  <text x="172" y="115" class="pin">USB</text>
+  <rect class="mod" x="60" y="102" width="176" height="132"/>
+  <text class="mt" x="148" y="124">Źródła</text>
+  <text class="tl" x="76" y="150">• Android Auto</text>
+  <text class="tl" x="76" y="170">• Bluetooth A2DP</text>
+  <text class="tl" x="76" y="190">• komunikaty głosowe</text>
+  <text class="tl" x="76" y="210">• sygnały parkowania</text>
+  <text class="ms" x="148" y="228">w systemie M910q</text>
 
-  <!-- RCA split point -->
-  <line x1="335" y1="120" x2="390" y2="120" class="audio"/>
-  <text x="362" y="112" class="pin">RCA L/R</text>
-  <circle cx="390" cy="120" r="4" fill="#906"/>
+  <path class="waud" d="M236 168 L282 168"/>
 
-  <!-- RCA to main amp -->
-  <line x1="390" y1="120" x2="430" y2="100" class="audio"/>
-  <!-- RCA to sub amp -->
-  <line x1="390" y1="120" x2="430" y2="260" class="audio"/>
-  <text x="405" y="195" class="pin" fill="#906">RCA</text>
+  <rect class="modB" x="282" y="102" width="186" height="132"/>
+  <text class="mt" x="375" y="124">PipeWire</text>
+  <text class="tl" x="298" y="150">• mikser i routing</text>
+  <text class="tl" x="298" y="170">• 10-pasmowy EQ</text>
+  <text class="tl" x="298" y="190">• ducking (−12…−18 dB)</text>
+  <text class="tl" x="298" y="210">• analizator widma</text>
+  <text class="ms" x="375" y="228">bez zmian wobec v8.5</text>
 
-  <!-- TDA7388 Main Amplifier -->
-  <rect x="430" y="50" width="190" height="120" class="box" fill="#ffe0e0"/>
-  <text x="525" y="72" class="label" font-weight="bold">TDA7388</text>
-  <text x="525" y="87" class="label">(CD7388CZ)</text>
-  <text x="525" y="105" class="pin">4-channel Class AB</text>
-  <text x="525" y="118" class="pin">4×41W @ 14.4V / 4Ω</text>
-  <text x="525" y="131" class="pin">MOSFET output, THD &lt;0.1%</text>
-  <text x="525" y="144" class="pin">Heatsink required!</text>
-  <text x="525" y="157" class="pin">~45-70 PLN</text>
+  <path class="wusb" d="M468 168 L514 168"/>
+  <text class="wl" x="472" y="162">USB</text>
 
-  <!-- 12V power to TDA7388 -->
-  <line x1="525" y1="50" x2="525" y2="35" class="power"/>
-  <text x="525" y="30" class="comp">12V / 25A fused (shared)</text>
+  <rect class="mod" x="514" y="102" width="200" height="132"/>
+  <text class="mt" x="614" y="124">DAC ES9038Q2M</text>
+  <text class="ms" x="614" y="142">USB Audio Class 2</text>
+  <text class="tl" x="530" y="168">wejście: USB bezpośrednio</text>
+  <text class="tl" x="530" y="184">w port M910q, nie przez hub</text>
+  <text class="tl" x="530" y="208">wyjście: RCA L/R,</text>
+  <text class="tl" x="530" y="224">poziom linii ~2 V RMS</text>
 
-  <!-- TDA2050 Subwoofer Amplifier -->
-  <rect x="430" y="220" width="190" height="100" class="box" fill="#ffe8d0"/>
-  <text x="525" y="242" class="label" font-weight="bold">TDA2050</text>
-  <text x="525" y="257" class="pin">Mono Class AB</text>
-  <text x="525" y="270" class="pin">32W @ 4Ω</text>
-  <text x="525" y="283" class="pin">Clean musical output</text>
-  <text x="525" y="296" class="pin">Small heatsink needed</text>
-  <text x="525" y="309" class="pin">~20-30 PLN</text>
+  <path class="waud" d="M714 168 L770 168"/>
+  <text class="wl" x="718" y="162">RCA L/R</text>
 
-  <!-- 12V power to TDA2050 -->
-  <line x1="525" y1="220" x2="525" y2="205" class="power"/>
-  <text x="525" y="200" class="comp">12V (shared fuse)</text>
+  <rect class="modC" x="770" y="102" width="248" height="132"/>
+  <text class="mt" x="894" y="124">Wzmacniacz samochodowy</text>
+  <text class="ms" x="894" y="142">gotowy moduł, nie DIY</text>
+  <text class="tl" x="786" y="168">4 kanały, wejścia RCA</text>
+  <text class="tl" x="786" y="186">klasa D — mniej ciepła i prądu</text>
+  <text class="tl" x="786" y="204">4 × 50–75 W RMS na 4 Ω</text>
+  <text class="tl" x="786" y="222">zaciski: +12V · GND · REM</text>
 
-  <!-- Speakers from TDA7388 -->
-  <rect x="680" y="35" width="130" height="35" class="box" fill="#e0ffe0"/>
-  <text x="745" y="52" class="label">Front Left</text>
-  <text x="745" y="64" class="pin">Door speaker 4Ω</text>
-  <line x1="620" y1="75" x2="680" y2="52" class="audio"/>
+  <path class="wspk" d="M1018 168 L1062 168"/>
 
-  <rect x="680" y="80" width="130" height="35" class="box" fill="#e0ffe0"/>
-  <text x="745" y="97" class="label">Front Right</text>
-  <text x="745" y="109" class="pin">Door speaker 4Ω</text>
-  <line x1="620" y1="90" x2="680" y2="97" class="audio"/>
+  <rect class="mod" x="1062" y="102" width="138" height="132"/>
+  <text class="mt" x="1131" y="124">Głośniki 4 Ω</text>
+  <text class="tl" x="1076" y="150">przód L — drzwi</text>
+  <text class="tl" x="1076" y="170">przód P — drzwi</text>
+  <text class="tl" x="1076" y="190">tył L — półka</text>
+  <text class="tl" x="1076" y="210">tył P — półka</text>
+  <text class="ms" x="1131" y="228">układ 4.0</text>
 
-  <rect x="680" y="125" width="130" height="35" class="box" fill="#e0ffe0"/>
-  <text x="745" y="142" class="label">Rear Left</text>
-  <text x="745" y="154" class="pin">Shelf speaker 4Ω</text>
-  <line x1="620" y1="110" x2="680" y2="142" class="audio"/>
+  <!-- ================= POWER — SEPARATE BRANCH ================= -->
+  <text class="sec" x="60" y="286">Zasilanie — gałąź całkowicie niezależna</text>
+  <rect class="modS" x="60" y="296" width="1140" height="212"/>
 
-  <rect x="680" y="170" width="130" height="35" class="box" fill="#e0ffe0"/>
-  <text x="745" y="187" class="label">Rear Right</text>
-  <text x="745" y="199" class="pin">Shelf speaker 4Ω</text>
-  <line x1="620" y1="130" x2="680" y2="187" class="audio"/>
+  <rect class="mod" x="86" y="322" width="200" height="72"/>
+  <text class="mt" x="186" y="344">Akumulator rozruchowy</text>
+  <text class="ms" x="186" y="362">zacisk „+”, komora silnika</text>
+  <text class="ms" x="186" y="382">NIE szyna buforowana</text>
 
-  <!-- Subwoofer from TDA2050 -->
-  <rect x="680" y="245" width="130" height="50" class="box" fill="#ffe0e0"/>
-  <text x="745" y="267" class="label" font-weight="bold">Subwoofer</text>
-  <text x="745" y="282" class="pin">Trunk mount 4Ω</text>
-  <line x1="620" y1="270" x2="680" y2="270" class="audio"/>
+  <path class="wpwr" d="M286 358 L336 358"/>
 
-  <!-- Notes box -->
-  <rect x="20" y="350" width="920" height="110" fill="#f8f8ff" stroke="#ccc" rx="4"/>
-  <text x="40" y="370" class="note" font-weight="bold">Signal chain:</text>
-  <text x="40" y="385" class="note">Audio Source → PipeWire (mix/EQ/duck) → ES9038Q2M USB DAC → RCA → TDA7388 (4ch) + TDA2050 (sub) → Speakers</text>
-  <text x="40" y="405" class="note" font-weight="bold">Audio ducking:</text>
-  <text x="40" y="420" class="note">Parking beeps -18dB | Voice announcements -12dB (+3dB boost) | Phone calls -15dB | 1s smooth fade-back</text>
-  <text x="40" y="440" class="note" font-weight="bold">Budget breakdown (~105-160 PLN):</text>
-  <text x="40" y="455" class="note">ES9038Q2M DAC ~45-75 PLN | TDA7388 board ~45-70 PLN | TDA2050 board ~20-30 PLN | Heatsink ~15-25 PLN</text>
+  <rect class="mod" x="336" y="322" width="196" height="72"/>
+  <text class="mt" x="434" y="344">Bezpiecznik</text>
+  <text class="ms" x="434" y="362">wartość wg karty wzmacniacza</text>
+  <text class="ms" x="434" y="382">oprawka ≤ 30 cm od klemy</text>
+
+  <path class="wpwr" d="M532 358 L582 358"/>
+  <text class="wl" x="536" y="352">6 mm²</text>
+
+  <rect class="modC" x="582" y="312" width="270" height="96"/>
+  <text class="mt" x="717" y="334">Wzmacniacz — bagażnik</text>
+  <text class="ms" x="717" y="356">zaciski +12V · GND · REM</text>
+  <text class="ms" x="717" y="376">masa lokalna, do 1 m,</text>
+  <text class="ms" x="717" y="394">tym samym przekrojem co „+”</text>
+
+  <path class="minus" d="M717 408 L717 436"/>
+  <use href="#gnd3" x="717" y="436"/>
+  <text class="note" x="738" y="434">masa przy wzmacniaczu — NIE punkt gwiazdowy</text>
+
+  <rect class="mod" x="906" y="312" width="264" height="96"/>
+  <text class="mt" x="1038" y="334">REM ← domena B</text>
+  <text class="ms" x="1038" y="356">z zacisku 87 przekaźnika zapłonu</text>
+  <text class="ms" x="1038" y="376">wzmacniacz wstaje i gaśnie</text>
+  <text class="ms" x="1038" y="394">razem z head unitem</text>
+
+  <path class="wsig" d="M906 358 L852 358"/>
+
+  <text class="warn" x="86" y="468">Z systemem buforowanym łączy je wyłącznie sygnał REM i ekran kabla RCA.</text>
+  <text class="note" x="86" y="490">Ani prąd zasilania, ani masa mocy wzmacniacza nie przechodzą przez bank, LVD ani listwę dystrybucyjną.</text>
+
+  <!-- ================= WHY ================= -->
+  <text class="sec" x="60" y="548">Dlaczego osobno</text>
+  <rect x="60" y="558" width="560" height="182" fill="#fbfcfd" stroke="#c8d2da" stroke-width="1.5" rx="6"/>
+  <text class="tb" x="78" y="582">Prąd</text>
+  <text class="note" x="78" y="600">Wzmacniacz 4 × 50 W RMS pobiera w szczytach 20–30 A. Bank 25,5 Ah</text>
+  <text class="note" x="78" y="616">rozłożyłby się przy takim prądzie w kilkanaście minut, a przekaźnik</text>
+  <text class="note" x="78" y="632">XH-M609 (20 A) zostałby przekroczony.</text>
+  <text class="tb" x="78" y="658">Zakłócenia</text>
+  <text class="note" x="78" y="676">Wzmacniacz to najbardziej „brudne” obciążenie w aucie — impulsy prądu</text>
+  <text class="note" x="78" y="692">w rytm muzyki. Poza szyną komputera oszczędza to sporo problemów.</text>
+  <text class="tb" x="78" y="718">Prostota</text>
+  <text class="note" x="78" y="734">Gotowy moduł ma wbudowane zabezpieczenia, wyciszanie startu i filtry.</text>
+
+  <rect x="650" y="558" width="550" height="182" fill="#fbfcfd" stroke="#c8d2da" stroke-width="1.5" rx="6"/>
+  <text class="tb" x="668" y="582">Pętla masy — najbardziej prawdopodobny problem</text>
+  <text class="note" x="668" y="602">DAC jest uziemiony przez USB do punktu gwiazdowego pod deską,</text>
+  <text class="note" x="668" y="618">a wzmacniacz do nadwozia w bagażniku. Ekran kabla RCA łączy oba</text>
+  <text class="note" x="668" y="634">punkty — różnica potencjałów daje przydźwięk alternatora.</text>
+  <text class="tb" x="668" y="660">Kolejność działań, jeśli słychać buczenie:</text>
+  <text class="note" x="668" y="678">1. masa wzmacniacza jak najkrócej, do gołego metalu, mocno dokręcona</text>
+  <text class="note" x="668" y="694">2. RCA po przeciwnej stronie auta niż kabel zasilania</text>
+  <text class="note" x="668" y="710">3. dopiero potem izolator pętli masy na RCA (transformatorowy)</text>
+  <text class="note" x="668" y="732">Izolator pogarsza pasmo — używaj go, gdy 1 i 2 nie pomogły.</text>
+
+  <!-- ================= SETUP ================= -->
+  <text class="sec" x="60" y="780">Uruchomienie</text>
+  <rect x="60" y="790" width="560" height="142" fill="#fbfcfd" stroke="#c8d2da" stroke-width="1.5" rx="6"/>
+  <text class="tb" x="78" y="814">Ustawienie wzmocnienia (gain)</text>
+  <text class="note" x="78" y="832">1. Głośność systemu ~75 %, EQ płasko, gain wzmacniacza na minimum</text>
+  <text class="note" x="78" y="848">2. Podnoś gain do pierwszych oznak zniekształceń, cofnij o krok</text>
+  <text class="note" x="78" y="864">Gain to dopasowanie poziomu, nie „pokrętło głośności”.</text>
+  <text class="tb" x="78" y="890">Filtry</text>
+  <text class="note" x="78" y="908">Bez subwoofera: górnoprzepustowy ok. 80 Hz na wszystkich kanałach</text>
+  <text class="note" x="78" y="924">chroni głośniki drzwiowe przed pompowaniem basem.</text>
+
+  <rect x="650" y="790" width="550" height="142" fill="#fbfcfd" stroke="#c8d2da" stroke-width="1.5" rx="6"/>
+  <text class="tb" x="668" y="814">Jeśli dojdzie subwoofer</text>
+  <text class="note" x="668" y="832">• wzmacniacz 5-kanałowy — jeden moduł i jedno zasilanie, najprościej</text>
+  <text class="note" x="668" y="848">• albo zmostkowanie pary tylnej, jeśli wzmacniacz to obsługuje</text>
+  <text class="note" x="668" y="864">• osobny monoblok tylko wtedy, gdy naprawdę potrzeba mocy</text>
+  <text class="note" x="668" y="886">Każdy wariant zasilaj tą samą gałęzią i dobierz bezpiecznik wg sumy</text>
+  <text class="note" x="668" y="902">kart katalogowych. Bank buforowy pozostaje nietknięty.</text>
+  <text class="warn" x="668" y="924">Po stronie software'u nic się nie zmienia — DAC i PipeWire bez zmian.</text>
 </svg>

--- a/schematics/power_buffered_m910q.svg
+++ b/schematics/power_buffered_m910q.svg
@@ -195,5 +195,5 @@
   <text class="tl" x="700" y="904" text-anchor="end">6 mm²</text>
   <text class="note" x="446" y="928">Przekroje dla trasy ok. 3 m przy spadku napięcia &lt; 3 %.</text>
 
-  <text class="note" x="24" y="1064">Wzmacniacze TDA7388 / TDA2050 zasilane są osobną gałęzią 12 V prosto z akumulatora samochodowego (bezpiecznik 20 A) — nie obciążają banku buforowego.</text>
+  <text class="note" x="24" y="1064">Wzmacniacz audio to gotowy moduł samochodowy zasilany osobną gałęzią 12 V prosto z akumulatora rozruchowego, z własną masą — nie obciąża banku buforowego.</text>
 </svg>

--- a/schematics/power_domains_m910q.svg
+++ b/schematics/power_domains_m910q.svg
@@ -122,10 +122,10 @@
   <text class="tb" x="70" y="586" fill="#97324a" font-size="14">GAŁĄŹ NIEZALEŻNA — wzmacniacze</text>
   <rect class="boxC" x="60" y="596" width="420" height="112"/>
   <text class="t" x="270" y="620">Prosto z akumulatora rozruchowego, z pominięciem banku buforowego</text>
-  <text class="tl" x="80" y="642">• bezpiecznik 20 A przy klemie „+”, przewód 4 mm²</text>
-  <text class="tl" x="80" y="662">• TDA7388 4 × 45 W + TDA2050 (subwoofer)</text>
-  <text class="tl" x="80" y="682">• REM/standby wyzwalany z domeny B (bez trzasków przy starcie)</text>
-  <text class="note" x="80" y="700">Szczyty 15–20 A rozładowałyby bank AGM w kilka minut — dlatego osobna gałąź.</text>
+  <text class="tl" x="80" y="642">• bezpiecznik wg karty wzmacniacza, przy klemie „+”, przewód 6 mm²</text>
+  <text class="tl" x="80" y="662">• gotowy wzmacniacz samochodowy 4-kanałowy (nie DIY)</text>
+  <text class="tl" x="80" y="682">• REM z zacisku 87 · masa lokalna, przy wzmacniaczu</text>
+  <text class="note" x="80" y="700">Szczyty 20–30 A rozłożyłyby bank AGM w kilkanaście minut i przekroczyły przekaźnik LVD.</text>
 
   <!-- ============ STANDBY TABLE ============ -->
   <rect x="700" y="596" width="420" height="196" fill="#fbfcfd" stroke="#c8d2da" stroke-width="1.5" rx="6"/>

--- a/schematics/vehicle_layout_m910q.svg
+++ b/schematics/vehicle_layout_m910q.svg
@@ -134,8 +134,8 @@
 
   <!-- ============ TRUNK ============ -->
   <rect class="zoneC" x="936" y="228" width="196" height="50"/>
-  <text class="zt" x="1034" y="247">TDA7388 + TDA2050</text>
-  <text class="zt" x="1034" y="263">radiatory, wentylacja</text>
+  <text class="zt" x="1034" y="247">wzmacniacz samochodowy</text>
+  <text class="zt" x="1034" y="263">gotowy moduł, wentylacja</text>
   <circle class="pin" cx="936" cy="228" r="11"/><text class="pinT" x="936" y="232">17</text>
 
   <rect class="zoneC" x="936" y="404" width="196" height="42"/>
@@ -182,8 +182,8 @@
   <text class="tl" x="668" y="638">14 · kamera przednia — za lusterkiem wstecznym</text>
   <text class="tl" x="668" y="658">15 · kamery boczne — lusterka / błotniki</text>
   <text class="tl" x="668" y="678">16 · DS18B20 — za zderzakiem przednim</text>
-  <text class="tl" x="668" y="698">17 · TDA7388 + TDA2050 z radiatorami</text>
-  <text class="tl" x="668" y="718">18 · subwoofer w obudowie</text>
+  <text class="tl" x="668" y="698">17 · gotowy wzmacniacz samochodowy 4-kanałowy</text>
+  <text class="tl" x="668" y="718">18 · subwoofer w obudowie (opcjonalnie)</text>
   <text class="tl" x="668" y="738">19 · kamera cofania — ramka tablicy rejestracyjnej</text>
   <text class="tl" x="668" y="758">20 · 4 × HC-SR04 — zderzak tylny</text>
   <text class="tl" x="668" y="778">21 · głośniki przednie — drzwi</text>
@@ -198,9 +198,9 @@
   <text class="note" x="78" y="906">na każde +10 °C. Bagażnik latem osiąga 45–55 °C — różnica wychodzi</text>
   <text class="note" x="78" y="922">2–4 lata (kabina) wobec 1,5–3 lat (bagażnik).</text>
 
-  <text class="tb" x="78" y="948">Wzmacniacze w bagażniku, nie przy banku</text>
-  <text class="note" x="78" y="966">Klasa AB grzeje się mocno i potrzebuje wentylacji. Idą osobną gałęzią 12 V</text>
-  <text class="note" x="78" y="982">prosto z akumulatora, więc nie ma powodu ciągnąć ich do kabiny.</text>
+  <text class="tb" x="78" y="948">Wzmacniacz w bagażniku, nie przy banku</text>
+  <text class="note" x="78" y="966">Potrzebuje wentylacji i idzie osobną gałęzią 12 V prosto z akumulatora,</text>
+  <text class="note" x="78" y="982">więc nie ma powodu ciągnąć go do kabiny.</text>
 
   <text class="tb" x="78" y="1008">M910q za deską po stronie pasażera</text>
   <text class="note" x="78" y="1026">Poziomo, logo do góry, na wsporniku VESA 100. Blisko obu wyświetlaczy</text>

--- a/schematics/wiring_power_modules.svg
+++ b/schematics/wiring_power_modules.svg
@@ -305,10 +305,10 @@
   <!-- ================= AMP BRANCH ================= -->
   <text class="sec" x="60" y="1380">GAŁĄŹ NIEZALEŻNA — wzmacniacze (z pominięciem bufora)</text>
   <rect class="mod" x="60" y="1390" width="560" height="118"/>
-  <text class="ms" x="340" y="1414">Prosto z klemy „+” akumulatora rozruchowego — NIE z szyny buforowanej</text>
-  <text class="wn" x="80" y="1438">• bezpiecznik 20 A przy klemie, przewód 4 mm²</text>
-  <text class="wn" x="80" y="1458">• TDA7388: „+12V” i „GND” — masa osobno, blisko wzmacniacza</text>
-  <text class="wn" x="80" y="1478">• REM/standby ← zacisk 87 przekaźnika zapłonu, przez 1 kΩ</text>
+  <text class="ms" x="340" y="1414">Gotowy wzmacniacz samochodowy — prosto z klemy „+”, NIE z szyny buforowanej</text>
+  <text class="wn" x="80" y="1438">• bezpiecznik wg karty wzmacniacza przy klemie, przewód 6 mm²</text>
+  <text class="wn" x="80" y="1458">• zaciski „+12V” i „GND” — masa lokalna, do 1 m, ten sam przekrój</text>
+  <text class="wn" x="80" y="1478">• REM ← zacisk 87 przekaźnika zapłonu (domena B)</text>
   <text class="note" x="80" y="1498">Wspólna masa z komputerem daje pętlę masy i przydźwięk alternatora.</text>
 
   <!-- ================= LEGEND ================= -->

--- a/schematics/wiring_usb_av.svg
+++ b/schematics/wiring_usb_av.svg
@@ -136,18 +136,15 @@
   <path class="waud" d="M234 626 L286 626"/>
   <text class="wl" x="240" y="620">RCA L/R</text>
 
-  <rect class="mod" x="286" y="592" width="170" height="86"/>
-  <text class="mt" x="371" y="614">TDA7388</text>
-  <text class="ms" x="371" y="632">4 × 45 W, klasa AB</text>
-  <text class="ms" x="371" y="650">radiator aluminiowy</text>
-  <text class="ms" x="371" y="668">wejścia IN1–IN4</text>
-
-  <path class="waud" d="M234 626 L260 626 L260 712 L286 712"/>
-  <circle cx="260" cy="626" r="3.5" fill="#97324a"/>
-  <rect class="mod" x="286" y="690" width="170" height="70"/>
-  <text class="mt" x="371" y="712">TDA2050</text>
-  <text class="ms" x="371" y="730">subwoofer, mono</text>
-  <text class="ms" x="371" y="748">suma L+R na wejściu</text>
+  <rect class="mod" x="286" y="592" width="170" height="168"/>
+  <text class="mt" x="371" y="614">Wzmacniacz</text>
+  <text class="ms" x="371" y="632">gotowy, samochodowy</text>
+  <text class="ms" x="371" y="650">4 kanały, wejścia RCA</text>
+  <text class="ms" x="371" y="668">4 × 50–75 W RMS / 4 Ω</text>
+  <text class="ms" x="371" y="690">klasa D</text>
+  <text class="ms" x="371" y="712">zaciski +12V · GND · REM</text>
+  <text class="ms" x="371" y="734">gain i filtry na module</text>
+  <text class="ms" x="371" y="752">bagażnik</text>
 
   <path class="waud" d="M456 626 L508 626"/>
   <rect class="mod" x="508" y="592" width="240" height="86"/>
@@ -156,15 +153,14 @@
   <text class="ms" x="628" y="650">CH3 tył L · CH4 tył P</text>
   <text class="ms" x="628" y="668">drzwi + półka tylna</text>
 
-  <path class="waud" d="M456 722 L508 722"/>
   <rect class="mod" x="508" y="690" width="240" height="70"/>
-  <text class="mt" x="628" y="712">Subwoofer 4 Ω</text>
-  <text class="ms" x="628" y="730">bagażnik</text>
-  <text class="ms" x="628" y="748">osobny radiator na TDA2050</text>
+  <text class="mt" x="628" y="712">Subwoofer — opcjonalnie</text>
+  <text class="ms" x="628" y="730">wzmacniacz 5-kanałowy albo</text>
+  <text class="ms" x="628" y="748">zmostkowana para tylna</text>
 
   <path class="wpwr" d="M371 760 L371 774 L84 774"/>
-  <text class="warn" x="84" y="792">Zasilanie 12 V wzmacniaczy — osobna gałąź prosto z akumulatora, bezpiecznik 20 A</text>
-  <text class="note" x="84" y="810">REM/standby ← zacisk 87 przekaźnika zapłonu, przez rezystor 1 kΩ (domena B)</text>
+  <text class="warn" x="84" y="792">Zasilanie 12 V wzmacniacza — osobna gałąź prosto z akumulatora, bezpiecznik wg karty modułu</text>
+  <text class="note" x="84" y="810">REM ← zacisk 87 przekaźnika zapłonu (domena B). Masa wzmacniacza lokalnie, nie do punktu gwiazdowego.</text>
 
   <!-- ============ NOTES ============ -->
   <rect x="60" y="852" width="1120" height="164" fill="#fbfcfd" stroke="#c8d2da" stroke-width="1.5" rx="6"/>
@@ -178,9 +174,9 @@
   <text class="note" x="80" y="1002">Brak reguł udev — K-Line trafia wtedy na port Arduino.</text>
 
   <text class="tb" x="640" y="900">Przydźwięk alternatora w głośnikach</text>
-  <text class="note" x="640" y="918">Pętla masy — masa wzmacniaczy musi być osobno, przy wzmacniaczach.</text>
+  <text class="note" x="640" y="918">Pętla masy — masa wzmacniacza musi być lokalna, a RCA po drugiej stronie auta.</text>
   <text class="tb" x="640" y="942">Trzask w głośnikach przy załączaniu</text>
-  <text class="note" x="640" y="960">REM podpięty nie z domeny B albo bez rezystora 1 kΩ.</text>
+  <text class="note" x="640" y="960">REM podpięty nie z domeny B — wzmacniacz wstaje przed komputerem.</text>
   <text class="tb" x="640" y="984">Graber gubi klatki</text>
   <text class="note" x="640" y="1002">Wpięty w hub zamiast bezpośrednio w port M910q.</text>
 

--- a/src/audio/pipewire_ctrl.py
+++ b/src/audio/pipewire_ctrl.py
@@ -5,8 +5,12 @@ On x86: uses default sound card (laptop/desktop speakers).
 On OPi: targets USB DAC (ES9038Q2M) as default sink.
 
 Audio hardware chain:
-  ES9038Q2M USB DAC → RCA → TDA7388 4ch Class AB amp (4×41W) → front/rear speakers
-                         └→ TDA2050 mono Class AB amp (32W) → subwoofer
+  ES9038Q2M USB DAC → RCA → off-the-shelf 4-channel car amplifier → 4x 4 ohm speakers
+
+The amplifier is a bought unit powered straight from the starter battery on
+its own fused branch, not from the buffered bus — see
+docs/ZASILANIE_BUFOROWANE.md and schematics/audio_system.svg. Nothing here
+depends on which amplifier it is; PipeWire only ever sees the USB DAC.
 """
 
 import subprocess


### PR DESCRIPTION
Stopień końcowy audio przestaje być budowany z płytek TDA7388 + TDA2050. Zamiast tego **gotowy 4-kanałowy wzmacniacz samochodowy** z wejściami RCA, podłączany jak radio: wprost z akumulatora rozruchowego, własny bezpiecznik przy klemie, własna masa lokalna, wyzwalanie sygnałem REM.

## Separacja jest tu sednem

Dokumentacja mówi to teraz wprost: z systemem buforowanym łączy wzmacniacz **wyłącznie sygnał REM i ekran kabla RCA**. Żaden prąd mocy ani masa mocy nie przechodzi przez bank, LVD ani listwę dystrybucyjną.

## Trzy wartości, które się przez to zmieniają

| | Poprzednio (DIY TDA) | Teraz (gotowy moduł) |
|---|---|---|
| Bezpiecznik gałęzi | 20 A na sztywno | **wg karty modułu** (zwykle 20–30 A) |
| Przekrój przewodu | 4 mm² | **6 mm²** |
| Sygnał REM | przez rezystor 1 kΩ | **wprost z zacisku 87** |

- Bezpiecznik dobierany „na oko" kończy się takim, który nigdy nie zadziała.
- 6 mm² wynika ze **spadku napięcia** na trasie ~4 m do bagażnika, nie z obciążalności prądowej.
- Rezystor 1 kΩ istniał dla płytki DIY. Wejście REM gotowego wzmacniacza jest wysokoomowe (10–20 kΩ) i moduł ma własne wyciszanie startu.

## `schematics/audio_system.svg` przepisany

Był to jeszcze rysunek z **v7** — klasa AB, radiatory, ceny poszczególnych płytek. Nowy zawiera: tor sygnałowy, osobną gałąź zasilania, uzasadnienie separacji i **problem pętli masy, który ta topologia tworzy**.

DAC ma masę przez USB do punktu gwiazdowego pod deską, wzmacniacz ma masę lokalną w bagażniku, a ekran RCA łączy oba punkty — różnica potencjałów daje przydźwięk alternatora. Kolejność diagnozy jest rozpisana celowo:

1. masa wzmacniacza — krótka, do gołego metalu, mocno dokręcona
2. RCA po przeciwnej stronie auta niż kabel zasilania
3. **dopiero potem** izolator pętli masy

Sięganie od razu po izolator to typowy błąd, a izolator pogarsza pasmo. Na rysunku jest też procedura ustawiania wzmocnienia i warianty na wypadek dołożenia subwoofera (5-kanałowy moduł / zmostkowana para tylna / monoblok).

## Po stronie software'u — zero zmian

PipeWire widzi wyłącznie DAC USB; co jest za gniazdem RCA, jest dla niego niewidoczne. Zaktualizowany został jedynie docstring `pipewire_ctrl.py` i opisowe klucze `amp_main`/`amp_sub` w `bcm_config.yaml` (nieczytane przez żaden kod), żeby przestały wymieniać części, których w budowie nie ma.

## Zaktualizowane pliki

Schematy: `audio_system.svg` (przepisany), `wiring_usb_av.svg`, `power_domains_m910q.svg`, `power_buffered_m910q.svg`, `wiring_power_modules.svg`, `vehicle_layout_m910q.svg`, `schematics/README.md`.

Dokumenty: `SCHEMATY_POLACZEN.md` (§2.6 i §5.4), `ZASILANIE_BUFOROWANE.md` (§2, tabele bezpieczników i przekrojów, nowa §13.5), `WDROZENIE_M910Q.md` (BOM, §14, nowa §19.5), `X86_PLATFORM_SETUP.md` (drzewo USB), `README.md`.

Dokumenty źródłowe pod `x86-production/` i `bcm_v85_docs.html` wciąż pokazują wariant DIY — odnotowane w sekcjach rozbieżności, nie przepisywane.

## Weryfikacja

- `pytest tests/` — **419 passed**
- `ruff check .` — **All checks passed**
- 115 względnych odnośników w plikach `.md` rozwiązuje się do istniejących plików
- Kotwice spisów treści zweryfikowane
- `bcm_config.yaml` parsuje się poprawnie
- Wszystkie SVG zwalidowane i wyrenderowane do PNG

---
_Generated by [Claude Code](https://claude.ai/code/session_017cXmt2HyZ8iv3aQHpkNA4c)_