### PR TITLE
Turn the test build into a rolling in-car install with wireless Android Auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ pip install -r requirements.txt -r requirements-x86.txt
 - **Deployment (production, M910q):** `docs/WDROZENIE_M910Q.md` —
   hardware, BIOS, OS, services, verification. Power system in detail:
   `docs/ZASILANIE_BUFOROWANE.md` + `schematics/`.
-- **Bench / dev build** (Android Auto + audio + steering-wheel buttons, the
-  rest switched off): `docs/WDROZENIE_TESTOWE.md`, config
-  `config/bcm_config_bench.yaml`.
+- **Test / dev build** — a rolling install with the full power chain but only
+  wireless Android Auto, audio and the steering-wheel buttons switched on:
+  `docs/WDROZENIE_TESTOWE.md`, config `config/bcm_config_test.yaml`.
 - Repo audit + improvement roadmap: `AUDYT_I_PLAN.md`. Unused legacy
   code lives in `legacy/`; docs for retired platforms (Orange Pi 5 Pro /
   5 Plus, Orange Pi PC bench rig, VMware smoke tests) live in

--- a/config/bcm_config_test.yaml
+++ b/config/bcm_config_test.yaml
@@ -1,8 +1,10 @@
-# BCM v8.5 — konfiguracja STANOWISKA TESTOWO-ROZWOJOWEGO
+# BCM v8.5 — konfiguracja WDROŻENIA TESTOWO-ROZWOJOWEGO
 #
-# Minimalny zestaw do weryfikacji na biurku / w aucie na etapie rozwoju:
+# Minimalny zestaw funkcji, ale instalacja jeżdżąca: zabudowa w aucie
+# z pełnym torem zasilania (ładowanie banku, LVD, przekaźnik zapłonu).
 #   • ekran 7" 1024x600 (docelowy jest 10,1" 1280x800 — patrz bcm_config.yaml)
-#   • Android Auto PO KABLU USB (bez WiFi P2P i bez Bluetooth)
+#   • Android Auto WIRELESS — P2P-GO na karcie MediaTek MT7921, handshake
+#     bootstrapowany po Bluetooth (src/multimedia/openauto.py, wifi_ap.py)
 #   • dźwięk przez wyjście analogowe M910q (mini-jack) — domyślny sink PipeWire
 #   • przyciski SWC przez Arduino Pro Micro (USB HID)
 #   • modem LTE — na x86 moduł `network` tylko raportuje stan łącza,
@@ -12,7 +14,7 @@
 # których jeszcze nie ma podłączonych.
 #
 # Uruchomienie:
-#   python3 main.py --platform x86 --config config/bcm_config_bench.yaml --frontend
+#   python3 main.py --platform x86 --config config/bcm_config_test.yaml --frontend
 #
 # Ten plik NIE jest nakładką na bcm_config.yaml — --config podmienia całą
 # konfigurację, więc jest to pełna kopia z pozmienianymi kluczami.
@@ -28,9 +30,9 @@ system:
 # Jeden przełącznik na każdy moduł/podsystem — pełna lista i stan
 # także w UI: Settings -> Moduły (GET/POST /api/modules).
 modules:
-  # --- WŁĄCZONE na stanowisku testowym ---
+  # --- WŁĄCZONE w wariancie testowym ---
   dashboard: true          # frontend HTML5 na porcie 5002
-  multimedia: true         # Android Auto (openauto)
+  multimedia: true         # Android Auto (openauto) — wireless
   input: true              # przyciski SWC przez Pro Micro (USB HID)
   audio: true              # głośność i EQ na domyślnym sinku PipeWire
   network: true            # status łącza (LTE/WiFi/ethernet) — tylko odczyt
@@ -40,7 +42,10 @@ modules:
   parking: false           # brak HC-SR04
   environment: false       # brak DS18B20
   camera: false            # brak grabera i kamer
-  power: false             # brak przekaźnika zapłonu w torze testowym
+  power: false             # przekaźnik zapłonu jest, ale PowerManager na x86
+                           # reaguje tylko na zdarzenia sim.ignition /
+                           # sim.reverse_gear — brak wejścia GPIO, więc
+                           # odcięcie domeny B robi sprzęt, nie ten moduł
   location: false          # brak GPS
   tracking: false          # zależy od GPS
   weather: false           # wymaga klucza API
@@ -54,15 +59,18 @@ modules:
   battery: false           # patrz docs/ZASILANIE_BUFOROWANE.md § 13.4
 
   # --- podsystemy (startowane wprost w main.py) ---
-  bluetooth: false         # AA po kablu nie potrzebuje BT
-  phonebook: false         # bez BT nie ma czego synchronizować
+  bluetooth: true          # bootstrap handshake'u AA wireless (btservice
+                           # jest w autoapp; tu rejestrują się PBAP/MAP
+                           # i wymuszany jest CoD carkit 0x620420)
+  phonebook: false         # PBAP działałby, ale nie jest przedmiotem testu
   fuel_sender: false       # brak ADC z Arduino
-  wifi_ap: false           # AA po kablu — bez P2P-GO
-  wifi_hotspot: false
+  wifi_ap: true            # P2P-GO na MT7921 — łącze danych Android Auto
+  wifi_hotspot: false      # ALFA-NET wymaga OSOBNEGO radia (dongla USB) —
+                           # MT7921 zgłasza #{AP, P2P-GO} <= 1
   route_planner: false     # wymaga kluczy API
-  small_display: false     # jeden ekran na stanowisku
+  small_display: false     # jeden ekran w wariancie testowym
 display:
-  # Stanowisko testowe: panel 7" 1024x600.
+  # Wariant testowy: panel 7" 1024x600.
   # Docelowo 10,1" 1280x800 — wartości produkcyjne w bcm_config.yaml.
   dashboard:
     width: 1024

--- a/docs/WDROZENIE_M910Q.md
+++ b/docs/WDROZENIE_M910Q.md
@@ -589,8 +589,11 @@ journalctl -b -u bcm-resume
 
 ## 10. Wyświetlacze i dotyk
 
-Oba wyjścia M910q to **DisplayPort**. Wyświetlacze samochodowe mają zwykle
-HDMI — potrzebne są **pasywne przejściówki DP → HDMI** (~10–15 PLN/szt.).
+**Sprawdź, jakie wyjścia ma Twoja sztuka** — M910q występuje w wersjach
+z DisplayPort i z HDMI, a na maszynie referencyjnej złącza enumerują się
+jako `HDMI-A-1` / `HDMI-A-2` (§19.1). Jeżeli wyjścia są DisplayPort,
+a wyświetlacz ma HDMI, potrzebne są **pasywne przejściówki DP → HDMI**
+(~10–15 PLN/szt.).
 
 | Wyjście | Wyświetlacz | Rozdzielczość | Zawartość | Port |
 |---------|-------------|---------------|-----------|------|

--- a/docs/WDROZENIE_TESTOWE.md
+++ b/docs/WDROZENIE_TESTOWE.md
@@ -1,15 +1,20 @@
-# Wdrożenie testowo-rozwojowe — minimalny zestaw
+# Wdrożenie testowo-rozwojowe — mało funkcji, pełny tor zasilania
 
