### PR TITLE
Make the docs match the code, and add a bench/dev build

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ BCM v8.5 — custom head unit for Alfa Romeo 156 1.9 JTD 8V, built on a
 - Dual DVR (front + rear) + 4-camera auto-switching (reverse, blinkers)
 - Ultrasonic parking sensors with buzzer
 - Android Auto (kiosk mode, integrated in dashboard)
-- Dual screen: 7/8" touchscreen (A1-A8 + Settings) + 4.3" stats display
+- Dual screen: 10.1" 1280x800 touchscreen (A1-A8 + Settings) + optional
+  6.86" 1280x480 widescreen stats display (hot-pluggable)
 - SWC steering wheel remote with configurable button mapping (dual-pod, 24 buttons, learn mode)
 - K-Line OBD-II diagnostics (KWP2000) with DTC read/clear
 - GPS tracking, weather, LTE connectivity
@@ -37,6 +38,9 @@ pip install -r requirements.txt -r requirements-x86.txt
 - **Deployment (production, M910q):** `docs/WDROZENIE_M910Q.md` —
   hardware, BIOS, OS, services, verification. Power system in detail:
   `docs/ZASILANIE_BUFOROWANE.md` + `schematics/`.
+- **Bench / dev build** (Android Auto + audio + steering-wheel buttons, the
+  rest switched off): `docs/WDROZENIE_TESTOWE.md`, config
+  `config/bcm_config_bench.yaml`.
 - Repo audit + improvement roadmap: `AUDYT_I_PLAN.md`. Unused legacy
   code lives in `legacy/`; docs for retired platforms (Orange Pi 5 Pro /
   5 Plus, Orange Pi PC bench rig, VMware smoke tests) live in

--- a/config/bcm_config_bench.yaml
+++ b/config/bcm_config_bench.yaml
@@ -1,0 +1,318 @@
+# BCM v8.5 — konfiguracja STANOWISKA TESTOWO-ROZWOJOWEGO
+#
+# Minimalny zestaw do weryfikacji na biurku / w aucie na etapie rozwoju:
+#   • ekran 7" 1024x600 (docelowy jest 10,1" 1280x800 — patrz bcm_config.yaml)
+#   • Android Auto PO KABLU USB (bez WiFi P2P i bez Bluetooth)
+#   • dźwięk przez wyjście analogowe M910q (mini-jack) — domyślny sink PipeWire
+#   • przyciski SWC przez Arduino Pro Micro (USB HID)
+#   • modem LTE — na x86 moduł `network` tylko raportuje stan łącza,
+#     samo połączenie robi NetworkManager
+#
+# Wszystko pozostałe wyłączone, żeby nie szukać usterek w rzeczach,
+# których jeszcze nie ma podłączonych.
+#
+# Uruchomienie:
+#   python3 main.py --platform x86 --config config/bcm_config_bench.yaml --frontend
+#
+# Ten plik NIE jest nakładką na bcm_config.yaml — --config podmienia całą
+# konfigurację, więc jest to pełna kopia z pozmienianymi kluczami.
+# Instrukcja: docs/WDROZENIE_TESTOWE.md
+#
+system:
+  name: BCM v8.5
+  version: 8.5.1
+  platform: x86
+  log_level: DEBUG
+  log_file: logs/bcm.log
+  simulation: false
+# Jeden przełącznik na każdy moduł/podsystem — pełna lista i stan
+# także w UI: Settings -> Moduły (GET/POST /api/modules).
+modules:
+  # --- WŁĄCZONE na stanowisku testowym ---
+  dashboard: true          # frontend HTML5 na porcie 5002
+  multimedia: true         # Android Auto (openauto)
+  input: true              # przyciski SWC przez Pro Micro (USB HID)
+  audio: true              # głośność i EQ na domyślnym sinku PipeWire
+  network: true            # status łącza (LTE/WiFi/ethernet) — tylko odczyt
+
+  # --- WYŁĄCZONE: brak podłączonego sprzętu ---
+  obd: false               # brak CP2102 + L9637D
+  parking: false           # brak HC-SR04
+  environment: false       # brak DS18B20
+  camera: false            # brak grabera i kamer
+  power: false             # brak przekaźnika zapłonu w torze testowym
+  location: false          # brak GPS
+  tracking: false          # zależy od GPS
+  weather: false           # wymaga klucza API
+  blinker_monitor: false   # brak sygnałów z auta
+  rain_sensor: false
+  central_lock: false      # brak Nano #1 i modułu przekaźników
+  lighting: false
+  performance: false       # zależy od OBD
+  alarm: false
+  crash_detect: false      # zależy od kamer
+  battery: false           # patrz docs/ZASILANIE_BUFOROWANE.md § 13.4
+
+  # --- podsystemy (startowane wprost w main.py) ---
+  bluetooth: false         # AA po kablu nie potrzebuje BT
+  phonebook: false         # bez BT nie ma czego synchronizować
+  fuel_sender: false       # brak ADC z Arduino
+  wifi_ap: false           # AA po kablu — bez P2P-GO
+  wifi_hotspot: false
+  route_planner: false     # wymaga kluczy API
+  small_display: false     # jeden ekran na stanowisku
+display:
+  # Stanowisko testowe: panel 7" 1024x600.
+  # Docelowo 10,1" 1280x800 — wartości produkcyjne w bcm_config.yaml.
+  dashboard:
+    width: 1024
+    height: 600
+    fps: 15
+    theme: heritage
+    brightness: 70
+  multimedia:
+    # Rozdzielczość renderowania Android Auto — trzymaj równą panelowi.
+    width: 1024
+    height: 600
+  small:
+    width: 1280
+    height: 480
+  appbar_px: 48
+  navbar_px: 48
+units:
+  speed: km/h
+  temperature: C
+language: pl
+gpio:
+  parking_trig: 79
+  parking_echo:
+  - 80
+  - 81
+  - 82
+  - 83
+  buzzer: 84
+  backlight_dashboard: 32
+  backlight_multimedia: 33
+  onewire: 7
+  ignition: 85
+  door: 86
+  rain_sensor: 87
+  sprayer: 88
+  central_lock: 89
+  blinker_left: 90
+  blinker_right: 91
+vehicle:
+  blinker_active_low: true
+  blinker_hold_sec: 0.8
+serial:
+  kline:
+    port_opi: /dev/ttyS3
+    port_x86: /dev/ttyUSB_kline   # CP2102/VIAKEN KKL — patrz reguła udev
+                                  # w docs/KLINE_SNIFFING.md §5.4
+    baudrate: 10400
+    ecu_address: 1
+obd:
+  use_real_hardware: false   # x86 produkcja: ustaw true, żeby czytać z
+                             # prawdziwego ECU zamiast symulatora
+  fast_init: false           # true tylko jeśli adapter/ECU wspiera fast init
+hardware:
+  gps:
+    enabled: true
+    port: /dev/ttyUSB0
+    baudrate: 9600
+  lte:
+    enabled: true
+    device: ''
+    apn: ''
+audio:
+  eq_dsp_enabled: true   # prawdziwy EQ przez PipeWire filter-chain
+  eq_preset: jazz
+  master_volume: 70
+  bass: 0
+  treble: 0
+  fader: 0
+  balance: 0
+  spectrum_enabled: true
+  dac: ES9038Q2M
+  # Opisowe, nieczytane przez kod. Wzmacniacz to gotowy moduł samochodowy
+  # na osobnej gałęzi 12 V — patrz docs/ZASILANIE_BUFOROWANE.md § 2.
+  amp_main: car-amp-4ch
+  amp_sub: none
+  mic_phone: ''
+  voice_duck_pct: 40
+  voice_listen_sec: 8
+camera:
+  segment_minutes: 5
+  max_storage_gb: 128
+  recording_path: /media/dashcam
+  front_device: /dev/video0
+  rear_device: /dev/video1
+  left_device: /dev/video2
+  right_device: /dev/video3
+  controller: true
+swc:
+  enabled: true
+  mapping:
+    volume_up:
+    - SWC_VOLUP
+    - SWC2_VOLUP
+    volume_down:
+    - SWC_VOLDN
+    - SWC2_VOLDN
+    next_track:
+    - SWC_NEXT
+    - SWC2_NEXT
+    prev_track:
+    - SWC_PREV
+    - SWC2_PREV
+    mute:
+    - SWC_MUTE
+    - SWC2_MUTE
+    phone_pickup:
+    - SWC_PICKUP
+    - SWC2_PICKUP
+    phone_hangup:
+    - SWC_HANGUP
+    - SWC2_HANGUP
+    bcm_power_toggle:
+    - SWC_MODE
+    - SWC2_MODE
+    voice_aa_trigger:
+    - SWC_VOICE
+    - SWC2_VOICE
+    navigate_aa:
+    - SWC_SRC
+    - SWC2_SRC
+    menu_up:
+    - SWC_UP
+    - SWC2_UP
+    menu_down:
+    - SWC_DOWN
+    - SWC2_DOWN
+brightness:
+  mode: auto
+  steps:
+  - 15
+  - 30
+  - 45
+  - 60
+  - 80
+  - 100
+music_panel:
+  enabled: true
+fuel_sender:
+  enabled: true
+  calibration:
+  - - 20
+    - 100
+  - - 50
+    - 75
+  - - 120
+    - 50
+  - - 220
+    - 25
+  - - 360
+    - 5
+  - - 400
+    - 0
+  tank_capacity_litres: 58
+wifi:
+  # WiFi wyłącznie do Android Auto wireless (Wi-Fi Direct / P2P-GO na
+  # karcie wewnętrznej). Sterowane przełącznikiem modules.wifi_ap.
+  enabled: true
+  ssid: ALFA
+  password: 87654321
+  mode: p2p_go
+  band: a
+  channel: 149
+  country: US
+  regdom: US
+  share_internet: true
+  interface: ''
+  ip: 10.0.0.1
+  netmask: 255.255.255.0
+  dhcp_start: 10.0.0.10
+  dhcp_end: 10.0.0.50
+  # Dodatkowy Access Point ALFA-NET (współdzielenie internetu). Wymaga
+  # OSOBNEGO interfejsu WiFi (dongla USB) — karta wewnętrzna nie robi
+  # P2P-GO i AP naraz. Włącza się przełącznikiem modules.wifi_hotspot;
+  # ten klucz jest jego odpowiednikiem (utrzymywany w synchronizacji).
+  alfa_net:
+    enabled: false
+    ssid: ALFA-NET
+    password: AlfaRomeo156
+    channel: 6
+    country: US
+    ip: 10.0.1.1
+    netmask: 255.255.255.0
+    dhcp_start: 10.0.1.10
+    dhcp_end: 10.0.1.50
+    share_internet: true
+  ssid_runtime: DIRECT-Ea
+  password_runtime: adVEiNlq
+  bssid_runtime: 4e:82:a9:17:47:97
+weather:
+  api_key: 631c2365675e193584b0f986798554c1
+  poll_interval_min: 15
+  default_lat: 50.06
+  default_lon: 19.94
+travel:
+  openrouteservice_key: ''
+  tomtom_key: ''
+power:
+  shutdown_delay_seconds: 30
+  backlight_fade_ms: 1000
+  standby_max_hours: 24
+  splash_duration_seconds: 15
+  ignition_watcher:
+    gpio_chip: gpiochip0
+    ignition_line: 7
+    bench_button_line: 21
+    debounce_ms: 200
+    active_low: true
+    autostart: true
+    suspend_on_stop: true
+    suspend_delay_seconds: 5
+rain_sensor:
+  sensitivity: medium
+central_lock:
+  port: /dev/ttyUSB1
+  baudrate: 9600
+lighting:
+  follow_me_home_seconds: 60
+  greeting_blinks: 2
+  leaving_home: true
+traffic:
+  api_key: ''
+  provider: tomtom
+  poll_interval_min: 5
+remote_status:
+  api_key: ''
+alarm:
+  siren_duration: 60
+  arming_delay: 30
+  sensors:
+    door: true
+    motion: true
+    tilt: true
+    shock: true
+crash_detection:
+  speed_drop_threshold: 30
+  g_force_threshold: 3.0
+  post_crash_record_sec: 60
+tracking:
+  db_path: data/gps_tracks.db
+  interval_sec: 30
+  trip_start_kmh: 5
+  trip_end_kmh: 2
+  trip_end_idle_sec: 60
+  lte_sync_min: 15
+  geofence_lat: 0
+  geofence_lon: 0
+  geofence_radius_km: 0
+  sms_number: ''
+multimedia:
+  last_bt_device: C0:7A:D6:90:E9:CC
+bluetooth:
+  enabled: true
+  preferred_adapter: ''

