### PR TITLE
Name concrete CC-CV and VSR models, fix the CV setpoint, power the panel from USB

### DIFF
--- a/arduino/output_controller/output_controller.ino
+++ b/arduino/output_controller/output_controller.ino
@@ -83,8 +83,8 @@
 #define PIN_TRUNK_BUTTON  6
 #define PIN_FL_UP         7
 #define PIN_FL_DOWN       8
-#define PIN_BACKLIGHT_L   9   // 7" main display PWM
-#define PIN_BACKLIGHT_S   10  // 4.3" small display PWM
+#define PIN_BACKLIGHT_L   9   // "large" — 10.1" dashboard PWM
+#define PIN_BACKLIGHT_S   10  // "small" — 6.86" side panel PWM
 #define PIN_FR_UP         11
 #define PIN_FR_DOWN       12
 #define PIN_LED           13

--- a/docs/WDROZENIE_TESTOWE.md
+++ b/docs/WDROZENIE_TESTOWE.md
@@ -117,13 +117,14 @@ XH-M609 (LVD)  ── bezpiecznik 15 A przed VIN+
 wyłącznik główny na „+"  (albo rozłącznik masy na „−" banku)
    │
    ├── przekaźnik zapłonu (cewka z ACC, dioda 1N4007) — DOMENA B