-Wariant do bieżącej weryfikacji i poprawek: **Android Auto + dźwięk przez
-mini-jack M910q, ekran 7", przyciski SWC, modem LTE**, zasilanie z posiadanego
-banku i modułów. Wszystko pozostałe wyłączone.
+Wariant do bieżącej weryfikacji i poprawek **w jeżdżącym aucie**: Android Auto
+wireless + dźwięk przez mini-jack M910q, ekran 7", przyciski SWC, modem LTE.
+Wszystko pozostałe wyłączone.
 
 Wdrożenie docelowe (pełne): [`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md).
+
+> **To nie jest stanowisko biurkowe.** Zestaw jedzie w aucie, więc tor
+> zasilania jest kompletny: ładowanie banku, blokada przeładowania, LVD
+> i przekaźnik zapłonu. Oszczędzamy na funkcjach BCM i na wariancie
+> ładowarki — **nie na zabezpieczeniach**.
 
 > **Ekran 7" to konfiguracja tymczasowa.** Docelowy panel to **10,1"
 > 1280×800**, opcjonalnie drugi **6,86" 1280×480** — i tak jest ustawione
 > w `config/bcm_config.yaml`. Ten wariant używa osobnego pliku
-> `config/bcm_config_bench.yaml` z 1024×600, żeby nie ruszać konfiguracji
+> `config/bcm_config_test.yaml` z 1024×600, żeby nie ruszać konfiguracji
 > produkcyjnej.
 
 ---
@@ -18,7 +23,7 @@ Wdrożenie docelowe (pełne): [`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md).
 
 1. [Co uruchamiamy](#1-co-uruchamiamy)
 2. [Co już masz](#2-co-już-masz)
-3. [Zasilanie — wersja minimalna](#3-zasilanie--wersja-minimalna)
+3. [Zasilanie](#3-zasilanie)
 4. [Lista zakupowa](#4-lista-zakupowa)
 5. [Instalacja software'u](#5-instalacja-softwareu)
 6. [Uruchomienie](#6-uruchomienie)
@@ -30,21 +35,24 @@ Wdrożenie docelowe (pełne): [`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md).
 
 ## 1. Co uruchamiamy
 
-Pięć modułów zamiast dwudziestu ośmiu:
+Pięć modułów zamiast dwudziestu ośmiu, plus dwa podsystemy potrzebne do
+Android Auto wireless:
 
-| Moduł | Po co | Czego wymaga |
-|-------|-------|--------------|
+| Przełącznik | Po co | Czego wymaga |
+|-------------|-------|--------------|
 | `dashboard` | frontend na porcie 5002 | ekran 7" + Chromium |
-| `multimedia` | **Android Auto** (openauto) | telefon po kablu USB |
+| `multimedia` | **Android Auto** (openauto) | telefon + BT + P2P-GO |
 | `input` | **przyciski SWC** | Arduino Pro Micro (USB HID) |
 | `audio` | głośność i EQ | wyjście analogowe M910q |
 | `network` | status łącza | modem LTE (przez NetworkManager) |
+| `bluetooth` | bootstrap handshake'u AA wireless | karta/dongiel BT |
+| `wifi_ap` | P2P-GO — łącze danych AA | karta MT7921 |
 
-Reszta — OBD, kamery, parkowanie, czujniki, przekaźniki, GPS, alarm,
-Bluetooth, WiFi AP — **wyłączona**, bo nie ma podłączonego sprzętu. Włączanie
-modułów bez hardware'u produkuje tylko szum w logach.
+Reszta — OBD, kamery, parkowanie, czujniki, przekaźniki, GPS, alarm — jest
+**wyłączona**, bo nie ma podłączonego sprzętu. Włączanie modułów bez
+hardware'u produkuje tylko szum w logach.
 
-### Dwa ustalenia z kodu, które upraszczają ten wariant
+### Trzy ustalenia z kodu, które upraszczają ten wariant
 
 **Dźwięk nie wymaga DAC-a USB.** `src/audio/pipewire_ctrl.py` na x86 używa
 **domyślnego sinka PipeWire** — czyli tego, co ustawisz w systemie. Wyjście
@@ -56,6 +64,11 @@ tylko **raportuje** stan łącza (`lte.connected`, `lte.signal`, `lte.ip`);
 samo połączenie robi NetworkManager. Huawei E3372 w trybie HiLink zgłasza się
 jako karta sieciowa i działa od podłączenia.
 
+**Moduł `power` zostaje wyłączony mimo przekaźnika zapłonu.** `PowerManager`
+(`src/power/power_manager.py`) reaguje na zdarzenia `hal.ignition` /
+`sim.ignition`, a na x86 nikt takich zdarzeń nie publikuje — nie ma wejścia
+GPIO. Odcięcie domeny B robi tu sprzęt (przekaźnik na ACC), nie software.
+
 ---
 
 ## 2. Co już masz
@@ -64,6 +77,7 @@ jako karta sieciowa i działa od podłączenia.
 |---------|-------|
 | Lenovo M910q | |
 | Ekran 7" | 1024×600, HDMI + dotyk USB |
+| Karta WiFi MediaTek MT7921 | **AA wireless po P2P-GO już działa** |
 | Pody SWC + dekoder | rezystorowa drabinka → wejście analogowe |
 | Modem LTE Huawei E3372 | HiLink, USB |
 | Akumulatory CSB HR1221W × 8 | AGM 12 V / 5,1 Ah |
@@ -72,124 +86,244 @@ jako karta sieciowa i działa od podłączenia.
 
 ---
 
-## 3. Zasilanie — wersja minimalna
+## 3. Zasilanie
 
-To jest miejsce, gdzie da się zaoszczędzić najwięcej, i to bez pogorszenia
-bezpieczeństwa.
+### 3.1 Tor — co jedzie w aucie
 
-### 3.1 Czego NIE potrzebujesz na stanowisku
-
-Na biurku nie ma alternatora, więc **cały tor ładowania jest zbędny**:
-
-| Element | Dlaczego zbędny na stanowisku |
-|---------|------------------------------|
-| Ładowarka CC-CV / B2B | nie ma z czego ładować — bank ładujesz między sesjami ładowarką sieciową |
-| VSR (rozdział ładowania) | nie ma akumulatora rozruchowego, od którego trzeba się odseparować |
-| Rozłącznik nadnapięciowy | zagrożeniem był alternator; ładowarka sieciowa ma własną regulację |
-| Przekaźnik zapłonu | włączasz wyłącznikiem, nie kluczykiem |
-| Dioda TVS, kondensator wejściowy | chroniły przed load dumpem alternatora |
-
-To oszczędza **od 150 do 1000 PLN** (w zależności od wariantu ładowarki)
-i wycina najbardziej kłopotliwą część układu.
-
-### 3.2 Czego potrzebujesz
+![Tor zasilania wariantu testowego](../schematics/power_test_build.svg)
 
 ```
-bank AGM (2–3 pakiety)
-   │  bezpiecznik 10 A na „+” każdego pakietu
+akumulator rozruchowy
+   │  bezpiecznik 15 A przy klemie „+", przewód 2,5 mm²
+   ▼
+TVS + kondensator 470 µF/35 V        ← ochrona wejścia (§5.4 ZASILANIE)
+   │
+   ▼
+VSR  (zał. 13,3 V / wył. 12,8 V)     ← zwiera dopiero, gdy alternator pracuje
+   │
+   ▼
+moduł CC-CV boost  (CV 13,8 V, CC wg §3.3)
+   │
+   ▼
+rozłącznik nadnapięciowy (próg 14,80 V)   ← warstwa 2
+   │
+   ▼
+BANK AGM 5 × HR1221W ── bezpiecznik 10 A na „+" każdego pakietu
+   │
    ▼
 XH-M609 (LVD)  ── bezpiecznik 15 A przed VIN+
    │  odcięcie 11,00 V · powrót 12,60 V
    ▼
-wyłącznik / rozłącznik
+wyłącznik główny na „+"  (albo rozłącznik masy na „−" banku)
    │
-   ▼
-XL6019 (step-up 12 → 19,5 V)  ── bezpiecznik 5 A na wyjściu
+   ├── przekaźnik zapłonu (cewka z ACC, dioda 1N4007) — DOMENA B
+   │      ├── bezp. 5 A → XL6019 12 → 19,5 V → M910q
+   │      └── bezp. 3 A → panel 7"
    │
-   ▼
-M910q — oryginalny wtyk
+   └── DOMENA A — w tym wariancie pusta (nie ma jeszcze Nano, HM-10, RXB6)
 ```
 
-Cztery elementy, wszystkie już masz poza bezpiecznikami i przewodami.
+Trzy rzeczy warto tu zauważyć:
 
-### 3.3 Ile pakietów
+- **Domena A jest pusta**, więc na postoju z banku pobiera prąd wyłącznie
+  sam XH-M609. To czyni pomiar jego poboru (§7.3
+  [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md)) najważniejszą liczbą
+  całego wariantu — patrz tabela w §3.3.
+- **Przekaźnik zapłonu nie jest opcją.** Bez niego XL6019 i M910q wiszą na
+  banku na postoju i rozkładają go w kilkanaście godzin.
+- **Panel 7" zasilaj wprost z 12 V**, jeśli tego wymaga. Buck 12 → 5 V dokup
+  tylko wtedy, gdy Twój panel jest 5-woltowy.
 
-**Dwa do trzech, nie pięć.** Na stanowisku mniej energii to mniej rzeczy, które
-mogą pójść źle, a czasu i tak wystarcza:
+### 3.2 Ładowanie — wariant B, i dlaczego akurat on
 
-| Pakiety | Pojemność | Czas pracy przy ~2,7 A (M910q ~30 W) |
-|---------|-----------|--------------------------------------|
-| 2 | 10,2 Ah | ~1,9 h do 50 % DoD |
-| 3 | 15,3 Ah | ~2,8 h do 50 % DoD |
-| 5 | 25,5 Ah | ~4,7 h do 50 % DoD |
+[`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) §5 opisuje dwa warianty:
+gotową ładowarkę B2B (800–1000 PLN) albo VSR + moduł CC-CV boost
+(120–220 PLN). Na etapie testowym bierzemy **wariant B** — różnica to
+kilkaset złotych za funkcje, które przy jeździe testowej niewiele wnoszą.
 
-Sesja rozwojowa rzadko trwa dłużej niż dwie godziny bez przerwy, a lżejszy
-zestaw łatwiej przestawić.
+Do tego stosujemy kompromis z §5.3: **CV ustawione na 13,8 V, bez fazy
+absorpcji**. Konsekwencje są konkretne i warto je znać:
 
-> **Bezpieczników na pakietach nie pomijaj nawet na stanowisku.** Zwarty
-> HR1221W potrafi oddać ponad 100 A — 5 Ah wystarczy, żeby zapalić przewód.
+| | |
+|---|---|
+| ✅ | nie potrzeba kompensacji temperaturowej ani czujnika NTC |
+| ✅ | 13,8 V bez kompensacji nie przeładuje banku nawet przy 50 °C |
+| ✅ | próg warstwy 2 schodzi z 15,30 V do **14,80 V** — łatwiej o tani przekaźnik napięciowy |
+| ⚠️ | bank ładuje się do ~90 %, nie do 100 % |
 
-### 3.4 Nastawy modułów
+Dla pracy buforowej to bardzo dobry kompromis. Przy przejściu na wariant A
+(ładowarka B2B) wracasz do 14,4 V absorpcji, kompensacji temperaturowej
+i progu 15,30 V.
+
+**Dlaczego VSR, a nie dioda Schottky:** boost nie potrafi dać napięcia
+niższego niż wejściowe, więc przy zgaszonym silniku podawałby 13,8 V
+i **rozładowywał akumulator auta**. VSR rozłącza obwód fizycznie poniżej
+12,8 V. Szczegóły: §5.3 [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md).
+
+### 3.3 Prąd ładowania — policz go z obciążeniem
+
+Moduł CC-CV limituje **prąd wyjściowy**, czyli obciążenie **plus** ładowanie.
+Zestaw testowy pobiera podczas jazdy ok. **3,5 A** (M910q ~30 W przez XL6019
+o sprawności ~85 % ≈ 2,7 A, panel ~0,6 A, reszta drobiazgi). Jeżeli ustawisz
+CC na 4 A, do banku popłynie 0,5 A i **nigdy się nie doładuje**.
+
+Reguła:
+
+```
+CC = obciążenie (≈3,5 A) + docelowy prąd ładowania
+     jednocześnie CC ≤ 2,1 A × liczba pakietów   ← sufit katalogowy CSB
+```
+
+| Pakiety | Sufit katalogowy | Zalecane CC | Netto do banku |
+|---------|------------------|-------------|----------------|
+| 3 | 6,3 A | 6,0 A | 2,5 A |
+| **5** | **10,5 A** | **8,0 A** | **4,5 A** |
+| 8 | 16,8 A | 10,0 A (limit modułu) | 6,5 A |
+
+Przy 8 A ciągłego prądu tani moduł „300 W / 10 A" **wymaga radiatora
+i przewiewu** — traktuj katalogowe 10 A jako wartość szczytową, nie roboczą.
+
+### 3.4 Ile pakietów
+
+**Pięć (25,5 Ah)** — tak jak w wersji docelowej, więc skrzynka, mocowanie
+i okablowanie nie będą do przerobienia po testach. Trzy wystarczą, jeśli
+w fazie testowej brakuje miejsca.
+
+| Pakiety | Pojemność | Praca przy zgaszonym silniku (3,5 A) | Postój przy 40 mA | Doładowanie z 50 % |
+|---------|-----------|--------------------------------------|-------------------|--------------------|
+| 3 | 15,3 Ah | ~2,2 h | ~8,0 dnia | ~3,1 h jazdy |
+| **5** | **25,5 Ah** | **~3,6 h** | **~13,3 dnia** | **~2,8 h jazdy** |
+| 8 | 40,8 Ah | ~5,8 h | ~21,3 dnia | ~3,1 h jazdy |
+
+Wszystko liczone do 50 % DoD. Postój wypada dłużej niż w wersji docelowej,
+bo domena A jest pusta — jedynym odbiornikiem jest XH-M609. Przy jego
+poborze 20 mA czasy się podwajają, przy 125 mA (katalogowe maksimum) spadają
+ponad trzykrotnie — **dlatego to zmierz**.
+
+> Krótkie przejazdy po mieście nie doładują banku po dłuższym postoju.
+> Kolumna „doładowanie" zakłada ciągłą jazdę z pracującym alternatorem.
+
+> **Bezpieczników na pakietach nie pomijaj.** Zwarty HR1221W potrafi oddać
+> ponad 100 A — 5 Ah wystarczy, żeby zapalić przewód.
+
+### 3.5 Nastawy modułów
 
 | Moduł | Nastawa | Uwaga |
 |-------|---------|-------|
 | **XL6019** | wyjście **19,5 V** pod obciążeniem | ustaw multimetrem, zabezpiecz potencjometr |
 | **XH-M609** | odcięcie **11,00 V**, powrót **12,60 V** | sprawdź, czy pracuje stabilnie przy 11 V |
+| **VSR** | zał. **13,3 V**, wył. **12,8 V** | zwykle fabryczne, sprawdź kartę |
+| **CC-CV boost** | CV **13,8 V**, CC wg §3.3 | ustaw CV **bez obciążenia**, CC na sztucznym obciążeniu |
+| **Rozłącznik nadnapięciowy** | próg **14,80 V**, powrót **14,0 V** | test zasilaczem laboratoryjnym, nie „na aucie" |
 
-Obowiązkowe sprawdzenia obu modułów przed pierwszym załączeniem:
+Obowiązkowe sprawdzenia XL6019 i XH-M609 przed pierwszym załączeniem:
 [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) §3.4 i §7.3.
 
 > **Limit poboru CPU ustaw od razu**, nie „potem". XL6019 daje ok. 45 W,
 > a M910q pod pełnym obciążeniem czterech wątków dobija do 55 W. Instrukcja:
 > [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) §3.5a.
 
+### 3.6 Wyłączanie — przekaźnik tnie twardo
+
+Przekaźnik zapłonu odcina domenę B **natychmiast** po przekręceniu kluczyka.
+Jeśli w tym momencie system pisze na dysk, ryzykujesz uszkodzenie
+systemu plików — a przy budowie rozwojowej cykli zasilania są dziesiątki
+dziennie.
+
+Procedura na czas testów:
+
+```
+1. Zaparkuj.
+2. Przycisk zasilania M910q  →  S3  (acpid + bcm-power-toggle.sh, §7.3 WDROZENIE_M910Q)
+3. Dopiero teraz kluczyk OFF.
+```
+
+W S3 nic nie jest zapisywane, więc odcięcie zasilania jest wtedy nieszkodliwe
+— maszyna wystartuje zimno przy następnym ACC. Zapominalskim ext4 zwykle
+wybacza, ale nie liczyłbym na to w nieskończoność.
+
+Automatyczne, „grzeczne" wyłączanie na zaniku ACC wymagałoby przekaźnika
+z opóźnieniem plus sygnału ACC podanego do Pro Micro i zmian w firmware —
+poza zakresem tego wariantu.
+
 ---
 
 ## 4. Lista zakupowa
 
-### 4.1 Obowiązkowe
+Ceny orientacyjne, rynek PL, 2025/2026.
+
+### 4.1 Tor ładowania i ochrona — obowiązkowe
 
 | # | Element | Specyfikacja | Cena (PLN) |
 |---|---------|--------------|-----------|
-| 1 | Oprawki bezpiecznikowe inline + wkładki | 10 A × 3 (pakiety), 15 A × 1 (LVD), 5 A × 1 (step-up) | 25–40 |
-| 2 | Przewód 2,5 mm² | czerwony + czarny, po 2 m | 20–30 |
-| 3 | Przewód 1,5 mm² | czerwony + czarny, po 2 m | 12–20 |
-| 4 | Nasuwki F2 6,35 mm izolowane | do zacisków HR1221W, komplet | 15–25 |
-| 5 | Konektory oczkowe + koszulki termokurczliwe | zestaw | 20–30 |
-| 6 | Wyłącznik / rozłącznik | kołyskowy 20 A albo rozłącznik masy | 15–40 |
-| 7 | Kabel USB do telefonu | dobrej jakości, do **Android Auto po kablu** | 20–40 |
-| | | **Razem** | **~130–225 PLN** |
+| 1 | **VSR** (voltage sensitive relay) | 12 V / 140 A, zał. 13,3 V | 60–120 |
+| 2 | **Moduł CC-CV boost** | 300 W / 10 A, regulacja **prądu i napięcia** | 60–100 |
+| 3 | **Rozłącznik nadnapięciowy** | przekaźnik napięciowy programowalny, próg 14,80 V | 40–80 |
+| 4 | **Przekaźnik zapłonu** | Bosch 12 V / 30 A SPDT + podstawka | 15–25 |
+| 5 | **Dioda 1N4007** | gaszeniowa, równolegle do cewki | 2–5 |
+| 6 | **Dioda TVS + kondensator** | 1.5KE33CA lub SMCJ26CA + 470 µF/35 V low-ESR | 10–20 |
+| 7 | **Radiator + wentylator 40 mm** | do XL6019 — w aucie obowiązkowy | 20–35 |
+| 8 | **Kondensator wyjściowy** | 470 µF/35 V low-ESR na wyjście XL6019 | 3–6 |
+| | | **Podsuma** | **210–391** |
 
-### 4.2 Zależne od tego, co już masz
+### 4.2 Bezpieczniki i okablowanie — obowiązkowe
+
+| # | Element | Specyfikacja | Cena (PLN) |
+|---|---------|--------------|-----------|
+| 9 | Bezpiecznik **15 A** + oprawka przy klemie „+" | zasilanie ładowarki | 15–25 |
+| 10 | Bezpieczniki inline **10 A × 5** + oprawki | po jednym na pakiet | 25–40 |
+| 11 | Bezpiecznik inline **15 A** + oprawka | przed VIN+ modułu XH-M609 | 8–12 |
+| 12 | Bezpiecznik **5 A** + oprawka | wyjście XL6019 | 8–12 |
+| 13 | Bezpiecznik **3 A** + oprawka | panel 7" | 8–12 |
+| 14 | Przewód **2,5 mm²** | FLRY, czerwony 5 m + czarny 3 m | 40–60 |
+| 15 | Przewód **1,5 mm²** | FLRY, czerwony + czarny po 3 m | 15–25 |
+| 16 | Przewód **0,75 mm²** | FLRY, kilka kolorów po 2 m (ACC, sterowanie) | 15–25 |
+| 17 | Nasuwki **F2 6,35 mm** izolowane | do zacisków HR1221W, komplet | 15–25 |
+| 18 | Konektory oczkowe, tulejki, koszulki | zestaw, koszulki z klejem | 30–50 |
+| 19 | **Rozłącznik masy** | 100 A — na czas montażu i dłuższego postoju | 40–70 |
+| 20 | Skrzynka / wspornik na bank + pasy | na 5 pakietów, mocowanie do nadwozia | 60–120 |
+| 21 | Peszel + przelotki gumowe | przejścia przez blachę | 25–40 |
+| | | **Podsuma** | **304–516** |
+
+**Razem obowiązkowo: ~514–907 PLN.**
+
+> **Przekrój 2,5 mm² zamiast 6 mm²** jest tu policzony pod ten wariant:
+> 8 A ładowania to ok. 9 A po stronie wejścia, a bezpiecznik 15 A chroni
+> przewód z zapasem. Przy przejściu na ładowarkę B2B (18–25 A) trzeba
+> **wymienić i przewód, i bezpiecznik** na 6 mm² / 30 A.
+
+### 4.3 Zależne od tego, co już masz
 
 | # | Element | Kiedy potrzebne | Cena (PLN) |
 |---|---------|----------------|-----------|
-| 8 | **Arduino Pro Micro** (ATmega32U4) | jeśli nie masz — pody SWC bez niego nie zadziałają | 40–60 |
-| 9 | **Wtyk zasilania do M910q** | najtaniej: odetnij kabel od oryginalnego zasilacza (koszt 0). Kupować tylko, jeśli zasilacza nie masz | 0–40 |
-| 10 | **Przejściówka DP → HDMI** | tylko jeśli Twój egzemplarz M910q ma wyjścia DisplayPort — sprawdź (§5.2) | 0–25 |
-| 11 | **Ładowarka sieciowa AGM** | do doładowania banku między sesjami; zwykła prostownikowa z trybem AGM wystarcza | 0–250 |
-| 12 | **Zaciskarka zapadkowa** | zaciski robione kombinerkami to najczęstsza usterka instalacji | 0–150 |
+| 22 | **Arduino Pro Micro** (ATmega32U4) | jeśli nie masz — pody SWC bez niego nie zadziałają | 40–60 |
+| 23 | **Wtyk zasilania do M910q** | najtaniej: odetnij kabel od oryginalnego zasilacza (koszt 0) | 0–40 |
+| 24 | **Przejściówka DP → HDMI** | tylko jeśli Twój egzemplarz M910q ma wyjścia DisplayPort — sprawdź (§5.2) | 0–25 |
+| 25 | **Buck 12 → 5 V** (MP1584, 3 A) | tylko jeśli panel 7" jest 5-woltowy | 0–15 |
+| 26 | **Zaciskarka zapadkowa** | zaciski robione kombinerkami to najczęstsza usterka instalacji | 0–150 |
+| 27 | **Ładowarka sieciowa AGM** | doładowanie w garażu przy krótkich przejazdach | 0–250 |
 
-### 4.3 Warto, ale nie na start
+### 4.4 Warto, ale nie na start
 
 | # | Element | Po co | Cena (PLN) |
 |---|---------|-------|-----------|
-| 13 | Woltomierz/amperomierz panelowy z bocznikiem | podgląd banku i poboru bez multimetru | 40–70 |
-| 14 | Radiator + wentylator 40 mm do XL6019 | na stanowisku przy ~30 W jeszcze nie krytyczne, w aucie obowiązkowe | 20–35 |
+| 28 | Woltomierz/amperomierz panelowy z bocznikiem | podgląd banku i prądu ładowania bez multimetru | 40–70 |
+| 29 | Multimetr z pomiarem prądu DC 10 A | pomiar poboru XH-M609 i prądu ładowania | 80–200 |
 
-### 4.4 Czego **nie** kupuj na tym etapie
+### 4.5 Czego **nie** kupuj na tym etapie
 
 | Element | Dlaczego |
 |---------|----------|
-| Ładowarka CC-CV / B2B | bez alternatora nie ma czego regulować — §3.1 |
-| VSR, rozłącznik nadnapięciowy | jw. |
+| Ładowarka B2B (Victron / Redarc) | wariant B robi to samo za ~1/5 ceny — §3.2 |
+| Czujnik NTC, kompensacja temperaturowa | CV 13,8 V bez absorpcji jej nie potrzebuje — §3.2 |
+| Przewód 6 mm², bezpiecznik główny 30 A | wymiarowane pod ładowarkę B2B — §4.2 |
+| Listwa dystrybucyjna 6–8 obwodów | cztery obwody obsłużą oprawki inline |
+| Buck 12 → 5 V dla domeny A | nie ma jeszcze Nano, HM-10 ani RXB6 |
+| Moduł 9 przekaźników, oba Nano, HM-10, RXB6 | odpowiednie moduły są wyłączone |
 | DAC USB ES9038Q2M | mini-jack M910q wystarcza do weryfikacji — §1 |
-| Karta WiFi MT7921 | AA po kablu nie potrzebuje P2P-GO |
-| Wzmacniacz, głośniki | na stanowisku wystarczą głośniki komputerowe albo słuchawki |
+| Karta WiFi | **masz MT7921 i P2P-GO już działa** |
+| Wzmacniacz, głośniki | osobna gałąź z akumulatora rozruchowego, po testach |
 | Drugi ekran, kamery, graber, czujniki | odpowiednie moduły są wyłączone |
-
-**Realny koszt startu: ~130–225 PLN**, plus Pro Micro i ładowarka AGM,
-jeśli ich nie masz.
 
 ---
 
@@ -225,10 +359,11 @@ speaker-test -c2 -twav -l1
 
 BCM nie wymaga tu żadnej konfiguracji — bierze domyślny sink.
 
-### 5.4 Konfiguracja stanowiska
+### 5.4 Konfiguracja wariantu testowego
 
-Repozytorium zawiera gotowy plik `config/bcm_config_bench.yaml`: pięć
-modułów włączonych, reszta wyłączona, ekran 1024×600.
+Repozytorium zawiera gotowy plik `config/bcm_config_test.yaml`: pięć
+modułów plus `bluetooth` i `wifi_ap` włączone, reszta wyłączona,
+ekran 1024×600.
 
 > `--config` **podmienia całą konfigurację**, nie nakłada się na
 > `bcm_config.yaml`. Dlatego jest to pełna kopia z pozmienianymi kluczami,
@@ -240,19 +375,54 @@ modułów włączonych, reszta wyłączona, ekran 1024×600.
 make -C arduino rotary_encoder-upload PORT=/dev/ttyACM0
 ```
 
-Pody SWC podłącz do **A0** (Pod 1) i **A6** (Pod 2), dekoder: czerwony → ACC
-(na stanowisku +12 V), czarny → masa. Kalibracja: przytrzymaj HOME + BACK
-przy starcie płytki i naciskaj kolejne przyciski wg podpowiedzi na porcie
-szeregowym. Progi zapisują się w EEPROM.
+Pody SWC podłącz do **A0** (Pod 1) i **A6** (Pod 2), dekoder: czerwony → ACC,
+czarny → masa. Kalibracja: przytrzymaj HOME + BACK przy starcie płytki
+i naciskaj kolejne przyciski wg podpowiedzi na porcie szeregowym. Progi
+zapisują się w EEPROM.
 
 Szczegóły: [`ARDUINO_SETUP_GUIDE.md`](ARDUINO_SETUP_GUIDE.md).
 
-### 5.6 Android Auto
+### 5.6 Android Auto wireless (P2P-GO)
 
 `openauto` kompilowany ze źródeł — procedura w
-[`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md) §13.3. Na tym etapie używamy
-**połączenia po kablu USB**: bez Bluetootha i bez WiFi P2P, czyli o dwie
-warstwy mniej do diagnozowania.
+[`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md) §13.3. Łącze jest **bezprzewodowe**:
+Bluetooth zestawia handshake, dane lecą po Wi-Fi Direct z karty MT7921.
+
+Co robi który element (wprost z kodu):
+
+| Element | Rola |
+|---------|------|
+| `modules.bluetooth` | rejestruje PBAP-PCE i MAP-MCE, wymusza Class-of-Device **0x620420** (carkit) |
+| **autoapp / btservice** | właściwy handshake AA po RFCOMM — BCM celowo **nie** rejestruje UUID Android Auto |
+| `modules.wifi_ap` | tworzy grupę **P2P-GO** i zapisuje `wifi.bssid_runtime` |
+| `openauto.py` | czyta `wifi.bssid_runtime` i podaje telefonowi adres punktu |
+
+Klucze w `config/bcm_config_test.yaml`, sekcja `wifi:` — ustawione domyślnie:
+
+```yaml
+wifi:
+  enabled: true       # openauto ostrzega w logu, jeśli false
+  mode: p2p_go
+  band: a             # AA wireless wymaga 5 GHz
+  channel: 149        # kanał 149 istnieje tylko w regdom US
+  country: US
+  regdom: US
+```
+
+Dwie pułapki, obie udokumentowane w kodzie:
+
+- **Class-of-Device.** `bluetoothd` sam syntezuje CoD z zarejestrowanych
+  wtyczek — PipeWire rejestruje A2DP/HFP i nadpisuje klasę carkit na
+  „Computer". Telefon używa bitów CoD do bramkowania AA, więc z klasą
+  „Computer" **wireless nigdy się nie pojawi**. `_force_carkit_cod()`
+  przestempluje ją po każdej burzy rejestracji.
+- **`wifi_hotspot` (ALFA-NET) musi zostać wyłączony.** MT7921 zgłasza
+  `#{AP, P2P-GO} <= 1` — druga sieć na tym samym radiu rozwali grupę P2P.
+  Współdzielenie internetu wymaga **osobnego** dongla USB.
+
+Parowanie: telefon → BT → sparuj z adapterem BCM → Android sam zaproponuje
+Android Auto. Kolejne uruchomienia łączą się automatycznie (boot sweep
+w `BluetoothManager`).
 
 ---
 
@@ -263,7 +433,7 @@ warstwy mniej do diagnozowania.
 ```bash
 cd /opt/bcm
 source .venv/bin/activate
-python3 main.py --platform x86 --config config/bcm_config_bench.yaml --frontend
+python3 main.py --platform x86 --config config/bcm_config_test.yaml --frontend
 ```
 
 Dashboard: `http://localhost:5002`. Zatrzymanie: `Ctrl+C`.
@@ -271,14 +441,15 @@ Dashboard: `http://localhost:5002`. Zatrzymanie: `Ctrl+C`.
 Sprawdzenie bez startowania modułów:
 
 ```bash
-python3 main.py --platform x86 --config config/bcm_config_bench.yaml --dry-run
+python3 main.py --platform x86 --config config/bcm_config_test.yaml --dry-run
 ```
 
-Powinno wypisać **5 modules would load**.
+Powinno wypisać **5 modules would load** — `bluetooth` i `wifi_ap` to
+podsystemy startowane wprost w `main.py`, więc nie liczą się do tej sumy.
 
 ### 6.2 Kiosk
 
-Na stanowisku wystarczy Chromium ręcznie:
+Na etapie testów wystarczy Chromium ręcznie:
 
 ```bash
 chromium --app=http://localhost:5002 --window-size=1024,600 --start-fullscreen
@@ -290,35 +461,65 @@ docelową — §7–§8 [`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md).
 ### 6.3 Kolejność załączania
 
 ```
-1. Bank odłączony, wyłącznik ROZWARTY
-2. Nastawy XL6019 i XH-M609 sprawdzone na zasilaczu laboratoryjnym
-3. Bezpieczniki na pakietach założone
-4. Bank podłączony do XH-M609 (bezpiecznik 15 A)
-5. Pomiar napięcia na wyjściu XL6019 BEZ podłączonego M910q → 19,5 V
-6. Dopiero teraz M910q
+ 1. Rozłącznik masy ROZWARTY, bank odłączony, ładowarka odłączona
+ 2. Nastawy XL6019, XH-M609, boostu i rozłącznika nadnapięciowego
+    sprawdzone na zasilaczu laboratoryjnym — wszystkie cztery
+ 3. Bezpieczniki na pakietach założone, bank złożony i zmierzony
+ 4. Bank → XH-M609 (bezpiecznik 15 A)
+ 5. Pomiar napięcia na wyjściu XL6019 BEZ podłączonego M910q → 19,5 V
+ 6. Dopiero teraz M910q
+ 7. Tor ładowania podłączany JAKO OSTATNI, przy zgaszonym silniku
+ 8. Rozruch silnika i pomiar prądu ładowania cęgami/bocznikiem
 ```
 
 Punkt 5 pomijany „bo przecież ustawiałem" to najczęstszy sposób na zabicie
-płyty głównej.
+płyty głównej. Punkt 7 pomijany to najczęstszy sposób na zabicie banku.
+
+Pełna procedura siedmioetapowa (z pomiarami na każdym kroku):
+[`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) §11.
 
 ---
 
 ## 7. Odbiór
 
+**Software**
+
 ```
 [ ] python3 main.py --dry-run pokazuje 5 modułów
 [ ] curl http://localhost:5002 zwraca HTML
-[ ] Dashboard widoczny na ekranie 7"
-[ ] Dotyk działa
+[ ] Dashboard widoczny na ekranie 7", dotyk działa
 [ ] wpctl status pokazuje analogowe wyjście jako domyślny sink
 [ ] Dźwięk słychać (speaker-test)
 [ ] Przyciski SWC wywołują akcje (głośność, utwory)
 [ ] Modem LTE widoczny w nmcli device, BCM raportuje łącze
-[ ] Android Auto łączy się po kablu USB
+[ ] hciconfig pokazuje class 0x620420 PO starcie BCM
+[ ] Android Auto łączy się bezprzewodowo, bez kabla
+[ ] Po restarcie telefon łączy się sam (boot sweep)
+```
+
+**Zasilanie — postój**
+
+```
 [ ] Napięcie na wtyku M910q ≥ 19,0 V pod obciążeniem
 [ ] Po 30 min pracy XL6019 nie parzy w dotyku
 [ ] XH-M609 odcina przy 11,00 V (test zasilaczem, nie rozładowywaniem banku)
+[ ] Kluczyk OFF → domena B zanika w całości (pomiar na wyjściu przekaźnika)
+[ ] Pobór z banku przy kluczyku OFF = pobór własny XH-M609 — ZMIERZ i zapisz
 ```
+
+**Zasilanie — ładowanie**
+
+```
+[ ] Silnik zgaszony → VSR rozwarty, zerowy prąd z akumulatora rozruchowego
+[ ] Silnik pracuje → VSR zwiera się w ciągu kilku sekund
+[ ] Prąd wyjściowy boostu nie przekracza nastawy CC (§3.3)
+[ ] Napięcie na banku po godzinie jazdy ≤ 13,8 V
+[ ] Rozłącznik nadnapięciowy odcina przy 14,80 V (test zasilaczem)
+[ ] Moduł boost po 30 min jazdy w granicach temperatury (radiator, przewiew)
+```
+
+Wynik pomiaru poboru XH-M609 zapisz — od niego zależy, czy na dłuższy postój
+wystarczy 5 pakietów, czy trzeba dołożyć pozostałe trzy (§3.4).
 
 ---
 
@@ -326,13 +527,14 @@ płyty głównej.
 
 | Nie ma | Wróci przy |
 |--------|-----------|
-| Ładowania banku | zabudowie w aucie (§5 `ZASILANIE_BUFOROWANE.md`) |
-| Domen A/B i przekaźnika zapłonu | zabudowie w aucie |
+| Domeny A (Nano ×2, HM-10, RXB6, przekaźniki) | dokupieniu płytek + buck 12 → 5 V |
+| Absorpcji 14,4 V i kompensacji temperaturowej | ładowarce B2B (wariant A, §5.2 `ZASILANIE_BUFOROWANE.md`) |
+| Modułu `power` w BCM | wejściu zapłonu, którego x86 nie ma — §1 |
 | Drugiego ekranu | panelu 6,86" — jest hot-plug, wystarczy wpiąć |
 | OBD / K-Line | CP2102 + L9637D |
 | Kamer, parkowania, czujników | grabera, HC-SR04, DS18B20, obu Nano |
-| Bluetooth, WiFi AP | karty MT7921 i przejścia na AA wireless |
-| Wzmacniacza i głośników | zakupie gotowego modułu |
+| Wzmacniacza i głośników | zakupie gotowego modułu (osobna gałąź) |
+| Współdzielenia internetu (ALFA-NET) | osobnym dongle'u WiFi — §5.6 |
 
 ---
 
@@ -344,17 +546,17 @@ i weryfikowalny osobno:
 | Krok | Co dochodzi | Co włączyć w configu |
 |------|-------------|---------------------|
 | 1 | ekran 10,1" 1280×800 | `display.dashboard` → 1280×800 (czyli `bcm_config.yaml`) |
-| 2 | karta MT7921 → AA wireless | `bluetooth`, `wifi_ap` |
-| 3 | wzmacniacz + głośniki | bez zmian w configu |
+| 2 | wzmacniacz + głośniki | bez zmian w configu — osobna gałąź zasilania |
+| 3 | DAC USB ES9038Q2M | bez zmian — zmiana domyślnego sinka PipeWire |
 | 4 | CP2102 + L9637D | `obd`, `obd.use_real_hardware: true` |
 | 5 | Nano #2 (sensor hub) | `environment`, `rain_sensor`, `blinker_monitor` |
-| 6 | Nano #1 + przekaźniki | `central_lock`, `lighting` |
+| 6 | Nano #1 + przekaźniki + buck domeny A | `central_lock`, `lighting` |
 | 7 | kamery + graber | `camera`, `crash_detect` |
 | 8 | GPS | `location`, `tracking` |
 | 9 | ekran 6,86" | `small_display` (hotplug — wystarczy wpiąć) |
-| 10 | zabudowa w aucie, pełne zasilanie | `power` + tor ładowania |
+| 10 | ładowarka B2B zamiast VSR + boost | bez zmian w configu — absorpcja 14,4 V, próg 15,30 V, przewód 6 mm² |
 
-Po każdym kroku przełóż odpowiedni klucz z `bcm_config_bench.yaml` albo
+Po każdym kroku przełóż odpowiedni klucz z `bcm_config_test.yaml` albo
 przejdź na `bcm_config.yaml`, gdy większość będzie już podłączona.
 
 ---
@@ -364,7 +566,7 @@ przejdź na `bcm_config.yaml`, gdy większość będzie już podłączona.
 | Dokument | Zakres |
 |----------|--------|
 | [`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md) | wdrożenie docelowe, pełne |
-| [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) | nastawy XL6019 i XH-M609, sprawdzenia przed załączeniem |
+| [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) | warianty ładowania, nastawy modułów, sprawdzenia przed załączeniem |
 | [`SCHEMATY_POLACZEN.md`](SCHEMATY_POLACZEN.md) | tabele połączeń dla wersji docelowej |
 | [`ARDUINO_SETUP_GUIDE.md`](ARDUINO_SETUP_GUIDE.md) | Pro Micro, kalibracja SWC |
 | [`URUCHOMIENIE.md`](URUCHOMIENIE.md) | symulacja bez sprzętu, przełączniki modułów |

--- a/schematics/README.md
+++ b/schematics/README.md
@@ -20,6 +20,7 @@ M910q Tiny**.
 | [`charging_lvd.svg`](charging_lvd.svg) | **Ładowanie i ochrona banku** — cztery warstwy (VSR → CC-CV → rozłącznik nadnapięciowy → LVD), komplet nastaw dla **CSB HR1221W (AGM)**, dwie tabele kompensacji temperaturowej, wpływ temperatury na żywotność, przebieg CC → CV → float. |
 | [`power_domains_m910q.svg`](power_domains_m910q.svg) | **Domeny A/B** — rozdział obciążeń między część zawsze zasilaną a część załączaną zapłonem, bezpieczniki odgałęzień, budżet poboru spoczynkowego, tabela czasu postoju, osobna gałąź wzmacniaczy. |
 | [`audio_system.svg`](audio_system.svg) | **Tor audio** — ES9038Q2M (USB DAC) → RCA → **gotowy wzmacniacz samochodowy** → głośniki 4 Ω. Wzmacniacz zasilany wprost z akumulatora rozruchowego, z własną masą — całkowicie odseparowany od systemu buforowanego. |
+| [`power_test_build.svg`](power_test_build.svg) | **Wariant testowo-rozwojowy** — uproszczony tor dla instalacji jeżdżącej z minimalnym zestawem funkcji: ładowanie wariantem B (VSR + CC-CV boost), bank, LVD, przekaźnik zapłonu, XL6019 i panel 7". Bez domeny A i bez wzmacniacza. Opis: [`../docs/WDROZENIE_TESTOWE.md`](../docs/WDROZENIE_TESTOWE.md). |
 
 ### Schematy połączeniowe — montaż
 

--- a/schematics/power_test_build.svg
+++ b/schematics/power_test_build.svg
@@ -1,0 +1,163 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="1164" viewBox="0 0 960 1164" font-family="DejaVu Sans, Verdana, sans-serif">
+  <title>BCM v8.5 — tor zasilania wariantu testowo-rozwojowego (M910q)</title>
+  <style>
+    .bg   { fill: #ffffff; }
+    .box  { fill: #f7f9fb; stroke: #2b3a45; stroke-width: 2; rx: 6; }
+    .boxC { fill: #eef7ee; stroke: #2d6a2d; stroke-width: 2; rx: 6; }
+    .boxB { fill: #fdf6e6; stroke: #9a6b12; stroke-width: 2; rx: 6; }
+    .boxL { fill: #eef2fa; stroke: #2b4a8a; stroke-width: 2; rx: 6; }
+    .note { fill: #fbfcfd; stroke: #c8d2da; stroke-width: 1.5; rx: 6; }
+    .wire { stroke: #c0392b; stroke-width: 3; fill: none; }
+    .ttl  { font-size: 19px; font-weight: bold; fill: #10202b; }
+    .sub  { font-size: 12px; fill: #5a6b78; }
+    .h    { font-size: 13.5px; font-weight: bold; fill: #10202b; text-anchor: middle; }
+    .t    { font-size: 11.5px; fill: #33424e; text-anchor: middle; }
+    .tl   { font-size: 11.5px; fill: #33424e; }
+    .tb   { font-size: 11.5px; font-weight: bold; fill: #10202b; }
+    .nh   { font-size: 12.5px; font-weight: bold; fill: #10202b; }
+    .nt   { font-size: 11px; fill: #4a5a66; }
+    .fuse { font-size: 11px; font-weight: bold; fill: #a8321a; }
+    .foot { font-size: 10.5px; fill: #6a7a86; }
+  </style>
+
+  <rect class="bg" x="0" y="0" width="960" height="1164"/>
+  <text class="ttl" x="24" y="32">Wariant testowo-rozwojowy — kompletny tor zasilania</text>
+  <text class="sub" x="24" y="52">Ładowanie wariantem B (VSR + CC-CV boost), bank 5 × CSB HR1221W, LVD XH-M609, domena B za przekaźnikiem zapłonu.</text>
+  <line x1="24" y1="64" x2="936" y2="64" stroke="#c8d2da" stroke-width="1.5"/>
+
+  <!-- ============== SPINE ============== -->
+  <text class="tb" x="90" y="88" fill="#2d6a2d" font-size="13.5">ŁADOWANIE</text>
+
+  <rect class="boxC" x="90" y="96" width="420" height="56"/>
+  <text class="h" x="300" y="119">Akumulator rozruchowy 12 V</text>
+  <text class="t" x="300" y="138">masa na fabrycznym punkcie nadwozia, nie „gdziekolwiek”</text>
+
+  <path class="wire" d="M300 152 L300 186"/>
+  <text class="fuse" x="312" y="172">bezp. 15 A przy klemie „+” · 2,5 mm²</text>
+
+  <rect class="boxC" x="90" y="186" width="420" height="62"/>
+  <text class="h" x="300" y="209">Ochrona wejścia</text>
+  <text class="t" x="300" y="228">dioda TVS 1.5KE33CA (lub SMCJ26CA) · C 470 µF / 35 V low-ESR</text>
+
+  <path class="wire" d="M300 248 L300 282"/>
+
+  <rect class="boxC" x="90" y="282" width="420" height="62"/>
+  <text class="h" x="300" y="305">VSR — przekaźnik napięciowy 12 V / 140 A</text>
+  <text class="t" x="300" y="324">załączenie 13,3 V · rozłączenie 12,8 V</text>
+
+  <path class="wire" d="M300 344 L300 378"/>
+
+  <rect class="boxC" x="90" y="378" width="420" height="76"/>
+  <text class="h" x="300" y="401">Moduł CC-CV boost 300 W / 10 A</text>
+  <text class="t" x="300" y="420">CV 13,80 V (bez absorpcji) · CC 8,0 A dla pięciu pakietów</text>
+  <text class="t" x="300" y="438">radiator i przewiew — 8 A ciągłe to nie jest praca „na sucho”</text>
+
+  <path class="wire" d="M300 454 L300 488"/>
+
+  <rect class="boxC" x="90" y="488" width="420" height="62"/>
+  <text class="h" x="300" y="511">Rozłącznik nadnapięciowy — warstwa 2</text>
+  <text class="t" x="300" y="530">próg 14,80 V · powrót 14,0 V</text>
+
+  <path class="wire" d="M300 550 L300 584"/>
+
+  <text class="tb" x="90" y="576" fill="#9a6b12" font-size="13.5">BANK</text>
+
+  <rect class="boxB" x="90" y="584" width="420" height="84"/>
+  <text class="h" x="300" y="607">BANK 5 × CSB HR1221W F2 — 25,5 Ah</text>
+  <text class="t" x="300" y="626">bezpiecznik 10 A na „+” każdego pakietu, osobno</text>
+  <text class="t" x="300" y="644">nasuwki F2 6,35 mm · łączenie równoległe wg §4.3 ZASILANIE</text>
+  <text class="t" x="300" y="661">3 pakiety wystarczą na czas testów; 8 = dłuższy postój</text>
+
+  <path class="wire" d="M300 668 L300 702"/>
+  <text class="fuse" x="312" y="690">bezp. 15 A przed VIN+</text>
+
+  <text class="tb" x="90" y="694" fill="#2b4a8a" font-size="13.5">ODBIORNIKI</text>
+
+  <rect class="boxL" x="90" y="702" width="420" height="62"/>
+  <text class="h" x="300" y="725">XH-M609 — LVD</text>
+  <text class="t" x="300" y="744">odcięcie 11,00 V · powrót 12,60 V</text>
+
+  <path class="wire" d="M300 764 L300 798"/>
+
+  <rect class="boxL" x="90" y="798" width="420" height="56"/>
+  <text class="h" x="300" y="821">Wyłącznik główny na „+”</text>
+  <text class="t" x="300" y="840">albo rozłącznik masy 100 A na „−” banku</text>
+
+  <path class="wire" d="M300 854 L300 888"/>
+
+  <rect class="boxL" x="90" y="888" width="420" height="62"/>
+  <text class="h" x="300" y="911">Przekaźnik zapłonu 30 A SPDT — domena B</text>
+  <text class="t" x="300" y="930">cewka z ACC · dioda gaszeniowa 1N4007 równolegle</text>
+
+  <path class="wire" d="M300 950 L300 972"/>
+  <path class="wire" d="M190 972 L410 972"/>
+  <path class="wire" d="M190 972 L190 1000"/>
+  <path class="wire" d="M410 972 L410 1000"/>
+  <circle cx="300" cy="972" r="4" fill="#c0392b"/>
+
+  <rect class="box" x="90" y="1000" width="200" height="88"/>
+  <text class="fuse" x="112" y="994">bezp. 5 A</text>
+  <text class="h" x="190" y="1023">XL6019 → 19,5 V</text>
+  <text class="t" x="190" y="1042">M910q, limit CPU 28 W</text>
+  <text class="t" x="190" y="1060">C 470 µF/35 V na wyjściu</text>
+  <text class="t" x="190" y="1078">radiator + wentylator 40 mm</text>
+
+  <rect class="box" x="310" y="1000" width="200" height="88"/>
+  <text class="fuse" x="332" y="994">bezp. 3 A</text>
+  <text class="h" x="410" y="1023">Panel 7" 1024×600</text>
+  <text class="t" x="410" y="1042">wprost z 12 V, jeśli taki jest</text>
+  <text class="t" x="410" y="1060">buck 12 → 5 V tylko dla</text>
+  <text class="t" x="410" y="1078">paneli 5-woltowych</text>
+
+  <!-- ============== NOTES ============== -->
+  <rect class="note" x="560" y="282" width="376" height="96"/>
+  <text class="nh" x="576" y="304">Dlaczego VSR, a nie dioda Schottky</text>
+  <text class="nt" x="576" y="325">Boost nie da napięcia niższego niż wejściowe, więc przy</text>
+  <text class="nt" x="576" y="342">zgaszonym silniku podawałby 13,8 V i rozładowywał</text>
+  <text class="nt" x="576" y="359">akumulator auta. VSR rozłącza obwód fizycznie.</text>
+
+  <rect class="note" x="560" y="394" width="376" height="130"/>
+  <text class="nh" x="576" y="416">Prąd CC liczysz razem z obciążeniem</text>
+  <text class="nt" x="576" y="437">Moduł limituje prąd WYJŚCIOWY — obciążenie plus</text>
+  <text class="nt" x="576" y="454">ładowanie. Zestaw pobiera podczas jazdy ok. 3,5 A.</text>
+  <text class="nt" x="576" y="475">CC 4 A  →  do banku 0,5 A  →  nigdy się nie doładuje</text>
+  <text class="nt" x="576" y="492">CC 8 A  →  do banku 4,5 A  →  z 50 % w ~2,8 h jazdy</text>
+  <text class="nt" x="576" y="513">Sufit katalogowy CSB: 2,1 A × liczba pakietów.</text>
+
+  <rect class="note" x="560" y="540" width="376" height="112"/>
+  <text class="nh" x="576" y="562">Domena A jest w tym wariancie pusta</text>
+  <text class="nt" x="576" y="583">Nie ma jeszcze Nano, HM-10 ani RXB6, więc na postoju</text>
+  <text class="nt" x="576" y="600">z banku pobiera prąd wyłącznie sam XH-M609.</text>
+  <text class="nt" x="576" y="621">Przy 40 mA i pięciu pakietach to ~13 dni do 50 % DoD,</text>
+  <text class="nt" x="576" y="638">przy 125 mA już tylko ~4 dni. Zmierz go — §7.3.</text>
+
+  <rect class="note" x="560" y="668" width="376" height="230"/>
+  <text class="nh" x="576" y="690">Bezpieczniki i przekroje</text>
+  <line x1="576" y1="700" x2="920" y2="700" stroke="#c8d2da"/>
+  <text class="tb" x="576" y="719">Obwód</text>
+  <text class="tb" x="800" y="719">Bezp.</text>
+  <text class="tb" x="866" y="719">Przekrój</text>
+  <line x1="576" y1="727" x2="920" y2="727" stroke="#c8d2da"/>
+  <text class="nt" x="576" y="746">ładowarka ← akumulator</text><text class="nt" x="800" y="746">15 A</text><text class="nt" x="866" y="746">2,5 mm²</text>
+  <text class="nt" x="576" y="768">każdy pakiet banku</text><text class="nt" x="800" y="768">10 A</text><text class="nt" x="866" y="768">2,5 mm²</text>
+  <text class="nt" x="576" y="790">wejście XH-M609</text><text class="nt" x="800" y="790">15 A</text><text class="nt" x="866" y="790">2,5 mm²</text>
+  <text class="nt" x="576" y="812">wyjście XL6019</text><text class="nt" x="800" y="812">5 A</text><text class="nt" x="866" y="812">1,5 mm²</text>
+  <text class="nt" x="576" y="834">panel 7"</text><text class="nt" x="800" y="834">3 A</text><text class="nt" x="866" y="834">1,5 mm²</text>
+  <text class="nt" x="576" y="856">cewka przekaźnika (ACC)</text><text class="nt" x="800" y="856">—</text><text class="nt" x="866" y="856">0,75 mm²</text>
+  <line x1="576" y1="868" x2="920" y2="868" stroke="#c8d2da"/>
+  <text class="foot" x="576" y="886">2,5 mm² zamiast 6 mm² — bo ładowarka daje 8 A, nie 25 A.</text>
+
+  <rect class="note" x="560" y="914" width="376" height="174"/>
+  <text class="nh" x="576" y="936">Kolejność pierwszego załączenia</text>
+  <text class="nt" x="576" y="957">1. Wyłącznik główny rozwarty, ładowarka odłączona.</text>
+  <text class="nt" x="576" y="978">2. Nastawy XL6019, XH-M609, boostu i rozłącznika</text>
+  <text class="nt" x="576" y="995">    nadnapięciowego sprawdzone na zasilaczu lab.</text>
+  <text class="nt" x="576" y="1016">3. Bank złożony, bezpieczniki pakietów założone.</text>
+  <text class="nt" x="576" y="1037">4. Pomiar 19,5 V na XL6019 BEZ M910q.</text>
+  <text class="nt" x="576" y="1058">5. M910q. 6. Tor ładowania JAKO OSTATNI, na zgaszonym</text>
+  <text class="nt" x="576" y="1075">    silniku. 7. Rozruch i pomiar prądu ładowania.</text>
+
+  <text class="foot" x="24" y="1108">Wzmacniacz nie występuje w tym wariancie. Gdy dojdzie — osobna gałąź wprost z akumulatora rozruchowego, własny</text>
+  <text class="foot" x="24" y="1124">bezpiecznik i własna masa; przez bank nie przechodzi wtedy żaden prąd mocy.</text>
+  <text class="foot" x="24" y="1146">Pełny opis nastaw i pomiarów: docs/ZASILANIE_BUFOROWANE.md · wariant docelowy z domeną A: schematics/power_domains_m910q.svg</text>
+</svg>

--- a/src/power/backlight.py
+++ b/src/power/backlight.py
@@ -1,8 +1,14 @@
-"""PWM backlight control for 2× displays (4.3" and 7").
+"""PWM backlight control for 2× displays ("small" and "large").
 
-On OPi: GPIO PWM2 (pin 32) for 4.3", PWM3 (pin 33) for 7" display.
-         BC547 → IRLZ44N MOSFET driver circuit.
-On x86: Simulated — publishes brightness events for UI feedback.
+The two channels map to the panels the build actually ships with:
+"large" is the 10.1" 1280x800 dashboard, "small" the optional 6.86"
+1280x480 side panel (display.dashboard / display.small in the config).
+
+On OPi: GPIO PWM2 (pin 32) for the small panel, PWM3 (pin 33) for the
+        large one. BC547 → IRLZ44N MOSFET driver circuit.
+On x86: Simulated — publishes brightness events for UI feedback. The
+        M910q build dims through the panel's own controller, so nothing
+        here drives real hardware.
 
 Supports independent fade-in/fade-out with configurable duration.
 """
@@ -20,9 +26,10 @@ FADE_DURATION = 1.0  # 1 second fade
 FADE_STEPS = 50      # Smoothness
 PWM_FREQUENCY = 1000  # Hz
 
-# GPIO PWM channels (OPi 5 Plus)
-PWM_CHANNEL_43 = 2   # Pin 32 — 4.3" display
-PWM_CHANNEL_7 = 3    # Pin 33 — 7" display
+# GPIO PWM channels (OPi 5 Plus). Named after the "small"/"large" keys the
+# controller uses, not after panel sizes — those changed to 6.86"/10.1".
+PWM_CHANNEL_SMALL = 2   # Pin 32 — side panel
+PWM_CHANNEL_LARGE = 3   # Pin 33 — dashboard
 
 
 class BacklightController:
@@ -46,8 +53,8 @@ class BacklightController:
 
         # Brightness state (0-100%)
         self._brightness = {
-            "small": 0,  # 4.3" display
-            "large": 0,  # 7" display
+            "small": 0,  # side panel
+            "large": 0,  # dashboard
         }
         self._target_brightness = {
             "small": config.get("power.backlight_small", 80),
@@ -77,8 +84,8 @@ class BacklightController:
         """Initialize hardware PWM channels."""
         if self._hal:
             try:
-                self._hal.pwm_setup(PWM_CHANNEL_43, PWM_FREQUENCY)
-                self._hal.pwm_setup(PWM_CHANNEL_7, PWM_FREQUENCY)
+                self._hal.pwm_setup(PWM_CHANNEL_SMALL, PWM_FREQUENCY)
+                self._hal.pwm_setup(PWM_CHANNEL_LARGE, PWM_FREQUENCY)
                 log.info("PWM channels initialized")
             except Exception as e:
                 log.error("PWM init failed: %s", e)
@@ -91,7 +98,7 @@ class BacklightController:
         """Set brightness immediately (no fade).
 
         Args:
-            display: 'small' (4.3") or 'large' (7").
+            display: 'small' (side panel) or 'large' (dashboard).
             brightness: 0-100 percentage.
         """
         brightness = max(0, min(100, brightness))
@@ -160,7 +167,7 @@ class BacklightController:
         if self._platform != "opi" or not self._hal:
             return
 
-        channel = PWM_CHANNEL_43 if display == "small" else PWM_CHANNEL_7
+        channel = PWM_CHANNEL_SMALL if display == "small" else PWM_CHANNEL_LARGE
         duty = brightness / 100.0
         try:
             self._hal.pwm_write(channel, duty)

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -10,7 +10,7 @@ from src.power.power_manager import (
 )
 from src.power.backlight import (
     BacklightController, FADE_DURATION, FADE_STEPS,
-    PWM_CHANNEL_43, PWM_CHANNEL_7,
+    PWM_CHANNEL_SMALL, PWM_CHANNEL_LARGE,
 )
 from src.power.shutdown import ShutdownHandler
 
@@ -220,8 +220,8 @@ class TestBacklightController:
         assert bl.get_brightness("large") == 60
 
     def test_pwm_channels(self):
-        assert PWM_CHANNEL_43 == 2
-        assert PWM_CHANNEL_7 == 3
+        assert PWM_CHANNEL_SMALL == 2
+        assert PWM_CHANNEL_LARGE == 3
 
     def test_fade_constants(self):
         assert FADE_DURATION == 1.0


### PR DESCRIPTION
Two premises of the test/dev variant (added in #110) were wrong. This corrects them.

## 1. It drives, so charging comes back

The old §3.1 was titled "Czego NIE potrzebujesz na stanowisku" and argued the whole charging chain was unnecessary because a bench has no alternator. True for a bench, irrelevant for something installed in the car.

Restored: VSR, CC-CV boost, overvoltage cutoff, ignition relay, input TVS + capacitor.

Charging uses **variant B** (VSR + CC-CV boost, ~180 PLN) rather than a B2B charger, with **CV at 13.8 V and no absorb phase**. That drops the temperature sensor entirely and lets the layer-2 cutoff sit at 14.80 V instead of 15.30 V — at the cost of charging to ~90 % instead of 100 %, which is a good trade for buffer duty. The upgrade path to a B2B charger is step 10 of the roadmap.

Two numbers that were missing and change what you buy:

- **The CC-CV module limits *output* current — load plus charge.** The rig draws ~3.5 A while driving, so CC set to 4 A puts 0.5 A into the bank and it never refills. CC 8 A for five packs (catalogue ceiling is 2.1 A × packs) leaves 4.5 A net, refilling from 50 % in ~2.8 h of driving.
- **Pack count goes back to five**, not the 2–3 that only made sense for bench sessions. Standby is *longer* than in the full build, not shorter, because domain A is empty — the only load on the bank at rest is the XH-M609 itself. Measuring its draw is now the single most consequential number in the variant.

Wire gauge is deliberately 2.5 mm² / 15 A rather than the full build's 6 mm² / 30 A, because an 8 A charger is ~9 A on the input side. Flagged explicitly so it gets upgraded alongside a B2B charger.

## 2. Android Auto is wireless, not wired

P2P-GO on the MediaTek MT7921 already works on the machine, so `bluetooth` and `wifi_ap` are on in the config and §5.6 documents what each piece does. Both traps it describes are already known to the code:

- `bluetoothd` re-synthesises Class-of-Device from registered plugins, so PipeWire's A2DP/HFP registration overwrites the carkit class with "Computer" — and phones gate the AA carkit path on those bits, so wireless silently never appears. `_force_carkit_cod()` re-stamps `0x620420`.
- The MT7921 advertises `#{AP, P2P-GO} <= 1`, so the ALFA-NET internet-share AP must stay off — it needs a separate USB radio.

## Also in this PR

- `config/bcm_config_bench.yaml` → `config/bcm_config_test.yaml`. "Bench" is misleading for something that drives.
- New `schematics/power_test_build.svg` — the whole chain for this variant on one page, with the fuse/gauge table and first-power-up order.
- `docs/WDROZENIE_M910Q.md` §10 still asserted "both M910q outputs are DisplayPort" while §19.1 retracted exactly that claim. Now it says to read the connector names off the machine.
- `src/power/backlight.py` named its PWM channels `PWM_CHANNEL_43` / `PWM_CHANNEL_7` after panels that no longer exist; renamed to `SMALL` / `LARGE`, matching the keys the controller actually uses.

`modules.power` stays off, and §1 now says why: `PowerManager` reacts to `hal.ignition` / `sim.ignition`, and nothing publishes those on x86. The domain-B cut is done by the relay, in hardware.

## Verification

- `main.py --config config/bcm_config_test.yaml --dry-run` → **5 modules would load** (`bluetooth` and `wifi_ap` are subsystems started directly in `main.py`, so they don't count toward that total — the doc says so)
- 419 tests pass, `ruff check` clean
- markdown links and heading anchors resolve across all 23 docs
- every SVG parses; `power_test_build.svg` render-checked for text collisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cXmt2HyZ8iv3aQHpkNA4c

---
_Generated by [Claude Code](https://claude.ai/code/session_017cXmt2HyZ8iv3aQHpkNA4c)_