--- a/config/scripts/setup-x86.sh
+++ b/config/scripts/setup-x86.sh
@@ -18,15 +18,23 @@ BCM_USER="${SUDO_USER:-abner}"
 BCM_HOME=$(eval echo "~$BCM_USER")
 BCM_DIR="/opt/bcm"
 
-# Display outputs (find with: for f in /sys/class/drm/card*-*/status; do echo "$f: $(cat $f)"; done)
-MAIN_OUTPUT="HDMI-1"
-SMALL_OUTPUT="HDMI-2"
+# Display outputs. ALWAYS check the real names on this machine first:
+#   for f in /sys/class/drm/card*-*/status; do echo "$f: $(cat $f)"; done
+# On the reference M910q the connectors enumerate as HDMI-A-1 / HDMI-A-2
+# (xrandr: HDMI-1 / HDMI-2) and the main panel came up on connector 2 —
+# see config/scripts/bcm-splash-play.sh. Swap these two if your main
+# panel is dark and the small one shows the dashboard.
+MAIN_OUTPUT="HDMI-2"
+SMALL_OUTPUT="HDMI-1"
 TOUCH_DEVICE="QDtech MPI5001"
 
-# Main display resolution (used for splash generation + touch calibration)
-MAIN_W=1024
-MAIN_H=600
-SMALL_W=800
+# Main display resolution (used for splash generation + touch calibration).
+# Must match display.dashboard / display.small in config/bcm_config.yaml.
+# Main   = 10.1" panel, 1280x800
+# Small  = 6.86" widescreen panel, 1280x480 (optional, hot-pluggable)
+MAIN_W=1280
+MAIN_H=800
+SMALL_W=1280
 SMALL_H=480
 
 # WiFi AP — 5 GHz channel 149, country US. MT7921 (mt7921e) exposes

--- a/config/scripts/xinitrc-x86-dual
+++ b/config/scripts/xinitrc-x86-dual
@@ -5,10 +5,17 @@
 # ──── USER CONFIG (set these for your hardware) ────
 # Find outputs:  xrandr | grep ' connected'
 # Find touch:    xinput list
-MAIN_OUTPUT="HDMI-2"           # 7" touchscreen
-SMALL_OUTPUT="HDMI-1"          # 4.3" status display (or FHD dev monitor)
+MAIN_OUTPUT="HDMI-2"           # 10.1" touchscreen, 1280x800
+SMALL_OUTPUT="HDMI-1"          # 6.86" widescreen, 1280x480 (or FHD dev monitor)
 TOUCH_DEVICE="QDtech MPI5001"  # touchscreen xinput name
 # ───────────────────────────────────────────────────
+#
+# NOTE: this is a standalone template. The supported path is
+# config/scripts/setup-x86.sh, which generates ~/.xinitrc with the same
+# logic PLUS small-display-watch.sh — the hotplug watcher that brings the
+# second screen up/down when it is plugged in after boot. This template
+# has no watcher: the small panel must be connected at boot or it stays
+# dark. Prefer setup-x86.sh unless you specifically want the simpler file.
 
 xset s off
 xset -dpms

--- a/docs/ARDUINO_SETUP_GUIDE.md
+++ b/docs/ARDUINO_SETUP_GUIDE.md
@@ -433,8 +433,8 @@ features layer on top.
 | D6  | Trunk button input (pull-up)           | **NO momentary switch → GND** |
 | D7  | Front-Left  UP   relay (hold)          | Relay module IN2 |
 | D8  | Front-Left  DOWN relay (hold)          | Relay module IN3 |
-| **D9**  | **7" display backlight PWM**          | **Display "PWM" pad** |
-| **D10** | **4.3" display backlight PWM**        | **Display PWM pad (M_PWM)** |
+| **D9**  | **main 10.1" display backlight PWM**  | **Display "PWM" pad** |
+| **D10** | **second 6.86" display backlight PWM** | **Display PWM pad (M_PWM)** |
 | D11 | Front-Right UP   relay (hold)          | Relay module IN4 |
 | D12 | Front-Right DOWN relay (hold)          | Relay module IN5 |
 | D13 | Status LED (on-board, no wiring)       | — |
@@ -587,7 +587,7 @@ Check `journalctl -u bcm-headunit | grep -i arduino` after boot.
 
 Once both Arduinos are flashed and verified:
 
-- Wire the display PWM pads to **Nano D9 (large 7") and D10 (small 4.3")**
+- Wire the display PWM pads to **Nano D9 (main 10.1") and D10 (second 6.86")**
   plus a common GND, then verify in Serial Monitor with
   `{"cmd":"backlight","display":"large","brightness":20}` and watch the
   screen dim.