-   │      ├── bezp. 5 A → XL6019 12 → 19,5 V → M910q
-   │      └── bezp. 3 A → panel 7"
+   │      └── bezp. 7,5 A → XL6019 12 → 19,5 V → M910q
+   │                                              └── USB: panel 7", dotyk,
+   │                                                  Pro Micro, modem LTE
    │
    └── DOMENA A — w tym wariancie pusta (nie ma jeszcze Nano, HM-10, RXB6)
 ```
 
-Trzy rzeczy warto tu zauważyć:
+Cztery rzeczy warto tu zauważyć:
 
 - **Domena A jest pusta**, więc na postoju z banku pobiera prąd wyłącznie
   sam XH-M609. To czyni pomiar jego poboru (§7.3
@@ -131,8 +132,45 @@ Trzy rzeczy warto tu zauważyć:
   całego wariantu — patrz tabela w §3.3.
 - **Przekaźnik zapłonu nie jest opcją.** Bez niego XL6019 i M910q wiszą na
   banku na postoju i rozkładają go w kilkanaście godzin.
-- **Panel 7" zasilaj wprost z 12 V**, jeśli tego wymaga. Buck 12 → 5 V dokup
-  tylko wtedy, gdy Twój panel jest 5-woltowy.
+- **Panel 7" wisi na USB M910q** — żadnego odgałęzienia 12 V, żadnego bucka,
+  żadnego dodatkowego bezpiecznika. Cały tor kończy się na jednym wyjściu
+  XL6019. Szczegóły i haczyki poniżej.
+- **Jedna gałąź zamiast dwóch to jeden bezpiecznik — ale większy.** Wszystko
+  idzie teraz przez XL6019, więc jego prąd wejściowy rośnie. Przy 45 W wyjścia
+  i sprawności 85 % to 4,2 A przy 12,6 V, a przy napięciu banku bliskim progu
+  LVD **4,6 A**. Bezpiecznik 5 A siedziałby na krawędzi i przepalał się
+  z powodów niezwiązanych z żadną usterką — dlatego **7,5 A**.
+
+#### Zasilanie wyświetlacza z USB — co trzeba wiedzieć
+
+**Budżet portu.** Panel 7" 1024×600 ciągnie zwykle 0,5–1 A przy 5 V. Port
+USB 3.0 M910q daje 900 mA, USB 2.0 — 500 mA. Jeżeli panel przyszedł z kablem
+rozgałęzionym na dwa wtyki USB, to nie ozdobnik: podepnij oba, do **różnych**
+portów. Objaw niedoboru to migotanie albo restart panelu przy jaśniejszym
+obrazie, nie brak obrazu w ogóle.
+
+**Zapas XL6019 się kurczy.** Panel przestał być osobnym odbiornikiem 12 V
+i wszedł na szynę 19,5 V razem z komputerem:
+
+| Odbiornik | Moc |
+|-----------|-----|
+| M910q (limit CPU 28 W) | 25–35 W |
+| Panel 7" + dotyk przez USB | 3–5 W |
+| Pro Micro + modem LTE | 3–5 W |
+| **Razem** | **31–45 W** |
+
+XL6019 daje ok. **45 W**. Górny kraniec tabeli to dokładnie jego sufit,
+więc **limit poboru CPU przestaje być zaleceniem, a staje się warunkiem
+działania** — instrukcja w [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md)
+§3.5a. Drugi panel na tej samej szynie już się nie zmieści.
+
+**PWM podświetlenia w tym wariancie nie ma.** Sterowanie jasnością realizuje
+**Arduino Nano #1** (`arduino/output_controller`, piny 9 i 10, komenda
+`{"cmd":"backlight","display":"large","brightness":80}`) — a tej płytki
+w wariancie testowym nie ma. Panel świeci na stałe, jasnością sterujesz jego
+własnym przyciskiem. Kiedy dojdzie Nano #1 i regulacja PWM, **podświetlenie
+trzeba będzie zasilić osobno** — stopień MOSFET nie da się zasilić z USB
+razem z logiką panelu.
 
 ### 3.2 Ładowanie — wariant B, i dlaczego akurat on
 
@@ -197,9 +235,11 @@ przy 13,8 V. Po odjęciu 3,5 A obciążenia zostaje 2,3 A do banku.
 ### 3.3 Prąd ładowania — policz go z obciążeniem
 
 Moduł CC-CV limituje **prąd wyjściowy**, czyli obciążenie **plus** ładowanie.
-Zestaw testowy pobiera podczas jazdy ok. **3,5 A** (M910q ~30 W przez XL6019
-o sprawności ~85 % ≈ 2,7 A, panel ~0,6 A, reszta drobiazgi). Jeżeli ustawisz
-CC na 4 A, do banku popłynie 0,5 A i **nigdy się nie doładuje**.
+Zestaw testowy pobiera podczas jazdy ok. **3,5 A** — to całe ~37 W z tabeli
+w §3.1 przepuszczone przez XL6019 (sprawność ~85 %) i przeliczone na napięcie
+banku. Przeniesienie panelu na USB niczego tu nie zmieniło: ta sama energia,
+tylko inną drogą. Jeżeli ustawisz CC na 4 A, do banku popłynie 0,5 A
+i **nigdy się nie doładuje**.
 
 Reguła:
 
@@ -307,19 +347,18 @@ Ceny orientacyjne, rynek PL, 2025/2026.
 | 9 | Bezpiecznik **15 A** + oprawka przy klemie „+" | zasilanie ładowarki | 15–25 |
 | 10 | Bezpieczniki inline **10 A × 5** + oprawki | po jednym na pakiet | 25–40 |
 | 11 | Bezpiecznik inline **15 A** + oprawka | przed VIN+ modułu XH-M609 | 8–12 |
-| 12 | Bezpiecznik **5 A** + oprawka | wyjście XL6019 | 8–12 |
-| 13 | Bezpiecznik **3 A** + oprawka | panel 7" | 8–12 |
-| 14 | Przewód **2,5 mm²** | FLRY, czerwony 5 m + czarny 3 m | 40–60 |
-| 15 | Przewód **1,5 mm²** | FLRY, czerwony + czarny po 3 m | 15–25 |
-| 16 | Przewód **0,75 mm²** | FLRY, kilka kolorów po 2 m (ACC, sterowanie) | 15–25 |
-| 17 | Nasuwki **F2 6,35 mm** izolowane | do zacisków HR1221W, komplet | 15–25 |
-| 18 | Konektory oczkowe, tulejki, koszulki | zestaw, koszulki z klejem | 30–50 |
-| 19 | **Rozłącznik masy** | 100 A — na czas montażu i dłuższego postoju | 40–70 |
-| 20 | Skrzynka / wspornik na bank + pasy | na 5 pakietów, mocowanie do nadwozia | 60–120 |
-| 21 | Peszel + przelotki gumowe | przejścia przez blachę | 25–40 |
-| | | **Podsuma** | **304–516** |
+| 12 | Bezpiecznik **7,5 A** + oprawka | odgałęzienie do XL6019 (strona 12 V) — §3.1 | 8–12 |
+| 13 | Przewód **2,5 mm²** | FLRY, czerwony 5 m + czarny 3 m | 40–60 |
+| 14 | Przewód **1,5 mm²** | FLRY, czerwony + czarny po 3 m | 15–25 |
+| 15 | Przewód **0,75 mm²** | FLRY, kilka kolorów po 2 m (ACC, sterowanie) | 15–25 |
+| 16 | Nasuwki **F2 6,35 mm** izolowane | do zacisków HR1221W, komplet | 15–25 |
+| 17 | Konektory oczkowe, tulejki, koszulki | zestaw, koszulki z klejem | 30–50 |
+| 18 | **Rozłącznik masy** | 100 A — na czas montażu i dłuższego postoju | 40–70 |
+| 19 | Skrzynka / wspornik na bank + pasy | na 5 pakietów, mocowanie do nadwozia | 60–120 |
+| 20 | Peszel + przelotki gumowe | przejścia przez blachę | 25–40 |
+| | | **Podsuma** | **296–504** |
 
-**Razem obowiązkowo: ~504–1077 PLN.** Dolny kraniec to bezmarkowy VSR
+**Razem obowiązkowo: ~496–1065 PLN.** Dolny kraniec to bezmarkowy VSR
 i moduł „600 W" na potencjometrach, górny — Victron Cyrix i boost
 z wyświetlaczem. Przy pierwszej instalacji warto dopłacić przynajmniej
 za moduł CC-CV z odczytem cyfrowym.
@@ -333,19 +372,19 @@ za moduł CC-CV z odczytem cyfrowym.
 
 | # | Element | Kiedy potrzebne | Cena (PLN) |
 |---|---------|----------------|-----------|
-| 22 | **Arduino Pro Micro** (ATmega32U4) | jeśli nie masz — pody SWC bez niego nie zadziałają | 40–60 |
-| 23 | **Wtyk zasilania do M910q** | najtaniej: odetnij kabel od oryginalnego zasilacza (koszt 0) | 0–40 |
-| 24 | **Przejściówka DP → HDMI** | tylko jeśli Twój egzemplarz M910q ma wyjścia DisplayPort — sprawdź (§5.2) | 0–25 |
-| 25 | **Buck 12 → 5 V** (MP1584, 3 A) | tylko jeśli panel 7" jest 5-woltowy | 0–15 |
-| 26 | **Zaciskarka zapadkowa** | zaciski robione kombinerkami to najczęstsza usterka instalacji | 0–150 |
-| 27 | **Ładowarka sieciowa AGM** | doładowanie w garażu przy krótkich przejazdach | 0–250 |
+| 21 | **Arduino Pro Micro** (ATmega32U4) | jeśli nie masz — pody SWC bez niego nie zadziałają | 40–60 |
+| 22 | **Wtyk zasilania do M910q** | najtaniej: odetnij kabel od oryginalnego zasilacza (koszt 0) | 0–40 |
+| 23 | **Przejściówka DP → HDMI** | tylko jeśli Twój egzemplarz M910q ma wyjścia DisplayPort — sprawdź (§5.2) | 0–25 |
+| 24 | **Drugi kabel USB do panelu** | jeśli panel przyszedł z rozgałęzieniem na dwa wtyki — §3.1 | 0–15 |
+| 25 | **Zaciskarka zapadkowa** | zaciski robione kombinerkami to najczęstsza usterka instalacji | 0–150 |
+| 26 | **Ładowarka sieciowa AGM** | doładowanie w garażu przy krótkich przejazdach | 0–250 |
 
 ### 4.4 Warto, ale nie na start
 
 | # | Element | Po co | Cena (PLN) |
 |---|---------|-------|-----------|
-| 28 | Woltomierz/amperomierz panelowy z bocznikiem | podgląd banku i prądu ładowania bez multimetru | 40–70 |
-| 29 | Multimetr z pomiarem prądu DC 10 A | pomiar poboru XH-M609 i prądu ładowania | 80–200 |
+| 27 | Woltomierz/amperomierz panelowy z bocznikiem | podgląd banku i prądu ładowania bez multimetru | 40–70 |
+| 28 | Multimetr z pomiarem prądu DC 10 A | pomiar poboru XH-M609 i prądu ładowania | 80–200 |
 
 ### 4.5 Czego **nie** kupuj na tym etapie
 
@@ -355,8 +394,9 @@ za moduł CC-CV z odczytem cyfrowym.
 | Czujnik NTC | tanie moduły CC-CV nie mają wejścia kompensacji, więc nie ma go gdzie wpiąć — §3.2 |
 | Moduł buck-boost LTC3780 | utrzyma 13,8 V, ale tylko 80 W ciągle — za mało przy pięciu pakietach, §3.2a |
 | Przewód 6 mm², bezpiecznik główny 30 A | wymiarowane pod ładowarkę B2B — §4.2 |
-| Listwa dystrybucyjna 6–8 obwodów | cztery obwody obsłużą oprawki inline |
+| Listwa dystrybucyjna 6–8 obwodów | trzy obwody obsłużą oprawki inline |
 | Buck 12 → 5 V dla domeny A | nie ma jeszcze Nano, HM-10 ani RXB6 |
+| Buck 12 → 5 V dla panelu | panel wisi na USB M910q — §3.1 |
 | Moduł 9 przekaźników, oba Nano, HM-10, RXB6 | odpowiednie moduły są wyłączone |
 | DAC USB ES9038Q2M | mini-jack M910q wystarcza do weryfikacji — §1 |
 | Karta WiFi | **masz MT7921 i P2P-GO już działa** |
@@ -538,7 +578,9 @@ Pełna procedura siedmioetapowa (z pomiarami na każdym kroku):
 **Zasilanie — postój**
 
 ```
-[ ] Napięcie na wtyku M910q ≥ 19,0 V pod obciążeniem
+[ ] Napięcie na wtyku M910q ≥ 19,0 V pod obciążeniem — z podłączonym
+    panelem, bo on też wisi na tej szynie (§3.1)
+[ ] Panel nie miga i nie restartuje się przy jasnym obrazie (budżet USB)
 [ ] Po 30 min pracy XL6019 nie parzy w dotyku
 [ ] XH-M609 odcina przy 11,00 V (test zasilaczem, nie rozładowywaniem banku)
 [ ] Kluczyk OFF → domena B zanika w całości (pomiar na wyjściu przekaźnika)
@@ -570,7 +612,8 @@ wystarczy 5 pakietów, czy trzeba dołożyć pozostałe trzy (§3.4).
 | Domeny A (Nano ×2, HM-10, RXB6, przekaźniki) | dokupieniu płytek + buck 12 → 5 V |
 | Kompensacji temperaturowej ładowania | ładowarce B2B (wariant A, §5.2 `ZASILANIE_BUFOROWANE.md`) |
 | Modułu `power` w BCM | wejściu zapłonu, którego x86 nie ma — §1 |
-| Drugiego ekranu | panelu 6,86" — jest hot-plug, wystarczy wpiąć |
+| Regulacji jasności (PWM podświetlenia) | Nano #1 + osobne zasilanie podświetlenia — §3.1 |
+| Drugiego ekranu | panelu 6,86" — hot-plug, ale **nie na USB M910q**: dwa panele nie zmieszczą się w zapasie XL6019 (§3.1) |
 | OBD / K-Line | CP2102 + L9637D |
 | Kamer, parkowania, czujników | grabera, HC-SR04, DS18B20, obu Nano |
 | Wzmacniacza i głośników | zakupie gotowego modułu (osobna gałąź) |
@@ -585,12 +628,12 @@ i weryfikowalny osobno:
 
 | Krok | Co dochodzi | Co włączyć w configu |
 |------|-------------|---------------------|
-| 1 | ekran 10,1" 1280×800 | `display.dashboard` → 1280×800 (czyli `bcm_config.yaml`) |
+| 1 | ekran 10,1" 1280×800 | `display.dashboard` → 1280×800 (czyli `bcm_config.yaml`) — sprawdź pobór, 10,1" częściej wychodzi poza budżet USB niż 7" |
 | 2 | wzmacniacz + głośniki | bez zmian w configu — osobna gałąź zasilania |
 | 3 | DAC USB ES9038Q2M | bez zmian — zmiana domyślnego sinka PipeWire |
 | 4 | CP2102 + L9637D | `obd`, `obd.use_real_hardware: true` |
 | 5 | Nano #2 (sensor hub) | `environment`, `rain_sensor`, `blinker_monitor` |
-| 6 | Nano #1 + przekaźniki + buck domeny A | `central_lock`, `lighting` |
+| 6 | Nano #1 + przekaźniki + buck domeny A | `central_lock`, `lighting` — wtedy też **PWM podświetlenia i osobne zasilanie paneli** |
 | 7 | kamery + graber | `camera`, `crash_detect` |
 | 8 | GPS | `location`, `tracking` |
 | 9 | ekran 6,86" | `small_display` (hotplug — wystarczy wpiąć) |

--- a/docs/WDROZENIE_TESTOWE.md
+++ b/docs/WDROZENIE_TESTOWE.md
@@ -102,10 +102,10 @@ TVS + kondensator 470 µF/35 V        ← ochrona wejścia (§5.4 ZASILANIE)
 VSR  (zał. 13,3 V / wył. 12,8 V)     ← zwiera dopiero, gdy alternator pracuje
    │
    ▼
-moduł CC-CV boost  (CV 13,8 V, CC wg §3.3)
+moduł CC-CV boost  (CV 14,40 V, CC wg §3.3)
    │
    ▼
-rozłącznik nadnapięciowy (próg 14,80 V)   ← warstwa 2
+rozłącznik nadnapięciowy (próg 15,30 V)   ← warstwa 2
    │
    ▼
 BANK AGM 5 × HR1221W ── bezpiecznik 10 A na „+" każdego pakietu
@@ -141,24 +141,58 @@ gotową ładowarkę B2B (800–1000 PLN) albo VSR + moduł CC-CV boost
 (120–220 PLN). Na etapie testowym bierzemy **wariant B** — różnica to
 kilkaset złotych za funkcje, które przy jeździe testowej niewiele wnoszą.
 