--- a/docs/SCHEMATY_POLACZEN.md
+++ b/docs/SCHEMATY_POLACZEN.md
@@ -160,8 +160,8 @@ dioda TVS 1.5KE33CA równolegle oraz kondensator 470 µF / 35 V równolegle.
 | 39 | XL6019 **OUT +** (15) | wtyk M910q, **środek** | 1,5 mm² | 5 A |
 | 40 | XL6019 **OUT −** (16) | wtyk M910q, **ekran** | 1,5 mm² | — |
 | 39a | XL6019 **OUT +** ↔ **OUT −** | kondensator 470 µF / 35 V low-ESR | — | — |
-| 41 | Buck MP1584 **OUT +** | panel 7" / 10", 5 V | 1,0 mm² | — |
-| 42 | Buck MP1584 **OUT +** | panel 4,3", 5 V | 1,0 mm² | — |
+| 41 | Buck MP1584 **OUT +** | panel główny 10,1", 5 V | 1,0 mm² | — |
+| 42 | Buck MP1584 **OUT +** | panel drugi 6,86", 5 V *(opcjonalny)* | 1,0 mm² | — |
 | 43 | Buck MP1584 **OUT −** | masa paneli (wspólna z Nano #1) | 1,0 mm² | — |
 
 > **Dioda gaszeniowa 1N4007** równolegle do cewki przekaźnika: **katoda do
@@ -289,8 +289,8 @@ i § 7b. Poniżej to, co dotyczy okablowania międzymodułowego.
 | D5 | Moduł przekaźników **IN1** (bagażnik) |
 | D6 | przycisk bagażnika → masa |
 | D7, D8 | **IN2, IN3** — szyba przód lewa góra/dół |
-| D9 | panel 7" — **M_PWM** |
-| D10 | panel 4,3" — **M_PWM** |
+| D9 | panel główny 10,1" — **M_PWM** |
+| D10 | panel drugi 6,86" — **M_PWM** |
 | D11, D12 | **IN4, IN5** — szyba przód prawa |
 | A0, A1 | **IN6, IN7** — szyba tył lewa |
 | A2, A3 | **IN8, IN9** — szyba tył prawa |
@@ -332,8 +332,14 @@ Patrz §3.3 i §3.4. Funkcje włącza się `#define FEATURE_*` na górze
 
 | Skąd | Dokąd | Uwagi |
 |------|-------|-------|
-| M910q **DP-1** | przejściówka pasywna DP → HDMI → wyświetlacz główny | dashboard, port 5002 |
-| M910q **DP-2** | przejściówka pasywna DP → HDMI → wyświetlacz mały | statystyki, port 5003 |
+| M910q, wyjście główne | wyświetlacz **10,1" 1280×800** + dotyk USB | dashboard, port 5002 |
+| M910q, wyjście drugie | wyświetlacz **6,86" 1280×480** *(opcjonalny)* | statystyki, port 5003 |
+
+> **Nazwy złączy sprawdź na swojej maszynie**, nie zakładaj z góry. Na
+> referencyjnym M910q złącza enumerują się jako `HDMI-A-1` / `HDMI-A-2`
+> (xrandr: `HDMI-1` / `HDMI-2`), a **główny panel wyszedł na złączu 2** —
+> patrz komentarz w `config/scripts/bcm-splash-play.sh`. Jeżeli Twoja sztuka
+> ma wyjścia DisplayPort, potrzebne będą pasywne przejściówki DP → HDMI.
 
 Nazwy złączy sprawdź: `for f in /sys/class/drm/card*-*/status; do echo "$f: $(cat $f)"; done`
 

--- a/docs/URUCHOMIENIE.md
+++ b/docs/URUCHOMIENIE.md
@@ -5,6 +5,8 @@ przez produkcyjną instalację w aucie (Lenovo M910q), po firmware Arduino.
 
 > **Platforma produkcyjna: Lenovo ThinkCentre M910q Tiny.** Pełna
 > dokumentacja wdrożeniowa: [`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md).
+> Wariant minimalny do bieżącej weryfikacji (Android Auto + dźwięk + SWC,
+> reszta wyłączona): [`WDROZENIE_TESTOWE.md`](WDROZENIE_TESTOWE.md).
 > Zasilanie buforowane (step-up 19/20 V, bank AGM CSB HR1221W, ładowanie,
 > blokada przeładowania): [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md).
 > Materiały dla Orange Pi 5 Pro / 5 Plus, stanowiska Orange Pi PC i testów
@@ -32,8 +34,8 @@ Po starcie otwórz w przeglądarce:
 
 | Adres | Co to jest |
 |-------|------------|
-| http://localhost:5002 | Główny ekran (7/8" dotykowy) — strony A1–A8 + Settings, 3 motywy; Android Auto i Bluetooth zintegrowane na tym porcie |
-| http://localhost:5003 | Mały wyświetlacz (4.3") — karuzela statystyk + kamera cofania |
+| http://localhost:5002 | Główny ekran (10,1" dotykowy, 1280×800) — strony A1–A8 + Settings, 3 motywy; Android Auto i Bluetooth zintegrowane na tym porcie |
+| http://localhost:5003 | Drugi wyświetlacz (6,86" widescreen 1280×480) — karuzela statystyk + kamera cofania |
 
 Zatrzymanie: `Ctrl+C`.
 
@@ -254,7 +256,7 @@ co obowiązuje, gdyby klucz usunąć z YAML-a.
 | `wifi_ap` | WiFi dla Android Auto wireless (Wi-Fi Direct / P2P-GO, karta wewnętrzna) | `true` | wyłączony |
 | `wifi_hotspot` | Dodatkowy Access Point ALFA-NET (współdzielenie internetu — **wymaga osobnego dongla WiFi**) | `false` | wyłączony |
 | `route_planner` | Planowanie trasy / travel plan (OpenRouteService, TomTom) | `true` | włączony |
-| `small_display` | Serwer małego wyświetlacza 4.3" (port 5003) | `true` | włączony |
+| `small_display` | Serwer drugiego wyświetlacza 6,86" (port 5003) | `true` | włączony |
 
 Uwaga: honorowane są też starsze klucze (`bluetooth.enabled`,
 `wifi.enabled`, `fuel_sender.enabled`, blok `modules_v85.*`), ale

--- a/docs/WDROZENIE_M910Q.md
+++ b/docs/WDROZENIE_M910Q.md
@@ -49,6 +49,7 @@ sprzęt → zasilanie → BIOS → OS → BCM → usługi → kiosk → peryferi
 | Temat | Gdzie szukać |
 |-------|--------------|
 | Symulacja na laptopie (bez sprzętu) | [`URUCHOMIENIE.md`](URUCHOMIENIE.md) § 1 |
+| **Wariant testowo-rozwojowy** (AA + dźwięk + SWC, reszta wyłączona) | [`WDROZENIE_TESTOWE.md`](WDROZENIE_TESTOWE.md) |
 | Szczegóły zasilania buforowanego | [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) |
 | Tabele połączeń, przekroje, kolejność montażu | [`SCHEMATY_POLACZEN.md`](SCHEMATY_POLACZEN.md) |
 | Rozmieszczenie podzespołów w aucie | [`../schematics/vehicle_layout_m910q.svg`](../schematics/vehicle_layout_m910q.svg) |
@@ -117,8 +118,8 @@ wspornik. Wszystkie kable spinaj opaskami, bo na dziurach będzie grzechotać.
 | 1 | Mini-PC | Lenovo M910q Tiny (i5-6400T, 8 GB, 256 GB) — używany | 1 | 200–400 |
 | 2 | Karta WiFi + BT | Fenvi FU-AX1800 (MT7921, WiFi 6 + BT 5.2) | 1 | 120–180 |
 | 3 | Przetwornica step-up | **XL6019** 12 V → 19,5 V — posiadana, ok. 45 W, patrz `ZASILANIE_BUFOROWANE.md` §3 | 1 | 15–30 |
-| 4 | Wyświetlacz główny | 7" IPS 1024×600 HDMI + dotyk USB (QDtech MPI5001) | 1 | 200–350 |
-| 5 | Wyświetlacz mały | 4,3" TFT 800×480 HDMI, bez dotyku | 1 | 150–250 |
+| 4 | Wyświetlacz główny | **10,1" IPS 1280×800** + dotyk USB | 1 | 300–500 |
+| 5 | Wyświetlacz drugi *(opcjonalny)* | **6,86" widescreen 1280×480**, bez dotyku | 0–1 | 150–300 |
 | 6 | Przejściówki DP → HDMI | pasywne, kablowe | 2 | 20–30 |
 | 7 | DAC USB | ES9038Q2M, wyjście RCA | 1 | 45–75 |
 | 8 | Wzmacniacz | **gotowy 4-kanałowy samochodowy**, wejścia RCA, klasa D, 4 × 50–75 W RMS | 1 | 250–600 |
@@ -484,7 +485,7 @@ mkdir -p /opt/bcm/assets/splash
 # 10":  ffmpeg -i source.mp4 -vf scale=1280:800 -c:v libx264 -crf 23 -c:a aac -y main.mp4
 cp twoj_splash.mp4 /opt/bcm/assets/splash/main.mp4
 
-# mały — bez dźwięku, 800×480
+# drugi ekran — bez dźwięku, 1280×480
 # ffmpeg -i source.mp4 -vf scale=800:480 -an -c:v libx264 -crf 23 -y small.mp4
 cp twoj_splash_maly.mp4 /opt/bcm/assets/splash/small.mp4
 ```
@@ -593,8 +594,16 @@ HDMI — potrzebne są **pasywne przejściówki DP → HDMI** (~10–15 PLN/szt.
 
 | Wyjście | Wyświetlacz | Rozdzielczość | Zawartość | Port |
 |---------|-------------|---------------|-----------|------|
-| DP-1 | 7"/10" IPS dotykowy | 1024×600 lub 1280×800 | dashboard BCM (A1–A8 + Settings) | 5002 |
-| DP-2 | 4,3" TFT | 800×480 | karuzela statystyk + kamera cofania | 5003 |
+| główne | **10,1" IPS dotykowy** | **1280×800** | dashboard BCM (A1–A8 + Settings) | 5002 |
+| drugie | **6,86" widescreen** *(opcjonalne)* | **1280×480** | karuzela statystyk + kamera cofania | 5003 |
+
+Wartości pochodzą z `display.dashboard` i `display.small` w
+`config/bcm_config.yaml` — to one są źródłem prawdy, a nie ten opis.
+
+> **Drugi ekran jest opcjonalny i obsługuje hotplug.** `small-display-watch.sh`
+> (uruchamiany z wygenerowanego `~/.xinitrc`) podnosi i zdejmuje okno
+> Chromium, gdy panel zostanie wpięty lub wypięty po starcie systemu.
+> Nie musi być podłączony przy boocie.
 
 Wykrycie nazw złączy:
 
@@ -751,6 +760,12 @@ journalctl -u bcm-headunit | grep -i openauto
 Tor: **ES9038Q2M (DAC USB) → RCA → gotowy wzmacniacz samochodowy →
 głośniki 4 Ω**. Schemat: [`../schematics/audio_system.svg`](../schematics/audio_system.svg).
 
+> **DAC USB nie jest warunkiem uruchomienia.** `src/audio/pipewire_ctrl.py`
+> na x86 używa **domyślnego sinka PipeWire**, więc wbudowane wyjście analogowe
+> M910q (mini-jack) działa bez zmian w kodzie — `wpctl set-default <ID>`
+> i tyle. DAC to podniesienie jakości, nie wymóg. Wariant na samym mini-jacku:
+> [`WDROZENIE_TESTOWE.md`](WDROZENIE_TESTOWE.md).
+
 Wzmacniacz to **kupiony moduł samochodowy**, nie układ DIY: 4 kanały,
 wejścia RCA, klasa D, 4 × 50–75 W RMS na 4 Ω. Podłączany jak radio —
 zasilanie wprost z akumulatora rozruchowego, własna masa, wyzwalanie REM.
@@ -802,7 +817,7 @@ zawsze pierwszeństwo.
 | `wifi_hotspot` | osobny dongiel USB WiFi (§13.1) |
 | `weather` | klucz API OpenWeatherMap |
 | `route_planner` | klucze OpenRouteService / TomTom |
-| `network` | `config/lte.conf` na bazie `config/lte.conf.example` |
+| `network` | na x86 **tylko raportuje** stan łącza — połączenie robi NetworkManager; `config/lte.conf` dotyczy wariantu ARM |
 | `battery` | ⚠ patrz §19.3 — nie działa bez dorobienia dzielnika i progów |
 
 ---
@@ -933,12 +948,30 @@ instalację bez pełnego resetu.
 Rzeczy wykryte przy porządkowaniu dokumentacji. Żadna nie blokuje wdrożenia,
 ale wszystkie potrafią kosztować godzinę szukania.
 
-### 19.1 `setup-x86.sh` domyślnie zakłada HDMI, nie DisplayPort
+### 19.1 Nazwy złączy — sprawdź na maszynie, nie w specyfikacji
 
-`config/scripts/setup-x86.sh` ma w USER CONFIG `MAIN_OUTPUT="HDMI-1"` /
-`SMALL_OUTPUT="HDMI-2"`, podczas gdy M910q ma **dwa wyjścia DisplayPort**
-i złącza zwykle nazywają się `DP-1` / `DP-2`. **Zawsze sprawdź faktyczne
-nazwy przed uruchomieniem skryptu** (§6.5).
+Wcześniejsze wydanie tej dokumentacji twierdziło, że skrypty błędnie używają
+nazw `HDMI-*`, bo M910q ma dwa wyjścia DisplayPort. **To było ustalenie
+z tabeli specyfikacji, nie z maszyny — i jest sprzeczne z tym, co widać
+w kodzie.**
+
+`config/scripts/bcm-splash-play.sh` oraz `config/systemd/bcm-splash-main.service`
+zawierają notatki z realnej diagnostyki na tej sztuce M910q: złącza
+enumerują się jako **`HDMI-A-1` / `HDMI-A-2`**, a główny panel wyszedł na
+**złączu 2** (stara konfiguracja przypięta na sztywno do `HDMI-A-1` powodowała
+znikanie splasha, bo tam nic nie było podłączone).
+
+Wnioski:
+
+- **nie zakładaj nazw** — odczytaj je z maszyny:
+  `for f in /sys/class/drm/card*-*/status; do echo "$f: $(cat $f)"; done`
+- `setup-x86.sh` ma teraz `MAIN_OUTPUT="HDMI-2"` / `SMALL_OUTPUT="HDMI-1"`,
+  zgodnie z powyższym; jeżeli na Twojej sztuce jest odwrotnie, zamień je
+  miejscami (główny panel ciemny, a drugi pokazuje dashboard = zamienione),
+- splash **nie wymaga** już żadnej konfiguracji złącza — wykrywa wszystkie
+  podłączone automatycznie,
+- jeżeli Twój egzemplarz faktycznie ma wyjścia DisplayPort, potrzebne będą
+  pasywne przejściówki DP → HDMI; nazwy złączy i tak odczytaj z systemu.
 
 ### 19.2 Limit prądu ładowania jest za wysoki dla CSB HR1221W
 
@@ -1007,6 +1040,7 @@ mimo neutralnej nazwy. Został zarchiwizowany jako
 
 | Dokument | Zakres |
 |----------|--------|
+| [`WDROZENIE_TESTOWE.md`](WDROZENIE_TESTOWE.md) | wariant minimalny do bieżącej weryfikacji + lista zakupowa na już |
 | [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) | zasilanie buforowane: schematy, dobór, lista zakupowa, procedura rozruchu |
 | [`SCHEMATY_POLACZEN.md`](SCHEMATY_POLACZEN.md) | schematy połączeniowe: tabele „skąd → dokąd”, przekroje, bezpieczniki, masy |
 | [`URUCHOMIENIE.md`](URUCHOMIENIE.md) | symulacja na laptopie, przełączniki modułów, Arduino w skrócie |

--- a/docs/WDROZENIE_TESTOWE.md
+++ b/docs/WDROZENIE_TESTOWE.md
@@ -1,0 +1,370 @@
+# Wdrożenie testowo-rozwojowe — minimalny zestaw
+
+Wariant do bieżącej weryfikacji i poprawek: **Android Auto + dźwięk przez
+mini-jack M910q, ekran 7", przyciski SWC, modem LTE**, zasilanie z posiadanego
+banku i modułów. Wszystko pozostałe wyłączone.
+
+Wdrożenie docelowe (pełne): [`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md).
+
+> **Ekran 7" to konfiguracja tymczasowa.** Docelowy panel to **10,1"
+> 1280×800**, opcjonalnie drugi **6,86" 1280×480** — i tak jest ustawione
+> w `config/bcm_config.yaml`. Ten wariant używa osobnego pliku
+> `config/bcm_config_bench.yaml` z 1024×600, żeby nie ruszać konfiguracji
+> produkcyjnej.
+
+---
+
+## Spis treści
+
+1. [Co uruchamiamy](#1-co-uruchamiamy)
+2. [Co już masz](#2-co-już-masz)
+3. [Zasilanie — wersja minimalna](#3-zasilanie--wersja-minimalna)
+4. [Lista zakupowa](#4-lista-zakupowa)
+5. [Instalacja software'u](#5-instalacja-softwareu)
+6. [Uruchomienie](#6-uruchomienie)
+7. [Odbiór](#7-odbiór)
+8. [Czego celowo nie ma](#8-czego-celowo-nie-ma)
+9. [Droga do wersji docelowej](#9-droga-do-wersji-docelowej)
+
+---
+
+## 1. Co uruchamiamy
+
+Pięć modułów zamiast dwudziestu ośmiu:
+
+| Moduł | Po co | Czego wymaga |
+|-------|-------|--------------|
+| `dashboard` | frontend na porcie 5002 | ekran 7" + Chromium |
+| `multimedia` | **Android Auto** (openauto) | telefon po kablu USB |
+| `input` | **przyciski SWC** | Arduino Pro Micro (USB HID) |
+| `audio` | głośność i EQ | wyjście analogowe M910q |
+| `network` | status łącza | modem LTE (przez NetworkManager) |
+
+Reszta — OBD, kamery, parkowanie, czujniki, przekaźniki, GPS, alarm,
+Bluetooth, WiFi AP — **wyłączona**, bo nie ma podłączonego sprzętu. Włączanie
+modułów bez hardware'u produkuje tylko szum w logach.
+
+### Dwa ustalenia z kodu, które upraszczają ten wariant
+
+**Dźwięk nie wymaga DAC-a USB.** `src/audio/pipewire_ctrl.py` na x86 używa
+**domyślnego sinka PipeWire** — czyli tego, co ustawisz w systemie. Wyjście
+analogowe M910q (mini-jack) działa bez żadnych zmian w kodzie. DAC USB
+ES9038Q2M to podniesienie jakości, nie warunek uruchomienia.
+
+**Modem LTE nie wymaga konfiguracji w BCM.** `src/network/lte.py` na x86
+tylko **raportuje** stan łącza (`lte.connected`, `lte.signal`, `lte.ip`);
+samo połączenie robi NetworkManager. Huawei E3372 w trybie HiLink zgłasza się
+jako karta sieciowa i działa od podłączenia.
+
+---
+
+## 2. Co już masz
+
+| Element | Uwaga |
+|---------|-------|
+| Lenovo M910q | |
+| Ekran 7" | 1024×600, HDMI + dotyk USB |
+| Pody SWC + dekoder | rezystorowa drabinka → wejście analogowe |
+| Modem LTE Huawei E3372 | HiLink, USB |
+| Akumulatory CSB HR1221W × 8 | AGM 12 V / 5,1 Ah |
+| **XL6019** | step-up 12 → 19,5 V dla M910q |
+| **XH-M609** | LVD, ochrona banku przed rozładowaniem |
+
+---
+
+## 3. Zasilanie — wersja minimalna
+
+To jest miejsce, gdzie da się zaoszczędzić najwięcej, i to bez pogorszenia
+bezpieczeństwa.
+
+### 3.1 Czego NIE potrzebujesz na stanowisku
+
+Na biurku nie ma alternatora, więc **cały tor ładowania jest zbędny**:
+
+| Element | Dlaczego zbędny na stanowisku |
+|---------|------------------------------|
+| Ładowarka CC-CV / B2B | nie ma z czego ładować — bank ładujesz między sesjami ładowarką sieciową |
+| VSR (rozdział ładowania) | nie ma akumulatora rozruchowego, od którego trzeba się odseparować |
+| Rozłącznik nadnapięciowy | zagrożeniem był alternator; ładowarka sieciowa ma własną regulację |
+| Przekaźnik zapłonu | włączasz wyłącznikiem, nie kluczykiem |
+| Dioda TVS, kondensator wejściowy | chroniły przed load dumpem alternatora |
+
+To oszczędza **od 150 do 1000 PLN** (w zależności od wariantu ładowarki)
+i wycina najbardziej kłopotliwą część układu.
+
+### 3.2 Czego potrzebujesz
+
+```
+bank AGM (2–3 pakiety)
+   │  bezpiecznik 10 A na „+” każdego pakietu
+   ▼
+XH-M609 (LVD)  ── bezpiecznik 15 A przed VIN+
+   │  odcięcie 11,00 V · powrót 12,60 V
+   ▼
+wyłącznik / rozłącznik
+   │
+   ▼
+XL6019 (step-up 12 → 19,5 V)  ── bezpiecznik 5 A na wyjściu
+   │
+   ▼
+M910q — oryginalny wtyk
+```
+
+Cztery elementy, wszystkie już masz poza bezpiecznikami i przewodami.
+
+### 3.3 Ile pakietów
+
+**Dwa do trzech, nie pięć.** Na stanowisku mniej energii to mniej rzeczy, które
+mogą pójść źle, a czasu i tak wystarcza:
+
+| Pakiety | Pojemność | Czas pracy przy ~2,7 A (M910q ~30 W) |
+|---------|-----------|--------------------------------------|
+| 2 | 10,2 Ah | ~1,9 h do 50 % DoD |
+| 3 | 15,3 Ah | ~2,8 h do 50 % DoD |
+| 5 | 25,5 Ah | ~4,7 h do 50 % DoD |
+
+Sesja rozwojowa rzadko trwa dłużej niż dwie godziny bez przerwy, a lżejszy
+zestaw łatwiej przestawić.
+
+> **Bezpieczników na pakietach nie pomijaj nawet na stanowisku.** Zwarty
+> HR1221W potrafi oddać ponad 100 A — 5 Ah wystarczy, żeby zapalić przewód.
+
+### 3.4 Nastawy modułów
+
+| Moduł | Nastawa | Uwaga |
+|-------|---------|-------|
+| **XL6019** | wyjście **19,5 V** pod obciążeniem | ustaw multimetrem, zabezpiecz potencjometr |
+| **XH-M609** | odcięcie **11,00 V**, powrót **12,60 V** | sprawdź, czy pracuje stabilnie przy 11 V |
+
+Obowiązkowe sprawdzenia obu modułów przed pierwszym załączeniem:
+[`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) §3.4 i §7.3.
+
+> **Limit poboru CPU ustaw od razu**, nie „potem". XL6019 daje ok. 45 W,
+> a M910q pod pełnym obciążeniem czterech wątków dobija do 55 W. Instrukcja:
+> [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) §3.5a.
+
+---
+
+## 4. Lista zakupowa
+
+### 4.1 Obowiązkowe
+
+| # | Element | Specyfikacja | Cena (PLN) |
+|---|---------|--------------|-----------|
+| 1 | Oprawki bezpiecznikowe inline + wkładki | 10 A × 3 (pakiety), 15 A × 1 (LVD), 5 A × 1 (step-up) | 25–40 |
+| 2 | Przewód 2,5 mm² | czerwony + czarny, po 2 m | 20–30 |
+| 3 | Przewód 1,5 mm² | czerwony + czarny, po 2 m | 12–20 |
+| 4 | Nasuwki F2 6,35 mm izolowane | do zacisków HR1221W, komplet | 15–25 |
+| 5 | Konektory oczkowe + koszulki termokurczliwe | zestaw | 20–30 |
+| 6 | Wyłącznik / rozłącznik | kołyskowy 20 A albo rozłącznik masy | 15–40 |
+| 7 | Kabel USB do telefonu | dobrej jakości, do **Android Auto po kablu** | 20–40 |
+| | | **Razem** | **~130–225 PLN** |
+
+### 4.2 Zależne od tego, co już masz
+
+| # | Element | Kiedy potrzebne | Cena (PLN) |
+|---|---------|----------------|-----------|
+| 8 | **Arduino Pro Micro** (ATmega32U4) | jeśli nie masz — pody SWC bez niego nie zadziałają | 40–60 |
+| 9 | **Wtyk zasilania do M910q** | najtaniej: odetnij kabel od oryginalnego zasilacza (koszt 0). Kupować tylko, jeśli zasilacza nie masz | 0–40 |
+| 10 | **Przejściówka DP → HDMI** | tylko jeśli Twój egzemplarz M910q ma wyjścia DisplayPort — sprawdź (§5.2) | 0–25 |
+| 11 | **Ładowarka sieciowa AGM** | do doładowania banku między sesjami; zwykła prostownikowa z trybem AGM wystarcza | 0–250 |
+| 12 | **Zaciskarka zapadkowa** | zaciski robione kombinerkami to najczęstsza usterka instalacji | 0–150 |
+
+### 4.3 Warto, ale nie na start
+
+| # | Element | Po co | Cena (PLN) |
+|---|---------|-------|-----------|
+| 13 | Woltomierz/amperomierz panelowy z bocznikiem | podgląd banku i poboru bez multimetru | 40–70 |
+| 14 | Radiator + wentylator 40 mm do XL6019 | na stanowisku przy ~30 W jeszcze nie krytyczne, w aucie obowiązkowe | 20–35 |
+
+### 4.4 Czego **nie** kupuj na tym etapie
+
+| Element | Dlaczego |
+|---------|----------|
+| Ładowarka CC-CV / B2B | bez alternatora nie ma czego regulować — §3.1 |
+| VSR, rozłącznik nadnapięciowy | jw. |
+| DAC USB ES9038Q2M | mini-jack M910q wystarcza do weryfikacji — §1 |
+| Karta WiFi MT7921 | AA po kablu nie potrzebuje P2P-GO |
+| Wzmacniacz, głośniki | na stanowisku wystarczą głośniki komputerowe albo słuchawki |
+| Drugi ekran, kamery, graber, czujniki | odpowiednie moduły są wyłączone |
+
+**Realny koszt startu: ~130–225 PLN**, plus Pro Micro i ładowarka AGM,
+jeśli ich nie masz.
+
+---
+
+## 5. Instalacja software'u
+
+### 5.1 System i BCM
+
+Debian 13 (Trixie) minimal + pakiety + `/opt/bcm` + venv —
+kroki §5 i §6 z [`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md). Bez zmian.
+
+### 5.2 Nazwy złączy — sprawdź, nie zakładaj
+
+```bash
+for f in /sys/class/drm/card*-*/status; do echo "$f: $(cat $f)"; done
+xrandr | grep " connected"
+```
+
+Na referencyjnym M910q złącza enumerują się jako `HDMI-A-1` / `HDMI-A-2`,
+a główny panel wyszedł na **złączu 2**. Twoja sztuka może mieć inaczej.
+
+### 5.3 Wyjście audio na mini-jack
+
+```bash
+# lista sinków
+wpctl status
+
+# ustaw analogowe wyjście M910q jako domyślne (podstaw swoje ID)
+wpctl set-default <ID_sinka_analogowego>
+
+# test
+speaker-test -c2 -twav -l1
+```
+
+BCM nie wymaga tu żadnej konfiguracji — bierze domyślny sink.
+
+### 5.4 Konfiguracja stanowiska
+
+Repozytorium zawiera gotowy plik `config/bcm_config_bench.yaml`: pięć
+modułów włączonych, reszta wyłączona, ekran 1024×600.
+
+> `--config` **podmienia całą konfigurację**, nie nakłada się na
+> `bcm_config.yaml`. Dlatego jest to pełna kopia z pozmienianymi kluczami,
+> a nie krótka nakładka.
+
+### 5.5 Firmware Pro Micro
+
+```bash
+make -C arduino rotary_encoder-upload PORT=/dev/ttyACM0
+```
+
+Pody SWC podłącz do **A0** (Pod 1) i **A6** (Pod 2), dekoder: czerwony → ACC
+(na stanowisku +12 V), czarny → masa. Kalibracja: przytrzymaj HOME + BACK
+przy starcie płytki i naciskaj kolejne przyciski wg podpowiedzi na porcie
+szeregowym. Progi zapisują się w EEPROM.
+
+Szczegóły: [`ARDUINO_SETUP_GUIDE.md`](ARDUINO_SETUP_GUIDE.md).
+
+### 5.6 Android Auto
+
+`openauto` kompilowany ze źródeł — procedura w
+[`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md) §13.3. Na tym etapie używamy
+**połączenia po kablu USB**: bez Bluetootha i bez WiFi P2P, czyli o dwie
+warstwy mniej do diagnozowania.
+
+---
+
+## 6. Uruchomienie
+
+### 6.1 Ręcznie (do rozwoju)
+
+```bash
+cd /opt/bcm
+source .venv/bin/activate
+python3 main.py --platform x86 --config config/bcm_config_bench.yaml --frontend
+```
+
+Dashboard: `http://localhost:5002`. Zatrzymanie: `Ctrl+C`.
+
+Sprawdzenie bez startowania modułów:
+
+```bash
+python3 main.py --platform x86 --config config/bcm_config_bench.yaml --dry-run
+```
+
+Powinno wypisać **5 modules would load**.
+
+### 6.2 Kiosk
+
+Na stanowisku wystarczy Chromium ręcznie:
+
+```bash
+chromium --app=http://localhost:5002 --window-size=1024,600 --start-fullscreen
+```
+
+Pełny kiosk z autologinem, splashem i usługami systemd zostaw na wersję
+docelową — §7–§8 [`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md).
+
+### 6.3 Kolejność załączania
+
+```
+1. Bank odłączony, wyłącznik ROZWARTY
+2. Nastawy XL6019 i XH-M609 sprawdzone na zasilaczu laboratoryjnym
+3. Bezpieczniki na pakietach założone
+4. Bank podłączony do XH-M609 (bezpiecznik 15 A)
+5. Pomiar napięcia na wyjściu XL6019 BEZ podłączonego M910q → 19,5 V
+6. Dopiero teraz M910q
+```
+
+Punkt 5 pomijany „bo przecież ustawiałem" to najczęstszy sposób na zabicie
+płyty głównej.
+
+---
+
+## 7. Odbiór
+
+```
+[ ] python3 main.py --dry-run pokazuje 5 modułów
+[ ] curl http://localhost:5002 zwraca HTML
+[ ] Dashboard widoczny na ekranie 7"
+[ ] Dotyk działa
+[ ] wpctl status pokazuje analogowe wyjście jako domyślny sink
+[ ] Dźwięk słychać (speaker-test)
+[ ] Przyciski SWC wywołują akcje (głośność, utwory)
+[ ] Modem LTE widoczny w nmcli device, BCM raportuje łącze
+[ ] Android Auto łączy się po kablu USB
+[ ] Napięcie na wtyku M910q ≥ 19,0 V pod obciążeniem
+[ ] Po 30 min pracy XL6019 nie parzy w dotyku
+[ ] XH-M609 odcina przy 11,00 V (test zasilaczem, nie rozładowywaniem banku)
+```
+
+---
+
+## 8. Czego celowo nie ma
+
+| Nie ma | Wróci przy |
+|--------|-----------|
+| Ładowania banku | zabudowie w aucie (§5 `ZASILANIE_BUFOROWANE.md`) |
+| Domen A/B i przekaźnika zapłonu | zabudowie w aucie |
+| Drugiego ekranu | panelu 6,86" — jest hot-plug, wystarczy wpiąć |
+| OBD / K-Line | CP2102 + L9637D |
+| Kamer, parkowania, czujników | grabera, HC-SR04, DS18B20, obu Nano |
+| Bluetooth, WiFi AP | karty MT7921 i przejścia na AA wireless |
+| Wzmacniacza i głośników | zakupie gotowego modułu |
+
+---
+
+## 9. Droga do wersji docelowej
+
+Kolejność, w jakiej warto to rozbudowywać — każdy krok jest niezależny
+i weryfikowalny osobno:
+
+| Krok | Co dochodzi | Co włączyć w configu |
+|------|-------------|---------------------|
+| 1 | ekran 10,1" 1280×800 | `display.dashboard` → 1280×800 (czyli `bcm_config.yaml`) |
+| 2 | karta MT7921 → AA wireless | `bluetooth`, `wifi_ap` |
+| 3 | wzmacniacz + głośniki | bez zmian w configu |
+| 4 | CP2102 + L9637D | `obd`, `obd.use_real_hardware: true` |
+| 5 | Nano #2 (sensor hub) | `environment`, `rain_sensor`, `blinker_monitor` |
+| 6 | Nano #1 + przekaźniki | `central_lock`, `lighting` |
+| 7 | kamery + graber | `camera`, `crash_detect` |
+| 8 | GPS | `location`, `tracking` |
+| 9 | ekran 6,86" | `small_display` (hotplug — wystarczy wpiąć) |
+| 10 | zabudowa w aucie, pełne zasilanie | `power` + tor ładowania |
+
+Po każdym kroku przełóż odpowiedni klucz z `bcm_config_bench.yaml` albo
+przejdź na `bcm_config.yaml`, gdy większość będzie już podłączona.
+
+---
+
+## Powiązane dokumenty
+
+| Dokument | Zakres |
+|----------|--------|
+| [`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md) | wdrożenie docelowe, pełne |
+| [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) | nastawy XL6019 i XH-M609, sprawdzenia przed załączeniem |
+| [`SCHEMATY_POLACZEN.md`](SCHEMATY_POLACZEN.md) | tabele połączeń dla wersji docelowej |
+| [`ARDUINO_SETUP_GUIDE.md`](ARDUINO_SETUP_GUIDE.md) | Pro Micro, kalibracja SWC |
+| [`URUCHOMIENIE.md`](URUCHOMIENIE.md) | symulacja bez sprzętu, przełączniki modułów |

--- a/docs/X86_PLATFORM_SETUP.md
+++ b/docs/X86_PLATFORM_SETUP.md
@@ -42,8 +42,13 @@ use passive DP-to-HDMI adapter cables (~10-15 PLN each).
 
 | Output | Display | Resolution | Content |
 |--------|---------|-----------|---------|
-| DP-1 | 7" or 10" IPS touchscreen (main) | 1024×600 or 1280×800 | BCM dashboard (port 5002) |
-| DP-2 | 4.3" TFT (small, status) | 800×480 | Small dashboard (port 5003) |
+| main | 10.1" IPS touchscreen | 1280×800 | BCM dashboard (port 5002) |
+| second | 6.86" widescreen, optional | 1280×480 | Small dashboard (port 5003) |
+
+These are the values in `display.dashboard` / `display.small` in
+`config/bcm_config.yaml`, which is the source of truth. The second panel is
+hot-pluggable — `small-display-watch.sh` raises and drops its window when the
+connector appears or disappears.
 
 **Discover your connector names** (run after OS install):
 ```bash
@@ -335,8 +340,8 @@ Edit `config/bcm_config.yaml` for your main display:
 ```yaml
 display:
   dashboard:
-    width: 1024       # 7" display; for 10" use 1280
-    height: 600       # 7" display; for 10" use 800
+    width: 1280       # 10.1" panel (production default)
+    height: 800       # set 1024x600 if you are bench-testing on a 7" panel
 ```
 
 ### 5.4 Test BCM manually
@@ -445,7 +450,7 @@ mkdir -p /opt/bcm/assets/splash
 # 10": ffmpeg -i source.mp4 -vf scale=1280:800 -c:v libx264 -crf 23 -c:a aac -y main.mp4
 cp your_main_video.mp4 /opt/bcm/assets/splash/main.mp4
 
-# Small display splash (silent, 800x480):
+# Second display splash (silent, 1280x480):
 # ffmpeg -i source.mp4 -vf scale=800:480 -an -c:v libx264 -crf 23 -y small.mp4
 cp your_small_video.mp4 /opt/bcm/assets/splash/small.mp4
 ```

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""BCM v7 — Alfa Romeo 156 Head Unit — Entry Point.
+"""BCM v8.5 — Alfa Romeo 156 Head Unit — Entry Point.
 
 Usage:
     python main.py                              # auto-detect platform, start all enabled modules
@@ -52,12 +52,12 @@ MODULE_REGISTRY: dict[str, dict] = {
 }
 
 # Dashboard is listed for --dry-run reporting but started separately
-DASHBOARD_INFO = {"part": 2, "description": "BCM Dashboard Renderer (4.3\" screen)", "start": start_dashboard}
+DASHBOARD_INFO = {"part": 2, "description": "BCM Dashboard Renderer (web frontend / Pygame)", "start": start_dashboard}
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="BCM v7 — Alfa Romeo 156 Head Unit",
+        description="BCM v8.5 — Alfa Romeo 156 Head Unit",
     )
     parser.add_argument(
         "--platform",
@@ -121,7 +121,7 @@ def main() -> None:
     log = get_logger("main")
 
     log.info("=" * 60)
-    log.info("BCM v7 — Alfa Romeo 156 Head Unit")
+    log.info("BCM v8.5 — Alfa Romeo 156 Head Unit")
     log.info("Version: %s", config.get("system.version", "unknown"))
     log.info("Platform: %s", config.platform)
     log.info("Config: %s", config.config_path)

--- a/schematics/power_buffered_m910q.svg
+++ b/schematics/power_buffered_m910q.svg
@@ -115,8 +115,8 @@
   <rect class="boxB" x="430" y="346" width="300" height="150"/>
   <text class="tl" x="446" y="370">• Lenovo M910q (19 V, do 65 W)</text>
   <text class="tl" x="446" y="390">• hub USB zasilany 7-portowy</text>
-  <text class="tl" x="446" y="410">• wyświetlacz główny 7"/10"</text>
-  <text class="tl" x="446" y="430">• wyświetlacz mały 4,3"</text>
+  <text class="tl" x="446" y="410">• wyświetlacz główny 10,1"</text>
+  <text class="tl" x="446" y="430">• wyświetlacz drugi 6,86" (opc.)</text>
   <text class="tl" x="446" y="450">• Arduino Pro Micro (wejścia, SWC)</text>
   <text class="t" x="580" y="474">pobór ~10 W (szczyt ~55 W)</text>
   <text class="t" x="580" y="490">0 W przy rozwartym przekaźniku</text>

--- a/schematics/power_domains_m910q.svg
+++ b/schematics/power_domains_m910q.svg
@@ -114,8 +114,8 @@
   <text class="tl" x="738" y="514">Pro Micro, GPS, LTE, mikrofon</text>
 
   <rect class="box" x="932" y="458" width="162" height="70"/>
-  <text class="tl" x="944" y="478">wyświetlacz 7"/10"</text>
-  <text class="tl" x="944" y="496">wyświetlacz 4,3"</text>
+  <text class="tl" x="944" y="478">wyświetlacz 10,1"</text>
+  <text class="tl" x="944" y="496">wyświetlacz 6,86" (opc.)</text>
   <text class="tl" x="944" y="514">DAC USB, graber AHD</text>
 
   <!-- ============ SEPARATE AMP BRANCH ============ -->

--- a/schematics/vehicle_layout_m910q.svg
+++ b/schematics/vehicle_layout_m910q.svg
@@ -105,11 +105,11 @@
 
   <!-- ============ CENTER CONSOLE ============ -->
   <rect class="zoneV" x="486" y="240" width="120" height="26"/>
-  <text class="zt" x="546" y="257">ekran 4,3"</text>
+  <text class="zt" x="546" y="257">ekran 6,86"</text>
   <circle class="pinV" cx="486" cy="240" r="11"/><text class="pinT" x="486" y="244">7</text>
 
   <rect class="zoneV" x="486" y="274" width="120" height="30"/>
-  <text class="zt" x="546" y="293">ekran 7" / 10"</text>
+  <text class="zt" x="546" y="293">ekran 10,1"</text>
   <circle class="pinV" cx="486" cy="274" r="11"/><text class="pinT" x="486" y="278">6</text>
 
   <rect class="zoneV" x="486" y="312" width="120" height="24"/>
@@ -169,8 +169,8 @@
   <text class="tl" x="78" y="638">3 · VSR — rozdział ładowania</text>
   <text class="tl" x="78" y="658">4 · M910q, hub USB, step-up, przekaźnik zapłonu, listwa</text>
   <text class="tl" x="78" y="678">5 · bank 5 × HR1221W, ładowarka CC-CV, LVD, rozłącznik masy</text>
-  <text class="tl" x="78" y="698">6 · wyświetlacz główny 7" / 10" — miejsce fabrycznego radia</text>
-  <text class="tl" x="78" y="718">7 · wyświetlacz mały 4,3"</text>
+  <text class="tl" x="78" y="698">6 · wyświetlacz główny 10,1" 1280×800 — miejsce radia</text>
+  <text class="tl" x="78" y="718">7 · wyświetlacz drugi 6,86" 1280×480 (opcjonalny)</text>
   <text class="tl" x="78" y="738">8 · enkoder, przyciski, panel muzyczny</text>
   <text class="tl" x="78" y="758">9 · Nano #1, Nano #2, moduł przekaźników, HM-10, RXB6</text>
   <text class="tl" x="78" y="778">10 · złącze OBD-II + CP2102 + L9637D (K-Line)</text>

--- a/schematics/wiring_usb_av.svg
+++ b/schematics/wiring_usb_av.svg
@@ -45,18 +45,18 @@
   <text class="sec" x="60" y="92">Obraz</text>
 
   <rect class="modV" x="60" y="102" width="330" height="140"/>
-  <text class="mt" x="225" y="126">Wyświetlacz główny 7" / 10"</text>
-  <text class="ms" x="225" y="144">1024×600 lub 1280×800 · dotyk USB</text>
-  <text class="tl" x="78" y="168">HDMI ← przejściówka pasywna DP-1 → HDMI</text>
+  <text class="mt" x="225" y="126">Wyświetlacz główny 10,1"</text>
+  <text class="ms" x="225" y="144">1280×800 · dotyk USB</text>
+  <text class="tl" x="78" y="168">wyjście główne M910q (sprawdź nazwę złącza)</text>
   <text class="tl" x="78" y="186">USB (dotyk) → hub USB</text>
   <text class="tl" x="78" y="204">zasilanie 5 V ← buck MP1584 (domena B)</text>
   <text class="tl" x="78" y="222">M_PWM ← Nano #1 D9 · GND wspólna z Nano</text>
   <text class="ms" x="225" y="238">dashboard BCM, port 5002</text>
 
   <rect class="modV" x="60" y="262" width="330" height="122"/>
-  <text class="mt" x="225" y="286">Wyświetlacz mały 4,3"</text>
-  <text class="ms" x="225" y="304">800×480 · bez dotyku</text>
-  <text class="tl" x="78" y="328">HDMI ← przejściówka pasywna DP-2 → HDMI</text>
+  <text class="mt" x="225" y="286">Wyświetlacz drugi 6,86" — opcjonalny</text>
+  <text class="ms" x="225" y="304">1280×480 widescreen · bez dotyku · hotplug</text>
+  <text class="tl" x="78" y="328">wyjście drugie M910q · small-display-watch.sh</text>
   <text class="tl" x="78" y="346">zasilanie 5 V ← buck MP1584 (domena B)</text>
   <text class="tl" x="78" y="364">M_PWM ← Nano #1 D10 · GND wspólna z Nano</text>
   <text class="ms" x="225" y="380">karuzela statystyk + kamera cofania, port 5003</text>
@@ -66,10 +66,10 @@
   <path class="wdp" d="M712 166 L712 240 L420 240 L420 320 L390 320"/>
   <text class="wl" x="428" y="316">DP-2</text>
 
-  <text class="warn" x="60" y="404">Oba wyjścia M910q to DisplayPort — potrzebne dwie</text>
-  <text class="warn" x="60" y="420">pasywne przejściówki DP → HDMI.</text>
-  <text class="note" x="60" y="440">Aktywne przejściówki nie są potrzebne i bywają</text>
-  <text class="note" x="60" y="456">źródłem problemów z wykryciem ekranu.</text>
+  <text class="warn" x="60" y="404">Nazwy złączy odczytaj z maszyny, nie zakładaj:</text>
+  <text class="warn" x="60" y="420">/sys/class/drm/card*-*/status</text>
+  <text class="note" x="60" y="440">Na referencyjnym M910q: HDMI-A-1 / HDMI-A-2,</text>
+  <text class="note" x="60" y="456">panel główny wyszedł na złączu 2.</text>
 
   <!-- ============ USB HUB ============ -->
   <text class="sec" x="470" y="268">Hub USB (zasilany, 7 portów)</text>

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,4 +1,4 @@
-"""BCM v7 Core Infrastructure — config, logging, event bus, HAL."""
+"""BCM v8.5 Core Infrastructure — config, logging, event bus, HAL."""
 
 from .config import BCMConfig
 from .event_bus import EventBus

--- a/src/dashboard/__init__.py
+++ b/src/dashboard/__init__.py
@@ -1,1 +1,5 @@
-"""BCM v7 Dashboard Renderer — 4.3" vehicle instrument cluster."""
+"""BCM v8.5 Dashboard Renderer — main 10.1" panel (1280x800).
+
+The optional second display (6.86" widescreen, 1280x480) is served
+separately by src/dashboard/small_viewer.py on port 5003.
+"""


### PR DESCRIPTION
Audyt repozytorium pod kątem tego, **co kod faktycznie robi**, a nie co zakładał projekt. Pięć rzeczy się rozjechało. Do tego nowy wariant wdrożenia testowo-rozwojowego.

## 1. Rozbieżności dokumentacja ↔ kod

### Wyświetlacze — 10,1" + 6,86", nie 7" + 4,3"

`config/bcm_config.yaml` i testy (`test_core.py:19`, `test_multimedia.py:276`) od dawna operują na **10,1" 1280×800** (główny) i **6,86" 1280×480** (drugi, widescreen). Dokumentacja i schematy nadal opisywały 7" 1024×600 + 4,3" 800×480.

Poprawione wszędzie, z zaznaczeniem, że **źródłem prawdy jest `bcm_config.yaml`**, a nie opis.

Przy okazji: **drugi ekran jest opcjonalny i obsługuje hotplug** — `small-display-watch.sh` podnosi i zdejmuje okno Chromium przy wpięciu/wypięciu złącza. Było w kodzie, nie było w żadnym dokumencie.

### Dźwięk nie wymaga DAC-a USB

`src/audio/pipewire_ctrl.py` na x86 używa **domyślnego sinka PipeWire**. Wbudowane wyjście analogowe M910q działa po samym `wpctl set-default`. Dokumentacja czytała się tak, jakby DAC był warunkiem uruchomienia — jest podniesieniem jakości.

### LTE na x86 tylko raportuje

`src/network/lte.py`: na x86 moduł zgłasza stan łącza, a samo połączenie robi NetworkManager. Dokumentacja sugerowała, że moduł steruje modemem.

### Nazwy złączy — korekta mojego wcześniejszego ustalenia

Wcześniejszy commit twierdził, że M910q ma 2× DisplayPort i że nazwy `HDMI-*` w skryptach są błędne. **To wyszło z tabeli specyfikacji, nie z maszyny.**

`bcm-splash-play.sh` i `bcm-splash-main.service` zawierają notatki z realnej diagnostyki na tej sztuce: złącza enumerują się jako `HDMI-A-1` / `HDMI-A-2`, a **główny panel wyszedł na złączu 2** (stara konfiguracja przypięta na sztywno do `HDMI-A-1` powodowała znikanie splasha).

Twierdzenie skorygowane, `MAIN_OUTPUT`/`SMALL_OUTPUT` w `setup-x86.sh` zamienione zgodnie z tym, a udokumentowana procedura to i tak **odczyt nazw z maszyny**.

### Przeterminowane wartości w skryptach

- `setup-x86.sh`: `MAIN_W/H` i `SMALL_W/H` (używane do generowania splasha i kalibracji dotyku) zrównane z `bcm_config.yaml`
- `xinitrc-x86-*`: oznaczone jako **zastąpione przez `setup-x86.sh`**, który generuje `~/.xinitrc` uruchamiający też watcher hotplug — szablony tego nie mają, więc panel wpięty po boocie zostaje ciemny

### Kod kłamiący o sobie

Baner startowy mówił **„BCM v7"** przy wersji 8.5.1, a moduł dashboardu opisywał się jako renderer **4,3"**.

## 2. Wariant testowo-rozwojowy

**`docs/WDROZENIE_TESTOWE.md` + `config/bcm_config_bench.yaml`** — pięć modułów (`dashboard`, `multimedia`, `input`, `audio`, `network`), 1024×600, Android Auto po kablu, dźwięk na mini-jacku.

Zweryfikowane `--dry-run`: **5 modules would load**.

### Sedno: czego ten wariant NIE potrzebuje

Bez alternatora **nie ma czego regulować**, więc cały tor ładowania wypada:

| Element | Dlaczego zbędny |
|---|---|
| Ładowarka CC-CV / B2B | nie ma z czego ładować — bank ładujesz między sesjami |
| VSR | nie ma akumulatora rozruchowego do odseparowania |
| Rozłącznik nadnapięciowy | zagrożeniem był alternator |
| Przekaźnik zapłonu | włączasz wyłącznikiem |
| Dioda TVS, kondensator wejściowy | chroniły przed load dumpem |

To **150–1000 PLN mniej** i wycięcie najbardziej awaryjnej części układu. Zostaje: `bank → XH-M609 → wyłącznik → XL6019 → M910q`.

Dodatkowo **2–3 pakiety zamiast pięciu** — na sesję wystarcza (~1,9–2,8 h przy poborze M910q ~30 W), a zestaw jest lżejszy. **Bezpieczniki na pakietach zostają**: zwarty HR1221W oddaje ponad 100 A.

**Lista zakupowa: ~130–225 PLN** obowiązkowo, plus Pro Micro i ładowarka AGM, jeśli ich nie ma. Osobna sekcja „czego nie kupuj na tym etapie".

Dokument zawiera też mapę rozbudowy do wersji docelowej — 10 kroków, każdy niezależnie weryfikowalny, z informacją który klucz w configu włączyć.

## Weryfikacja

- `pytest tests/` — **419 passed**
- `ruff check .` — **All checks passed**
- `main.py --config config/bcm_config_bench.yaml --dry-run` — 5 modułów
- 131 względnych odnośników `.md` rozwiązuje się
- Oba pliki YAML parsują się, skrypty przechodzą `bash -n`
- SVG zwalidowane i wyrenderowane

---
_Generated by [Claude Code](https://claude.ai/code/session_017cXmt2HyZ8iv3aQHpkNA4c)_