-Do tego stosujemy kompromis z §5.3: **CV ustawione na 13,8 V, bez fazy
-absorpcji**. Konsekwencje są konkretne i warto je znać:
+**CV ustawiamy na 14,40 V, nie niżej.** To nie jest wybór estetyczny: boost
+ma władzę nad prądem tylko wtedy, gdy faktycznie przetwarza, czyli gdy
+wyjście jest wyżej niż wejście. Na wejściu modułu przy pracującym alternatorze
+jest 13,4–14,2 V, więc nastawa 13,8 V wepchnęłaby moduł w **pass-through**,
+gdzie pętla CC nie ma czym sterować, a rozładowany bank ciągnąłby ponad 30 A
+przez sam dławik. Pełne wyprowadzenie: §5.3b
+[`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md).
+
+Konsekwencje 14,40 V bez kompensacji temperaturowej — i co je łagodzi:
 
 | | |
 |---|---|
-| ✅ | nie potrzeba kompensacji temperaturowej ani czujnika NTC |
-| ✅ | 13,8 V bez kompensacji nie przeładuje banku nawet przy 50 °C |
-| ✅ | próg warstwy 2 schodzi z 15,30 V do **14,80 V** — łatwiej o tani przekaźnik napięciowy |
-| ⚠️ | bank ładuje się do ~90 %, nie do 100 % |
+| ✅ | CC działa zawsze, więc prąd ładowania jest naprawdę ograniczony |
+| ✅ | absorpcja podawana **tylko przy pracującym silniku** — VSR rozwiera obwód na postoju, bank nie stoi na 14,4 V |
+| ✅ | bank ładuje się do 100 %, nie do 90 % |
+| ⚠️ | brak kompensacji: przy 40 °C prawidłowa absorpcja to 13,95 V, czyli jedziesz 0,45 V za wysoko |
+| ⚠️ | próg warstwy 2 zostaje na **15,30 V** |
 
-Dla pracy buforowej to bardzo dobry kompromis. Przy przejściu na wariant A
-(ładowarka B2B) wracasz do 14,4 V absorpcji, kompensacji temperaturowej
-i progu 15,30 V.
+Jeśli bagażnik latem dochodzi do 50 °C — zejdź z CV do **14,10 V**. Nadal
+powyżej wejścia, więc CC pozostaje sprawne.
 
 **Dlaczego VSR, a nie dioda Schottky:** boost nie potrafi dać napięcia
-niższego niż wejściowe, więc przy zgaszonym silniku podawałby 13,8 V
+niższego niż wejściowe, więc przy zgaszonym silniku podawałby 14,4 V
 i **rozładowywał akumulator auta**. VSR rozłącza obwód fizycznie poniżej
 12,8 V. Szczegóły: §5.3 [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md).
+
+### 3.2a Konkretne moduły
+
+**Moduł CC-CV** — trzy sensowne opcje, wszystkie to boost:
+
+| Model | Dane | Cena (PLN) | Kiedy ten |
+|-------|------|-----------|-----------|
+| **„900 W 15 A" z wyświetlaczem** (typ CNC/DPS, wej. 8–60 V, wyj. 10–120 V) | CC 0–15 A, nastawa cyfrowa z odczytem | 90–140 | **bierz ten** — wpisujesz 14,40 V i 8,0 A i odczytujesz z powrotem; przy pierwszej instalacji to warte tych 40 zł różnicy |
+| **SZBK07** (SZ-BT07CCCV-D1 „1500 W 30 A", wej. 10–60 V, wyj. 12–90 V) | CC 0,8–20 A ±0,3 A · sprawność 92–97 % · ochrona odwrotnej polaryzacji · 130 × 84 × 52 mm | 80–130 | duży zapas mocy, pracuje zimno; nastawa potencjometrami — mierz multimetrem |
+| **„600 W 10 A"** (wej. 10–60 V, wyj. 12–80 V) | CC-CV potencjometrami | 50–80 | tylko przy trzech pakietach (CC do 6 A) |
+
+> **Sprawdź „auto output on power-on"** w module z wyświetlaczem. Jeśli ta
+> opcja jest wyłączona, po każdym uruchomieniu silnika wyjście stoi w OFF
+> i bank się nie ładuje — bez żadnego objawu, dopóki nie zejdzie do LVD.
+
+Modułu **buck-boost LTC3780** (WD2002SJ / XR-131) *nie* bierz do pięciu
+pakietów: utrzymałby 13,8 V, ale ciągle daje tylko 7 A / 80 W, czyli ~5,8 A
+przy 13,8 V. Po odjęciu 3,5 A obciążenia zostaje 2,3 A do banku.
+
+**VSR** — cztery opcje, od markowej do najtańszej:
+
+| Model | Progi | Cena (PLN) | Uwaga |
+|-------|-------|-----------|-------|
+| **Durite 0-727-11** — 12 V / 140 A | zał. 13,3 V · rozł. 12,65 V | 150–250 | zalany żywicą, LED stanu, progi fabrycznie takie, jakich potrzebujesz |
+| **Victron Cyrix-ct 12/24-120** | mikroprocesorowy | 250–350 | bezobsługowy; przy 9 A przesada |
+| Bezmarkowy „VSR 12 V 140 A" | zwykle 13,3 / 12,8 V | 60–120 | **zweryfikuj progi zasilaczem** — bywają przekłamane o 0,3 V |
+| **Przekaźnik 30 A z D+ alternatora** | zwiera, gdy alternator ładuje | 15–25 | tor niesie 9 A, więc 140 A to przesada. Trzeba znaleźć zacisk **D+/L** i sprawdzić, czy lampka kontrolna dalej działa — cewka bierze ~150 mA z jej obwodu |
 
 ### 3.3 Prąd ładowania — policz go z obciążeniem
 
@@ -213,8 +247,8 @@ ponad trzykrotnie — **dlatego to zmierz**.
 | **XL6019** | wyjście **19,5 V** pod obciążeniem | ustaw multimetrem, zabezpiecz potencjometr |
 | **XH-M609** | odcięcie **11,00 V**, powrót **12,60 V** | sprawdź, czy pracuje stabilnie przy 11 V |
 | **VSR** | zał. **13,3 V**, wył. **12,8 V** | zwykle fabryczne, sprawdź kartę |
-| **CC-CV boost** | CV **13,8 V**, CC wg §3.3 | ustaw CV **bez obciążenia**, CC na sztucznym obciążeniu |
-| **Rozłącznik nadnapięciowy** | próg **14,80 V**, powrót **14,0 V** | test zasilaczem laboratoryjnym, nie „na aucie" |
+| **CC-CV boost** | CV **14,40 V**, CC wg §3.3 | ustaw CV **bez obciążenia**, CC na sztucznym obciążeniu; nigdy poniżej napięcia wejściowego — §3.2 |
+| **Rozłącznik nadnapięciowy** | próg **15,30 V**, powrót **14,00 V** | test zasilaczem laboratoryjnym, nie „na aucie" |
 
 Obowiązkowe sprawdzenia XL6019 i XH-M609 przed pierwszym załączeniem:
 [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) §3.4 i §7.3.
@@ -256,15 +290,15 @@ Ceny orientacyjne, rynek PL, 2025/2026.
 
 | # | Element | Specyfikacja | Cena (PLN) |
 |---|---------|--------------|-----------|
-| 1 | **VSR** (voltage sensitive relay) | 12 V / 140 A, zał. 13,3 V | 60–120 |
-| 2 | **Moduł CC-CV boost** | 300 W / 10 A, regulacja **prądu i napięcia** | 60–100 |
-| 3 | **Rozłącznik nadnapięciowy** | przekaźnik napięciowy programowalny, próg 14,80 V | 40–80 |
+| 1 | **VSR** | Durite 0-727-11 albo bezmarkowy 12 V / 140 A — modele w §3.2a | 60–250 |
+| 2 | **Moduł CC-CV boost** | „900 W 15 A" z wyświetlaczem albo SZBK07 — modele w §3.2a | 50–140 |
+| 3 | **Rozłącznik nadnapięciowy** | przekaźnik napięciowy programowalny (XY-WJ01 lub odpowiednik), próg 15,30 V | 40–80 |
 | 4 | **Przekaźnik zapłonu** | Bosch 12 V / 30 A SPDT + podstawka | 15–25 |
 | 5 | **Dioda 1N4007** | gaszeniowa, równolegle do cewki | 2–5 |
 | 6 | **Dioda TVS + kondensator** | 1.5KE33CA lub SMCJ26CA + 470 µF/35 V low-ESR | 10–20 |
 | 7 | **Radiator + wentylator 40 mm** | do XL6019 — w aucie obowiązkowy | 20–35 |
 | 8 | **Kondensator wyjściowy** | 470 µF/35 V low-ESR na wyjście XL6019 | 3–6 |
-| | | **Podsuma** | **210–391** |
+| | | **Podsuma** | **200–561** |
 
 ### 4.2 Bezpieczniki i okablowanie — obowiązkowe
 
@@ -285,7 +319,10 @@ Ceny orientacyjne, rynek PL, 2025/2026.
 | 21 | Peszel + przelotki gumowe | przejścia przez blachę | 25–40 |
 | | | **Podsuma** | **304–516** |
 
-**Razem obowiązkowo: ~514–907 PLN.**
+**Razem obowiązkowo: ~504–1077 PLN.** Dolny kraniec to bezmarkowy VSR
+i moduł „600 W" na potencjometrach, górny — Victron Cyrix i boost
+z wyświetlaczem. Przy pierwszej instalacji warto dopłacić przynajmniej
+za moduł CC-CV z odczytem cyfrowym.
 
 > **Przekrój 2,5 mm² zamiast 6 mm²** jest tu policzony pod ten wariant:
 > 8 A ładowania to ok. 9 A po stronie wejścia, a bezpiecznik 15 A chroni
@@ -315,7 +352,8 @@ Ceny orientacyjne, rynek PL, 2025/2026.
 | Element | Dlaczego |
 |---------|----------|
 | Ładowarka B2B (Victron / Redarc) | wariant B robi to samo za ~1/5 ceny — §3.2 |
-| Czujnik NTC, kompensacja temperaturowa | CV 13,8 V bez absorpcji jej nie potrzebuje — §3.2 |
+| Czujnik NTC | tanie moduły CC-CV nie mają wejścia kompensacji, więc nie ma go gdzie wpiąć — §3.2 |
+| Moduł buck-boost LTC3780 | utrzyma 13,8 V, ale tylko 80 W ciągle — za mało przy pięciu pakietach, §3.2a |
 | Przewód 6 mm², bezpiecznik główny 30 A | wymiarowane pod ładowarkę B2B — §4.2 |
 | Listwa dystrybucyjna 6–8 obwodów | cztery obwody obsłużą oprawki inline |
 | Buck 12 → 5 V dla domeny A | nie ma jeszcze Nano, HM-10 ani RXB6 |
@@ -513,8 +551,10 @@ Pełna procedura siedmioetapowa (z pomiarami na każdym kroku):
 [ ] Silnik zgaszony → VSR rozwarty, zerowy prąd z akumulatora rozruchowego
 [ ] Silnik pracuje → VSR zwiera się w ciągu kilku sekund
 [ ] Prąd wyjściowy boostu nie przekracza nastawy CC (§3.3)
-[ ] Napięcie na banku po godzinie jazdy ≤ 13,8 V
-[ ] Rozłącznik nadnapięciowy odcina przy 14,80 V (test zasilaczem)
+[ ] Napięcie na banku po godzinie jazdy w przedziale 14,35–14,45 V
+[ ] Prąd ładowania spada w miarę ładowania (dowód, że moduł REGULUJE,
+    a nie stoi w pass-through — §3.2)
+[ ] Rozłącznik nadnapięciowy odcina przy 15,30 V (test zasilaczem)
 [ ] Moduł boost po 30 min jazdy w granicach temperatury (radiator, przewiew)
 ```
 
@@ -528,7 +568,7 @@ wystarczy 5 pakietów, czy trzeba dołożyć pozostałe trzy (§3.4).
 | Nie ma | Wróci przy |
 |--------|-----------|
 | Domeny A (Nano ×2, HM-10, RXB6, przekaźniki) | dokupieniu płytek + buck 12 → 5 V |
-| Absorpcji 14,4 V i kompensacji temperaturowej | ładowarce B2B (wariant A, §5.2 `ZASILANIE_BUFOROWANE.md`) |
+| Kompensacji temperaturowej ładowania | ładowarce B2B (wariant A, §5.2 `ZASILANIE_BUFOROWANE.md`) |
 | Modułu `power` w BCM | wejściu zapłonu, którego x86 nie ma — §1 |
 | Drugiego ekranu | panelu 6,86" — jest hot-plug, wystarczy wpiąć |
 | OBD / K-Line | CP2102 + L9637D |

--- a/docs/ZASILANIE_BUFOROWANE.md
+++ b/docs/ZASILANIE_BUFOROWANE.md
@@ -496,8 +496,70 @@ akumulator → bezp. 30 A → VSR → moduł CC-CV boost → blokada nadnapięci
 
 | Element | Rola | Nastawa | Cena |
 |---------|------|---------|------|
-| **VSR** (voltage sensitive relay) 12 V / 140 A | zwiera obwód dopiero, gdy alternator pracuje | zał. 13,3 V, wył. 12,8 V | 60–120 PLN |
-| **Moduł CC-CV boost** 300 W / 10 A z regulacją prądu i napięcia | podnosi 13,75 V → 14,4 V i limituje prąd | CV 14,40 V, CC 6,0 A | 60–100 PLN |
+| **VSR** (voltage sensitive relay) 12 V / 140 A | zwiera obwód dopiero, gdy alternator pracuje | zał. 13,3 V, wył. 12,8 V | 60–250 PLN |
+| **Moduł CC-CV boost** z regulacją prądu i napięcia | podnosi 13,75 V → 14,4 V i limituje prąd | CV 14,40 V, CC 6,0 A | 50–140 PLN |
+
+#### 5.3a Konkretne moduły CC-CV
+
+Wszystkie trzy to **boost**, więc nastawa CV musi być wyższa od napięcia
+wejściowego — patrz §5.3b.
+
+| Model | Dane | Cena | Kiedy ten |
+|-------|------|------|-----------|
+| **„900 W 15 A" z wyświetlaczem** (typ CNC/DPS, wej. 8–60 V, wyj. 10–120 V) | CC 0–15 A, nastawa cyfrowa z odczytem, pamięć nastaw | 90–140 PLN | **domyślny wybór** — wpisujesz 14,40 V i 6,0 A i odczytujesz z powrotem, zamiast celować potencjometrem |
+| **SZBK07** (SZ-BT07CCCV-D1, „1500 W 30 A", wej. 10–60 V, wyj. 12–90 V) | CC 0,8–20 A ±0,3 A · sprawność 92–97 % · ochrona odwrotnej polaryzacji · 130 × 84 × 52 mm | 80–130 PLN | gdy chcesz duży zapas mocy i zimną pracę; nastawa potencjometrami |
+| **„600 W 10 A"** (wej. 10–60 V, wyj. 12–80 V) | CC-CV potencjometrami | 50–80 PLN | wystarczy przy trzech pakietach (CC do 6 A) |
+
+> **„Auto output on power-on".** Moduły z wyświetlaczem mają opcję
+> automatycznego załączenia wyjścia po podaniu zasilania. Jeżeli zostanie
+> wyłączona, to po każdym uruchomieniu silnika moduł stoi z wyjściem OFF
+> i **bank się nie ładuje, bez żadnego objawu**. Ustaw to przy nastawianiu
+> i sprawdź, odcinając i podając zasilanie.
+
+#### 5.3b Nastawa CV musi być wyższa od wejścia
+
+Boost ma władzę nad prądem **tylko wtedy, gdy przetwarza** — czyli gdy
+napięcie wyjściowe jest wyższe od wejściowego. Poniżej tego progu duty
+schodzi do zera i moduł przechodzi w **pass-through**: prąd płynie przez
+dławik i diodę, a pętla CC nie ma czym sterować. To ta sama fizyka, którą
+§3.2a opisuje dla XL6019.
+
+Praktycznie: przy pracującym alternatorze na wejściu modułu jest
+**13,4–14,2 V** (zależnie od spadku na przewodzie). Rozładowany bank ma
+12,0 V. W pass-through różnicę 1,5–2 V ogranicza tylko rezystancja
+okablowania i banku — przy ~50 mΩ to **ponad 30 A**, czyli przepalony
+bezpiecznik w najlepszym razie.
+
+| Nastawa CV | Co się dzieje |
+|-----------|---------------|
+| **14,40 V** | wyjście zawsze powyżej wejścia → moduł zawsze przetwarza → **CC działa** ✅ |
+| 13,80 V | wejście bywa wyższe → pass-through → **CC nie działa** ❌ |
+
+Dlatego **CV = 14,40 V**, a nie 13,80 V. Konsekwencje przyjmujesz świadomie:
+próg warstwy 2 zostaje na **15,30 V** (§6.2), a kompensacji temperaturowej
+nie ma.
+
+**Co to łagodzi:** przy VSR napięcie absorpcji jest podawane **wyłącznie
+podczas pracy silnika**. Na postoju VSR rozwiera obwód i bank stoi na własnym
+napięciu spoczynkowym — nie jest trzymany na 14,4 V na okrągło. To zupełnie
+inny reżim niż stały float 14,4 V i dla pracy buforowej całkowicie
+akceptowalny.
+
+**Jeżeli mimo wszystko chcesz 13,80 V**, potrzebujesz topologii z władzą
+w obie strony — modułu **buck-boost**:
+
+| Model | Dane | Cena | Haczyk |
+|-------|------|------|--------|
+| **LTC3780** (moduł WD2002SJ / XR-131, wej. 5–32 V, wyj. 1–30 V) | buck-boost, CC + CV + próg podnapięciowy (trzy potencjometry), 10 A szczytowo | 50–90 PLN | **7 A i 80 W ciągle** — przy 13,8 V to tylko ~5,8 A, więc po odjęciu obciążenia do banku idzie mało. Do trzech pakietów w porządku, do ośmiu bez sensu |
+
+#### 5.3c Konkretne VSR-y
+
+| Model | Progi | Cena | Uwaga |
+|-------|-------|------|-------|
+| **Durite 0-727-11** — 12 V / 140 A | zał. 13,3 V · rozł. 12,65 V | 150–250 PLN | markowy, zalany żywicą, dioda LED stanu; progi fabrycznie dokładnie takie, jakich potrzebujesz |
+| **Victron Cyrix-ct 12/24-120** | sterowany mikroprocesorem | 250–350 PLN | najbardziej odporny i bezobsługowy; przy 6–9 A mocno przewymiarowany |
+| Bezmarkowy „VSR 12 V 140 A dual battery isolator" | zwykle 13,3 / 12,8 V | 60–120 PLN | działa, ale **zweryfikuj progi zasilaczem laboratoryjnym** przed montażem — potrafią być przekłamane o 0,3 V |
+| **Zamiennik: przekaźnik 30 A sterowany z D+** | zwiera, gdy alternator ładuje | 15–25 PLN | tor ładowania niesie 6–9 A, więc 140 A to przesada. Wymaga znalezienia zacisku **D+/L** alternatora i sprawdzenia, czy lampka kontrolna dalej działa — cewka pobiera ~150 mA z jej obwodu |
 
 **Dlaczego VSR, a nie dioda Schottky.** Boost nie może dawać napięcia
 niższego niż wejściowe — przy zgaszonym silniku (12,4 V na akumulatorze
@@ -511,12 +573,19 @@ dołożyć przekaźnik sterowany z ACC, który odcina ładowarkę przy zgaszonym
 silniku.
 
 **Kompensacja temperaturowa w wariancie B** jest ręczna: tanie moduły CC-CV
-jej nie mają. Praktyczne obejście — ustaw CV na **13,8 V**, czyli górny kraniec
-katalogowego zakresu buforowego, i zrezygnuj z fazy absorpcji. Bank będzie
-ładowany do ~90 % zamiast 100 %, ale **nie zostanie przeładowany nawet przy
-50 °C w bagażniku** (13,8 V bez kompensacji odpowiada wtedy mniej więcej
-prawidłowemu float). Dla pracy buforowej to bardzo dobry kompromis, a przy
-takiej nastawie próg warstwy 2 obniż do **14,80 V**.
+jej nie mają, a — jak pokazuje §5.3b — zejście z CV do „bezpiecznych" 13,8 V
+kupuje spokój kosztem utraty ograniczenia prądowego, czyli w złą stronę.
+Zostaje **14,40 V bez kompensacji**, z trzema rzeczami, które to trzymają
+w ryzach:
+
+- VSR podaje to napięcie **tylko przy pracującym silniku**, nie na postoju,
+- rozłącznik nadnapięciowy 15,30 V łapie awarię modułu (§6),
+- bank w bagażniku rzadko przekracza 30 °C, a przy 40 °C prawidłowa absorpcja
+  to 13,95 V — czyli 14,40 V to przegrzanie o 0,45 V przez kilka godzin jazdy,
+  a nie stałe przeładowanie.
+
+Jeżeli auto stoi latem w słońcu i bagażnik dochodzi do 50 °C, obniż CV do
+**14,10 V** — nadal powyżej wejścia, więc CC pozostaje sprawne.
 
 ### 5.4 Ochrona wejścia
 
@@ -847,7 +916,7 @@ dłuższym postoju; jeśli tak wygląda Twój profil użytkowania, rozważ
 | # | Element | Specyfikacja | Szt. | Cena (PLN) |
 |---|---------|--------------|------|-----------|
 | 1 | **Ładowarka DC-DC** *(wariant A)* | Victron Orion-Tr Smart 12/12-18 lub odpowiednik z presetem **AGM** | 1 | 800–1000 |
-| | *albo:* VSR + moduł CC-CV boost *(wariant B)* | VSR 12 V/140 A + boost 300 W/10 A z regulacją CC i CV | 1+1 | 120–220 |
+| | *albo:* VSR + moduł CC-CV boost *(wariant B)* | VSR: **Durite 0-727-11** / Victron Cyrix-ct 12/24-120 / bezmarkowy 140 A · boost: **„900 W 15 A" z wyświetlaczem** albo **SZBK07** — pełne zestawienie w §5.3a i §5.3c | 1+1 | 110–390 |
 | 2 | **Rozłącznik nadnapięciowy** | programowalny przekaźnik napięciowy, próg 15,3 V / powrót 14,0 V | 1 | 40–80 |
 | 3 | ~~Moduł LVD~~ | **posiadany — XH-M609** | — | 0 |
 | 4 | **Przekaźnik zapłonu** | Bosch 12 V / 30 A SPDT + podstawka | 1 | 15–25 |
@@ -874,7 +943,7 @@ dłuższym postoju; jeśli tak wygląda Twój profil użytkowania, rozważ
 | 24a | **Kondensator wyjściowy** | 470 µF / 35 V low-ESR na wyjście XL6019 | 1 | 3–6 |
 | 24b | **Termistor NTC** | 5 Ω / 5 A, ogranicznik prądu rozruchowego (tylko jeśli §3.2b) | 1 | 3–6 |
 | | | | **Razem wariant A** | **~1280–1870 PLN** |
-| | | | **Razem wariant B** | **~580–1070 PLN** |
+| | | | **Razem wariant B** | **~570–1240 PLN** |
 
 Kwoty są niższe niż w pierwszej wersji listy, bo moduł LVD i przetwornica
 step-up są już na stanie.

--- a/docs/ZASILANIE_BUFOROWANE.md
+++ b/docs/ZASILANIE_BUFOROWANE.md
@@ -67,6 +67,14 @@ przetwornic, zero ryzyka, że coś obudzi maszynę na parkingu. BCM budzi się
 zimnym startem na ACC — startuje w ~15 s, co przy samochodzie jest
 akceptowalne.
 
+**Dlaczego wyświetlacze mają własny buck, a nie USB.** Same panele
+spokojnie zasiliłyby się z portów USB M910q — i tak właśnie robi wariant
+testowy ([`WDROZENIE_TESTOWE.md`](WDROZENIE_TESTOWE.md) §3.1). W wersji
+docelowej stoi temu na przeszkodzie **regulacja jasności**: podświetlenie
+jest sterowane PWM-em z Nano #1 przez stopień MOSFET, a tego nie da się
+wpiąć w zasilanie logiki panelu idące po USB. Drugi powód jest energetyczny
+— dwa panele na szynie 19,5 V wypchnęłyby XL6019 poza jego ~45 W.
+
 **Wzmacniacz idzie osobną gałęzią** prosto z akumulatora rozruchowego —
 gotowy moduł samochodowy, podłączany jak radio: własny bezpiecznik przy klemie
 (wg karty modułu, zwykle 20–30 A), przewód 6 mm², **własna masa lokalna**
@@ -926,7 +934,7 @@ dłuższym postoju; jeśli tak wygląda Twój profil użytkowania, rozważ
 | 8 | **Bezpieczniki inline** | 10 A × 5–8 (pakiety) + oprawki, oraz 15 A przed VIN+ modułu XH-M609 | 6–9 | 20–35 |
 | 9 | **Bezpieczniki nożowe** | 5 A, 3 A × 2, 20 A + zapas | kpl. | 10–15 |
 | 10 | **Buck 12 → 5 V** (domena A) | LM2596, min. 1 A | 1 | 5–10 |
-| 11 | **Buck 12 → 5 V** (wyświetlacze) | MP1584 / MP2307, min. 3 A | 1 | 5–15 |
+| 11 | **Buck 12 → 5 V** (wyświetlacze) | MP1584 / MP2307, min. 3 A — potrzebny przez **PWM podświetlenia**, patrz niżej | 1 | 5–15 |
 | 12 | **Dioda TVS** | 1.5KE33CA lub SMCJ26CA | 2 | 5–10 |
 | 13 | **Kondensator elektrolityczny** | 470 µF / 35 V, low-ESR, 105 °C | 2 | 5–10 |
 | 14 | **Dioda gaszeniowa** | 1N4007 (na cewki przekaźników) | 5 | 2–5 |

--- a/schematics/charging_lvd.svg
+++ b/schematics/charging_lvd.svg
@@ -135,7 +135,7 @@
   <text class="warn" x="52" y="814">HR1221W to AGM — 14,4 V jest prawidłowe, nie za dużo.</text>
   <text class="note" x="52" y="832">Katalog CSB: cykliczne 14,4–15,0 V, buforowe 13,5–13,8 V @ 25 °C. Wartości 14,4 / 13,65 V</text>
   <text class="note" x="52" y="848">to dolne krańce obu zakresów — najłagodniejsze dla żywotności.</text>
-  <text class="note" x="52" y="870">Bez kompensacji temperaturowej: absorpcja na stałe 14,4 V, próg warstwy 2 obniż do 14,80 V.</text>
+  <text class="note" x="52" y="870">Bez kompensacji temperaturowej: absorpcja 14,4 V, próg warstwy 2 zostaje 15,30 V.</text>
 
   <!-- ===== TEMP COMPENSATION TABLE ===== -->
   <rect x="596" y="516" width="290" height="228" fill="#fbfcfd" stroke="#c8d2da" stroke-width="1.5" rx="6"/>

--- a/schematics/power_test_build.svg
+++ b/schematics/power_test_build.svg
@@ -89,25 +89,14 @@
   <text class="h" x="300" y="911">Przekaźnik zapłonu 30 A SPDT — domena B</text>
   <text class="t" x="300" y="930">cewka z ACC · dioda gaszeniowa 1N4007 równolegle</text>
 
-  <path class="wire" d="M300 950 L300 972"/>
-  <path class="wire" d="M190 972 L410 972"/>
-  <path class="wire" d="M190 972 L190 1000"/>
-  <path class="wire" d="M410 972 L410 1000"/>
-  <circle cx="300" cy="972" r="4" fill="#c0392b"/>
+  <path class="wire" d="M300 950 L300 1000"/>
+  <text class="fuse" x="312" y="978">bezp. 7,5 A</text>
 
-  <rect class="box" x="90" y="1000" width="200" height="88"/>
-  <text class="fuse" x="112" y="994">bezp. 5 A</text>
-  <text class="h" x="190" y="1023">XL6019 → 19,5 V</text>
-  <text class="t" x="190" y="1042">M910q, limit CPU 28 W</text>
-  <text class="t" x="190" y="1060">C 470 µF/35 V na wyjściu</text>
-  <text class="t" x="190" y="1078">radiator + wentylator 40 mm</text>
-
-  <rect class="box" x="310" y="1000" width="200" height="88"/>
-  <text class="fuse" x="332" y="994">bezp. 3 A</text>
-  <text class="h" x="410" y="1023">Panel 7" 1024×600</text>
-  <text class="t" x="410" y="1042">wprost z 12 V, jeśli taki jest</text>
-  <text class="t" x="410" y="1060">buck 12 → 5 V tylko dla</text>
-  <text class="t" x="410" y="1078">paneli 5-woltowych</text>
+  <rect class="box" x="90" y="1000" width="420" height="88"/>
+  <text class="h" x="300" y="1023">XL6019 12 → 19,5 V → M910q</text>
+  <text class="t" x="300" y="1042">limit CPU 28 W · radiator + wentylator 40 mm · C 470 µF/35 V</text>
+  <text class="t" x="300" y="1060">USB M910q: panel 7" 1024×600 + dotyk, Pro Micro, modem LTE</text>
+  <text class="t" x="300" y="1078">razem 31–45 W na szynie 19,5 V — sufit XL6019 to ok. 45 W</text>
 
   <!-- ============== NOTES ============== -->
   <rect class="note" x="560" y="282" width="376" height="96"/>
@@ -141,8 +130,8 @@
   <text class="nt" x="576" y="746">ładowarka ← akumulator</text><text class="nt" x="800" y="746">15 A</text><text class="nt" x="866" y="746">2,5 mm²</text>
   <text class="nt" x="576" y="768">każdy pakiet banku</text><text class="nt" x="800" y="768">10 A</text><text class="nt" x="866" y="768">2,5 mm²</text>
   <text class="nt" x="576" y="790">wejście XH-M609</text><text class="nt" x="800" y="790">15 A</text><text class="nt" x="866" y="790">2,5 mm²</text>
-  <text class="nt" x="576" y="812">wyjście XL6019</text><text class="nt" x="800" y="812">5 A</text><text class="nt" x="866" y="812">1,5 mm²</text>
-  <text class="nt" x="576" y="834">panel 7"</text><text class="nt" x="800" y="834">3 A</text><text class="nt" x="866" y="834">1,5 mm²</text>
+  <text class="nt" x="576" y="812">odgałęzienie do XL6019</text><text class="nt" x="800" y="812">7,5 A</text><text class="nt" x="866" y="812">1,5 mm²</text>
+  <text class="nt" x="576" y="834">panel 7" (przez USB)</text><text class="nt" x="800" y="834">—</text><text class="nt" x="866" y="834">—</text>
   <text class="nt" x="576" y="856">cewka przekaźnika (ACC)</text><text class="nt" x="800" y="856">—</text><text class="nt" x="866" y="856">0,75 mm²</text>
   <line x1="576" y1="868" x2="920" y2="868" stroke="#c8d2da"/>
   <text class="foot" x="576" y="886">2,5 mm² zamiast 6 mm² — bo ładowarka daje 8 A, nie 25 A.</text>

--- a/schematics/power_test_build.svg
+++ b/schematics/power_test_build.svg
@@ -48,15 +48,15 @@
   <path class="wire" d="M300 344 L300 378"/>
 
   <rect class="boxC" x="90" y="378" width="420" height="76"/>
-  <text class="h" x="300" y="401">Moduł CC-CV boost 300 W / 10 A</text>
-  <text class="t" x="300" y="420">CV 13,80 V (bez absorpcji) · CC 8,0 A dla pięciu pakietów</text>
+  <text class="h" x="300" y="401">Moduł CC-CV boost — „900 W 15 A” albo SZBK07</text>
+  <text class="t" x="300" y="420">CV 14,40 V · CC 8,0 A dla pięciu pakietów</text>
   <text class="t" x="300" y="438">radiator i przewiew — 8 A ciągłe to nie jest praca „na sucho”</text>
 
   <path class="wire" d="M300 454 L300 488"/>
 
   <rect class="boxC" x="90" y="488" width="420" height="62"/>
   <text class="h" x="300" y="511">Rozłącznik nadnapięciowy — warstwa 2</text>
-  <text class="t" x="300" y="530">próg 14,80 V · powrót 14,0 V</text>
+  <text class="t" x="300" y="530">próg 15,30 V · powrót 14,00 V</text>
 
   <path class="wire" d="M300 550 L300 584"/>
 
@@ -113,7 +113,7 @@
   <rect class="note" x="560" y="282" width="376" height="96"/>
   <text class="nh" x="576" y="304">Dlaczego VSR, a nie dioda Schottky</text>
   <text class="nt" x="576" y="325">Boost nie da napięcia niższego niż wejściowe, więc przy</text>
-  <text class="nt" x="576" y="342">zgaszonym silniku podawałby 13,8 V i rozładowywał</text>
+  <text class="nt" x="576" y="342">zgaszonym silniku podawałby 14,4 V i rozładowywał</text>
   <text class="nt" x="576" y="359">akumulator auta. VSR rozłącza obwód fizycznie.</text>
 
   <rect class="note" x="560" y="394" width="376" height="130"/>


### PR DESCRIPTION
Two changes to the test build, both prompted by details that only surface once you pick real parts.

---

# 1. The CV setpoint was wrong

The test build called for a plain boost module with **CV at 13.8 V**. That does not work.

A boost only has control authority while it is switching — while `Vout > Vin`. With the engine running the module input sits at **13.4–14.2 V** depending on the wiring drop, so a 13.8 V setpoint parks it in **pass-through**: current flows through the inductor and diode, and the CC loop has nothing to act on. A bank at 12.0 V behind ~50 mΩ then pulls **over 30 A**.

This is the same behaviour `ZASILANIE_BUFOROWANE.md` §3.2a already documents for the XL6019 on the output side. It applies just as well to the charger, and neither §5.3 nor the test doc accounted for it.

**CV goes to 14.40 V**, which keeps the output above the input in every condition and keeps CC live. The consequences are taken deliberately and written down: the layer-2 cutoff stays at **15.30 V** (not 14.80 V), and there is no temperature compensation. What makes that acceptable is the VSR — absorb voltage reaches the bank *only while the engine runs*, never as a permanent float, which is a completely different regime from holding 14.4 V around the clock. For a boot that hits 50 °C in summer, drop CV to 14.10 V — still above the input.

## Concrete CC-CV modules

| Model | Why you'd pick it |
|-------|-------------------|
| **"900 W 15 A" with a display** (CNC/DPS type, 8–60 V in, 10–120 V out) | Default pick — you type in 14.40 V / 8.0 A and read it back instead of aiming a potentiometer. Its **"auto output on power-on"** setting has to be on, or the bank quietly stops charging after every engine start, with no symptom until it hits the LVD. |
| **SZBK07** (SZ-BT07CCCV-D1, 10–60 V in, 12–90 V out) | CC 0.8–20 A ±0.3 A, 92–97 % efficiency, reverse-polarity protection. Pots rather than a display, but a lot of headroom so it runs cold. |
| **"600 W 10 A"** (10–60 V in, 12–80 V out) | Enough up to three packs (CC ≤ 6 A). |
| **LTC3780 buck-boost** (WD2002SJ / XR-131) | The only one that *would* hold 13.8 V — but 7 A / 80 W continuous means ~5.8 A at 13.8 V, and after the 3.5 A load that leaves 2.3 A for the bank. Documented as the option it is, not recommended for five packs. |

## Concrete VSRs

| Model | Thresholds | Note |
|-------|-----------|------|
| **Durite 0-727-11** — 12 V / 140 A | 13.3 V make, 12.65 V break | Potted, LED, factory thresholds are exactly what's needed |
| **Victron Cyrix-ct 12/24-120** | microprocessor controlled | Maintenance-free, heavily oversized at 9 A |
| Unbranded "VSR 12 V 140 A" | usually 13.3 / 12.8 V | Works, but verify on a bench supply — they can be off by 0.3 V |
| **30 A relay off the alternator D+** | closes when the alternator charges | The charging branch only carries 9 A, so 140 A is theatre. Needs the D+/L terminal found and the charge lamp checked afterwards — the coil draws ~150 mA from its circuit. |

Acceptance gained the observable that distinguishes real regulation from pass-through: **the charge current has to taper as the bank fills**.

---

# 2. The panel runs off USB, so domain B is one branch

The displays are USB-powered; only PWM dimming needs its own supply, and the first test build has no dimming. The panel now hangs on the M910q and the separate 12 V display branch is gone.

Three things follow, and two of them are not cosmetic:

**The fuse gets bigger, not smaller.** Everything goes through the XL6019 now, so its input current is the whole load: 45 W out at 85 % is 4.2 A at 12.6 V, and **4.6 A** once the bank sags toward the LVD threshold. A 5 A fuse would sit on the edge and blow for reasons unrelated to any fault — so **7.5 A** on the 12 V side of the branch.

**The XL6019 margin shrinks.**

| Load | Power |
|------|-------|
| M910q (CPU capped at 28 W) | 25–35 W |
| Panel 7" + touch over USB | 3–5 W |
| Pro Micro + LTE modem | 3–5 W |
| **Total on the 19.5 V rail** | **31–45 W** |

Against a ~45 W ceiling. The RAPL cap stops being advice and becomes a condition of operation, and a second panel no longer fits on that rail — flagged where the roadmap adds the 6.86".

**The charge-current arithmetic does not move.** Same energy, different route: ~3.5 A while driving, so the CC table in §3.3 stands as written.

Also documented: the USB port budget (a 7" panel wants 0.5–1 A, a USB 3.0 port gives 900 mA, and a two-plug cable is not decoration), and where PWM dimming actually lives — **Nano #1**, `output_controller` pins 9/10, which the test build does not have. `ZASILANIE_BUFOROWANE.md` now says why the target build keeps a separate display buck instead of doing the same thing: the MOSFET dimming stage can't hang off the panel's USB supply, and two panels would push the XL6019 past its ceiling.

Shopping list: panel fuse row removed, XL6019 row 5 A → 7.5 A, the 12 → 5 V buck replaced by a second USB cable, items renumbered, totals recut to **~496–1065 PLN**.

---

## Files

- `docs/ZASILANIE_BUFOROWANE.md` — new §5.3a (modules), §5.3b (why CV must exceed Vin), §5.3c (VSRs); the old 13.8 V workaround replaced; §2 note on the display buck vs USB; shopping row 1 and the variant-B total updated
- `docs/WDROZENIE_TESTOWE.md` — §3.1 rewritten (single branch, USB budget, XL6019 headroom, where PWM lives), §3.2 + new §3.2a, §3.3, §3.5, §4.1–4.5, §6.3, §7, §8, §9
- `schematics/power_test_build.svg` — CV 14.40 V, cutoff 15.30 V, module named, load branches collapsed to one, fuse table updated
- `schematics/charging_lvd.svg` — the "lower layer 2 to 14.80 V" note was stale for the same reason
- `arduino/output_controller/output_controller.ino` — PWM pins were still named after the 4.3"/7" panels; same stale naming already fixed in `backlight.py`

Verified: 419 tests pass, ruff clean, markdown links + anchors resolve, all SVGs parse and both edited ones render without text collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cXmt2HyZ8iv3aQHpkNA4c