### PR TITLE
Drop the VSR, power the BCM permanently, sleep it from the Arduino — with full schematics

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ pip install -r requirements.txt -r requirements-x86.txt
 - **Test / dev build** — a rolling install with the full power chain but only
   wireless Android Auto, audio and the steering-wheel buttons switched on:
   `docs/WDROZENIE_TESTOWE.md`, config `config/bcm_config_test.yaml`.
+  Everything to buy for it, in one table: `docs/LISTA_ZAKUPOWA.md`.
 - Repo audit + improvement roadmap: `AUDYT_I_PLAN.md`. Unused legacy
   code lives in `legacy/`; docs for retired platforms (Orange Pi 5 Pro /
   5 Plus, Orange Pi PC bench rig, VMware smoke tests) live in

--- a/arduino/sensor_hub/sensor_hub.ino
+++ b/arduino/sensor_hub/sensor_hub.ino
@@ -13,6 +13,8 @@
  *   TEMP:23.5                                    DS18B20 [°C]
  *   PARK:FL=123,FR=45,RL=200,RR=180              dystanse [cm]
  *   CRUISE:1 / IMMO:1 / AIRBAG:1                 opcjonalne
+ *   PWR:RUNNING|SLEEP|OFF|UNKNOWN                stan M910q
+ *   PWRACT:SHORT|LONG                            wysłany impuls na przycisk
  *
  * ================= WŁĄCZANIE / WYŁĄCZANIE FUNKCJI =================
  * Każda funkcja ma własny przełącznik kompilacji. Zakomentuj
@@ -25,6 +27,12 @@
 #define FEATURE_RAIN       // moduł czujnika deszczu, wyjście cyfrowe (D10)
 #define FEATURE_TEMP       // DS18B20 1-Wire (D11) — wymaga bibliotek
                            // OneWire + DallasTemperature
+#define FEATURE_PWRBTN     // sterowanie przyciskiem zasilania M910q (A0)
+                           // — zapłon usypia do S3 i wybudza. Wymaga
+                           // FEATURE_IGN. Szczegóły niżej.
+#define FEATURE_PWRLED     // odczyt diody zasilania panelu przedniego (A1)
+                           // — zamyka pętlę: firmware WIE, czy maszyna
+                           // pracuje, zamiast zgadywać. Opcjonalne.
 // #define FEATURE_PARK    // 4x HC-SR04 (TRIG D12, ECHO A0-A3).
                            // DOMYŚLNIE WYŁĄCZONE — czujniki parkowania
                            // obsługuje moduł parking na GPIO (Part 4).
@@ -48,10 +56,37 @@
  *   D10 Deszcz        (wyjście DO modułu czujnika; LOW = deszcz)
  *   D11 DS18B20 DQ    (+4.7kΩ pull-up do 5V)
  *   D12 HC-SR04 TRIG  (wspólny dla 4 czujników)
- *   A0-A3 HC-SR04 ECHO FL/FR/RL/RR (przez dzielnik 1k/2k z 5V!)
+ *   A0  Przekaźnik przycisku zasilania M910q  (FEATURE_PWRBTN)
+ *   A1  Dioda zasilania panelu przedniego     (FEATURE_PWRLED)
+ *   A0-A3 HC-SR04 ECHO FL/FR/RL/RR — TYLKO z FEATURE_PARK, które
+ *         wyklucza się z FEATURE_PWRBTN (patrz #error niżej)
  *   A4  Tempomat, A5 Immo (opcje), D13 Airbag (opcja)
  *
  * Watchdog: 2 s — zawieszenie = automatyczny reset.
+ *
+ * --- Sterowanie zasilaniem M910q (FEATURE_PWRBTN) ---
+ * Styki modułu przekaźnika 1-kanałowego wpięte RÓWNOLEGLE do przycisku
+ * zasilania M910q. Nie ma tu żadnego protokołu — impuls zwiera przycisk,
+ * a całą logikę ma już system operacyjny:
+ *
+ *   praca      + krótkie wciśnięcie → S3
+ *   S3         + krótkie wciśnięcie → wybudzenie (~3 s)
+ *   wyłączony  + krótkie wciśnięcie → start
+ *   dowolny    + przytrzymanie 5 s  → twarde wyłączenie
+ *
+ * Po stronie hosta: acpid (event=button/power → bcm-power-toggle.sh)
+ * plus HandlePowerKey=ignore w logind.conf — jedno i drugie jest już
+ * skonfigurowane, patrz docs/WDROZENIE_M910Q.md §7.3.
+ *
+ * Płytka MUSI mieć własne 5 V (MP1584 z bufora), niezależne od USB —
+ * inaczej gaśnie razem z komputerem i nie ma czym nacisnąć przycisku.
+ * W kablu USB przetnij żyłę VBUS.
+ *
+ * Bez FEATURE_PWRLED firmware działa w pętli otwartej: zakłada stan
+ * maszyny po własnych impulsach i reaguje wyłącznie na ZMIANĘ zapłonu,
+ * więc reset watchdogiem nie powoduje przypadkowego wciśnięcia.
+ * Z FEATURE_PWRLED odczytuje stan z diody panelu (świeci = praca,
+ * miga = S3, zgaszona = wyłączony) i sam się synchronizuje.
  */
 
 #include <avr/wdt.h>
@@ -76,6 +111,18 @@
 #define PIN_CRUISE    A4
 #define PIN_IMMO      A5
 #define PIN_AIRBAG    13
+#define PIN_PWR_RELAY A0
+#define PIN_PWR_LED   A1
+
+#if defined(FEATURE_PWRBTN) && !defined(FEATURE_IGN)
+#error "FEATURE_PWRBTN wymaga FEATURE_IGN - to zaplon steruje maszyna"
+#endif
+#if defined(FEATURE_PWRBTN) && defined(FEATURE_PARK)
+#error "Konflikt pinow: FEATURE_PARK uzywa A0-A3 na ECHO, FEATURE_PWRBTN A0/A1"
+#endif
+#if defined(FEATURE_PWRLED) && !defined(FEATURE_PWRBTN)
+#error "FEATURE_PWRLED bez FEATURE_PWRBTN nie ma czego synchronizowac"
+#endif
 
 // --- Cadence ---
 #define DEBOUNCE_MS        50
@@ -83,6 +130,21 @@
 #define TEMP_REPORT_MS   5000
 #define PARK_CYCLE_MS     100   // jeden czujnik na cykl → pełny skan 400 ms
 #define PARK_ECHO_TIMEOUT_US 25000UL  // ~4.3 m maks. zasięg
+
+#ifdef FEATURE_PWRBTN
+// Większość tanich modułów przekaźnikowych wyzwala się stanem NISKIM.
+// Jeśli Twój jest odwrotny — zmień na 0. Dodatkowo warto dać 10 kΩ
+// pull-up na IN, żeby przekaźnik nie zadziałał w kilku ms przed setup().
+#define PWR_RELAY_ACTIVE_LOW  1
+#define PWR_LED_ACTIVE_LOW    1     // PC817 na diodzie: świeci → pin LOW
+
+#define PWR_PULSE_SHORT_MS     250UL      // krótkie wciśnięcie
+#define PWR_PULSE_LONG_MS     5000UL      // przytrzymanie → twarde wyłączenie
+#define PWR_SETTLE_MS        15000UL      // po impulsie nie ruszamy niczego
+#define PWR_IGN_CONFIRM_MS    2000UL      // zapłon musi się utrzymać (rozruch!)
+#define PWR_OFF_AFTER_MS   7200000UL      // 2 h zgaszonego zapłonu → wyłącz
+#define PWR_LED_WINDOW_MS     1600UL      // okno rozpoznania migania diody
+#endif
 
 #ifdef FEATURE_DOORS
 const uint8_t DOOR_PINS[6]  = {PIN_DOOR_FL, PIN_DOOR_FR, PIN_DOOR_RL,
@@ -137,11 +199,49 @@ uint8_t parkIdx = 0;
 unsigned long lastParkCycle = 0;
 #endif
 
+#ifdef FEATURE_PWRBTN
+enum PwrState : uint8_t { PWR_UNKNOWN = 0, PWR_RUNNING, PWR_SLEEP, PWR_OFF };
+const char* const PWR_NAMES[4] = {"UNKNOWN", "RUNNING", "SLEEP", "OFF"};
+
+PwrState pwrState   = PWR_UNKNOWN;   // co (naszym zdaniem) robi maszyna
+PwrState pwrDesired = PWR_UNKNOWN;   // czego od niej chcemy
+
+bool          pwrIgnKnown  = false;  // czy zapłon jest już potwierdzony
+bool          pwrIgnLevel  = false;  // ostatni potwierdzony poziom
+bool          pwrIgnCand   = false;  // kandydat oczekujący na potwierdzenie
+unsigned long pwrIgnCandAt = 0;
+unsigned long pwrIgnOffAt  = 0;      // kiedy zapłon zgasł (do eskalacji)
+bool          pwrOffDone   = false;  // twarde wyłączenie już wysłane
+
+unsigned long pwrPulseUntil  = 0;    // trwa impuls do tej chwili (0 = brak)
+unsigned long pwrSettleUntil = 0;    // cisza po impulsie
+#endif
+
+#ifdef FEATURE_PWRLED
+bool          pwrLedLit      = false;
+uint8_t       pwrLedEdges    = 0;
+unsigned long pwrLedWindowAt = 0;
+#endif
+
 unsigned long lastStateRefresh = 0;
 
 // -----------------------------------------------------------------------------
 void setup() {
   wdt_disable();  // czysty stan po resecie watchdogiem
+
+#ifdef FEATURE_PWRBTN
+  // NAJPIERW przekaźnik w stan nieaktywny — zanim cokolwiek innego zdąży
+  // potrwać. Pin do tej chwili był wejściem (Hi-Z), stąd zalecany pull-up.
+#if PWR_RELAY_ACTIVE_LOW
+  digitalWrite(PIN_PWR_RELAY, HIGH);
+#else
+  digitalWrite(PIN_PWR_RELAY, LOW);
+#endif
+  pinMode(PIN_PWR_RELAY, OUTPUT);
+#endif
+#ifdef FEATURE_PWRLED
+  pinMode(PIN_PWR_LED, INPUT_PULLUP);
+#endif
 
 #ifdef FEATURE_DOORS
   for (uint8_t i = 0; i < 6; i++) pinMode(DOOR_PINS[i], INPUT_PULLUP);
@@ -278,6 +378,135 @@ void handlePark(unsigned long now) {
 }
 #endif
 
+#ifdef FEATURE_PWRBTN
+void pwrRelay(bool on) {
+#if PWR_RELAY_ACTIVE_LOW
+  digitalWrite(PIN_PWR_RELAY, on ? LOW : HIGH);
+#else
+  digitalWrite(PIN_PWR_RELAY, on ? HIGH : LOW);
+#endif
+}
+
+void pwrSetState(PwrState s) {
+  if (s == pwrState) return;
+  pwrState = s;
+  Serial.print(F("PWR:"));
+  Serial.println(PWR_NAMES[s]);
+}
+
+// Impuls jest NIEBLOKUJĄCY — 5 s w delay() zabiłoby watchdoga (2 s).
+void pwrStartPulse(unsigned long ms, const __FlashStringHelper* what) {
+  pwrRelay(true);
+  pwrPulseUntil = millis() + ms;
+  Serial.print(F("PWRACT:"));
+  Serial.println(what);
+}
+
+#ifdef FEATURE_PWRLED
+// Dioda panelu: świeci ciągle = praca, miga = S3, zgaszona = wyłączony.
+// Rozpoznajemy przez zliczanie zboczy w oknie PWR_LED_WINDOW_MS.
+void pwrObserveLed(unsigned long now) {
+  bool lit = digitalRead(PIN_PWR_LED) == (PWR_LED_ACTIVE_LOW ? LOW : HIGH);
+  if (lit != pwrLedLit) {
+    pwrLedLit = lit;
+    if (pwrLedEdges < 250) pwrLedEdges++;
+  }
+  if (now - pwrLedWindowAt < PWR_LED_WINDOW_MS) return;
+  pwrLedWindowAt = now;
+
+  if (pwrLedEdges >= 2)   pwrSetState(PWR_SLEEP);
+  else if (pwrLedLit)     pwrSetState(PWR_RUNNING);
+  else                    pwrSetState(PWR_OFF);
+  pwrLedEdges = 0;
+}
+#endif
+
+void handlePwrButton(unsigned long now) {
+  // 1. Domknij trwający impuls i odczekaj, aż maszyna wykona przejście.
+  if (pwrPulseUntil) {
+    if ((long)(now - pwrPulseUntil) >= 0) {
+      pwrRelay(false);
+      pwrPulseUntil = 0;
+      pwrSettleUntil = now + PWR_SETTLE_MS;
+    }
+    return;
+  }
+
+#ifdef FEATURE_PWRLED
+  pwrObserveLed(now);
+#endif
+
+  // 2. Potwierdzenie zapłonu. DEBOUNCE_MS (50 ms) wystarcza do raportowania
+  //    IGN:, ale nie do usypiania komputera — zapad przy rozruchu potrafi
+  //    zgasić ACC na chwilę. Stąd osobne, dłuższe potwierdzenie.
+  bool ign = inIgn.state;
+
+  if (!pwrIgnKnown) {
+    if (ign != pwrIgnCand) { pwrIgnCand = ign; pwrIgnCandAt = now; }
+    if ((now - pwrIgnCandAt) >= PWR_IGN_CONFIRM_MS) {
+      pwrIgnLevel = ign;
+      pwrIgnKnown = true;
+      if (!ign) pwrIgnOffAt = now;
+    }
+    return;  // pierwsza obserwacja po starcie NIE wywołuje akcji
+  }
+
+  if (ign != pwrIgnCand) { pwrIgnCand = ign; pwrIgnCandAt = now; }
+  if (pwrIgnCand != pwrIgnLevel && (now - pwrIgnCandAt) >= PWR_IGN_CONFIRM_MS) {
+    pwrIgnLevel = pwrIgnCand;
+    if (pwrIgnLevel) {
+      pwrDesired = PWR_RUNNING;
+    } else {
+      pwrIgnOffAt = now;
+      pwrOffDone  = false;
+      pwrDesired  = PWR_SLEEP;
+    }
+  }
+
+  // 3. Eskalacja: po dwóch godzinach postoju S3 przestaje się opłacać.
+  if (!pwrIgnLevel && !pwrOffDone && (now - pwrIgnOffAt) >= PWR_OFF_AFTER_MS) {
+    pwrDesired = PWR_OFF;
+  }
+
+  // 4. Wykonanie. Zamiar jest JEDNORAZOWY — po impulsie kasujemy go, żeby
+  //    firmware nie walczył z człowiekiem, który sam nacisnął przycisk.
+  if (now < pwrSettleUntil) return;
+  if (pwrDesired == PWR_UNKNOWN) return;
+  if (pwrDesired == pwrState) { pwrDesired = PWR_UNKNOWN; return; }
+
+  switch (pwrDesired) {
+    case PWR_RUNNING:
+      pwrStartPulse(PWR_PULSE_SHORT_MS, F("SHORT"));
+#ifndef FEATURE_PWRLED
+      pwrSetState(PWR_RUNNING);
+#endif
+      break;
+
+    case PWR_SLEEP:
+      // Z wyłączonej maszyny nie robimy S3 — krótki impuls by ją WŁĄCZYŁ.
+      if (pwrState == PWR_OFF) { pwrDesired = PWR_UNKNOWN; break; }
+      pwrStartPulse(PWR_PULSE_SHORT_MS, F("SHORT"));
+#ifndef FEATURE_PWRLED
+      pwrSetState(PWR_SLEEP);
+#endif
+      break;
+
+    case PWR_OFF:
+      pwrStartPulse(PWR_PULSE_LONG_MS, F("LONG"));
+      pwrOffDone = true;
+#ifndef FEATURE_PWRLED
+      pwrSetState(PWR_OFF);
+#endif
+      break;
+
+    default:
+      break;
+  }
+
+  pwrDesired = PWR_UNKNOWN;
+}
+#endif
+
 void reportFullState() {
 #ifdef FEATURE_DOORS
   reportDoors();
@@ -299,6 +528,10 @@ void reportFullState() {
 #endif
 #ifdef FEATURE_AIRBAG
   reportBool(F("AIRBAG:"), inAirbag.state);
+#endif
+#ifdef FEATURE_PWRBTN
+  Serial.print(F("PWR:"));
+  Serial.println(PWR_NAMES[pwrState]);
 #endif
 }
 
@@ -334,6 +567,9 @@ void loop() {
 #endif
 #ifdef FEATURE_PARK
   handlePark(now);
+#endif
+#ifdef FEATURE_PWRBTN
+  handlePwrButton(now);
 #endif
 
   // Okresowe odświeżenie pełnego stanu — BCM po restarcie dostaje

--- a/arduino/sensor_hub/sketch.yaml
+++ b/arduino/sensor_hub/sketch.yaml
@@ -1,4 +1,11 @@
 # arduino-cli build profile — kompilacja: make -C arduino sensor_hub
+# UWAGA na klony z ATmega328PB. To NIE jest 328P — ma inną sygnaturę
+# (0x1E9516 zamiast 0x1E950F) i rdzeń arduino:avr jej nie zna. Objaw:
+# avrdude przerywa z "Expected signature for ATmega328P". Wyjścia:
+#   • wgraj przez MiniCore:  fqbn: MiniCore:avr:328:variant=modelPB
+#     (arduino-cli core install MiniCore:avr, po dodaniu URL boards managera)
+#   • albo wymuś:  arduino-cli upload ... --programmer ... -F
+# Sam sketch kompiluje się na obu — używa wyłącznie peryferiów wspólnych.
 profiles:
   default:
     fqbn: arduino:avr:nano    # nowy bootloader; stary: arduino:avr:nano:cpu=atmega328old

--- a/docs/LISTA_ZAKUPOWA.md
+++ b/docs/LISTA_ZAKUPOWA.md
@@ -1,0 +1,111 @@
+# Lista zakupowa — wszystko w jednym miejscu
+
+Jedna lista do wariantu z [`WDROZENIE_TESTOWE.md`](WDROZENIE_TESTOWE.md):
+instalacja jeżdżąca z pełnym torem zasilania, Android Auto wireless, dźwiękiem
+przez mini-jack i przyciskami SWC.
+
+Ceny orientacyjne, rynek PL, 2025/2026. **Razem: ~479–923 PLN.**
+
+---
+
+## Masz już — nie kupuj
+
+| Element | Rola |
+|---------|------|
+| Lenovo ThinkCentre M910q Tiny | komputer |
+| Ekran 7" 1024×600, HDMI + dotyk USB | wyświetlacz na czas testów |
+| Karta WiFi MediaTek MT7921 | P2P-GO dla Android Auto wireless |
+| Pody SWC + dekoder rezystorowy | przyciski na kierownicy |
+| Modem LTE Huawei E3372 (HiLink) | internet |
+| CSB HR1221W F2 × 8 (12 V / 5,1 Ah AGM) | bank buforowy — użyj 5, lepiej 8 |
+| **XL6019** | step-up 12 → 19,5 V dla M910q |
+| **XH-M609** | LVD, ochrona banku |
+| **Arduino Pro Micro** (ATmega32U4) | SWC, enkoder, przyciski — USB HID |
+| **Arduino Nano V3** (ATmega328PB) | zapłon + sterowanie zasilaniem M910q |
+| **LM2596** | 12 → 5 V, podświetlenie panelu |
+| **MP1584** | 12 → 5 V, zasilanie Nano niezależne od USB |
+
+> **Nano V3 z 328PB wymaga uwagi przy wgrywaniu.** To nie jest 328P — ma inną
+> sygnaturę i rdzeń `arduino:avr` jej nie zna. Objaw: avrdude przerywa
+> z „Expected signature for ATmega328P". Rozwiązania są w
+> `arduino/sensor_hub/sketch.yaml`. Sam firmware kompiluje się na obu.
+
+---
+
+## Do kupienia
+
+| # | Element | Specyfikacja | Po co | Cena (PLN) |
+|---|---------|--------------|-------|-----------|
+| 1 | Przekaźnik 30 A SPDT + podstawka | Bosch 12 V | rozłącza tor ładowania przy zgaszonym silniku | 15–25 |
+| 2 | **Dioda MBR2545CT** | 25 A / 45 V, TO-220AB | blokada wsteczna; **obie anody zwarte** | 5–12 |
+| 3 | Radiator do TO-220 + podkładka mikowa | ok. 4,5 W strat | blaszka diody to katoda — musi być izolowana | 7–15 |
+| 4 | **Moduł CC-CV boost** | „900 W 15 A" z wyświetlaczem albo **SZBK07** | ładowarka: CV 14,40 V, CC 8 A | 50–140 |
+| 5 | Rozłącznik nadnapięciowy | przekaźnik napięciowy programowalny (XY-WJ01 lub odp.) | blokada przeładowania, próg 15,30 V | 40–80 |
+| 6 | Dioda TVS | 1.5KE33CA albo SMCJ26CA | ochrona wejścia przed load dumpem | 5–10 |
+| 7 | Kondensator 470 µF / 35 V low-ESR × 2 | 105 °C | wejście ładowarki + wyjście XL6019 | 7–14 |
+| 8 | Dioda 1N4007 × 5 | | gaszenie cewek przekaźników | 2–5 |
+| 9 | Radiator + wentylator 40 mm | do XL6019 | w aucie obowiązkowy | 20–35 |
+| 10 | **Moduł przekaźnika 1-kanałowy 5 V** | z optoizolacją | styki równolegle do przycisku zasilania M910q | 5–12 |
+| 11 | Transoptor **PC817** × 2 | DIP-4 | wejście zapłonu + odczyt diody panelu | 2–5 |
+| 12 | Rezystory 1/4 W | 2,2 kΩ × 2, 10 kΩ × 2, 1 kΩ × 2 | do transoptorów i pull-upów | 5–10 |
+| 13 | Kondensator 100 nF × 2 | ceramiczny | filtr na wejściach zapłonu i diody | 2–4 |
+| 14 | Bezpiecznik **15 A** + oprawka | przy klemie „+" | zasilanie ładowarki | 15–25 |
+| 15 | Bezpieczniki inline **10 A × 5** + oprawki | | po jednym na pakiet banku | 25–40 |
+| 16 | Bezpiecznik inline **15 A** + oprawka | | wejście XH-M609 | 8–12 |
+| 17 | Bezpiecznik **7,5 A** + oprawka | | odgałęzienie XL6019 | 8–12 |
+| 18 | Bezpiecznik **3 A** + oprawka × 2 | | LM2596 (podświetlenie) i MP1584 (Nano) | 12–20 |
+| 19 | Przewód **2,5 mm²** FLRY | czerwony 5 m + czarny 3 m | tor ładowania i bank | 40–60 |
+| 20 | Przewód **1,5 mm²** FLRY | czerwony + czarny po 3 m | odgałęzienia przetwornic | 15–25 |
+| 21 | Przewód **0,75 mm²** FLRY | kilka kolorów po 2 m | cewki, zasilanie logiki | 15–25 |
+| 22 | Przewód **0,5 mm²** | kilka kolorów po 2 m | sygnały: zapłon, przekaźnik, dioda panelu | 10–20 |
+| 23 | Nasuwki **F2 6,35 mm** izolowane | komplet | zaciski akumulatorów HR1221W | 15–25 |
+| 24 | Konektory oczkowe, tulejki, koszulki | zestaw, koszulki z klejem | | 30–50 |
+| 25 | **Rozłącznik masy 100 A** | kluczykowy albo pokrętło | jedyne realne zero poboru na postoju | 40–70 |
+| 26 | Skrzynka / wspornik na bank + pasy | na 5–8 pakietów | mocowanie do nadwozia | 60–120 |
+| 27 | Peszel + przelotki gumowe | 5 m + komplet | przejścia przez blachę | 25–40 |
+| 28 | Kabel USB z **przeciętą żyłą VBUS** | albo przetnij czerwoną w zwykłym | Nano ma własne 5 V — dwa źródła nie mogą się bić | 0–20 |
+| | | | **Razem** | **479–923** |
+
+---
+
+## Warto, ale nie na start
+
+| Element | Po co | Cena (PLN) |
+|---------|-------|-----------|
+| Multimetr z pomiarem prądu DC 10 A | pomiar poboru w S3 i prądu ładowania — **bez tego nie odbierzesz instalacji** | 80–200 |
+| Zaciskarka zapadkowa | zaciski robione kombinerkami to najczęstsza usterka instalacji | 60–150 |
+| Woltomierz/amperomierz panelowy z bocznikiem | podgląd banku bez multimetru | 40–70 |
+| Ładowarka sieciowa AGM | doładowanie w garażu przy krótkich przejazdach | 150–300 |
+| Przejściówka DP → HDMI | **tylko jeśli** Twój M910q ma wyjścia DisplayPort — sprawdź (`WDROZENIE_TESTOWE.md` §5.2) | 0–25 |
+| Drugi kabel USB do panelu | jeśli panel przyszedł z rozgałęzieniem na dwa wtyki | 0–20 |
+
+---
+
+## Czego **nie** kupować
+
+| Element | Dlaczego |
+|---------|----------|
+| VSR / separator akumulatorów | zastąpiony przekaźnikiem z zapłonu i diodą — §5.3c [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) |
+| Ładowarka B2B (Victron / Redarc) | wariant z przekaźnikiem i boostem robi to samo za ~1/5 ceny |
+| Moduł buck-boost LTC3780 | utrzyma 13,8 V, ale tylko 80 W ciągle — za mało przy pięciu pakietach |
+| Czujnik NTC | tanie moduły CC-CV nie mają wejścia kompensacji |
+| Przewód 6 mm², bezpiecznik główny 30 A | wymiarowane pod ładowarkę B2B, nie pod 8 A |
+| Buck 12 → 5 V dla panelu | logika i dotyk idą po USB z M910q |
+| DAC USB ES9038Q2M | mini-jack M910q wystarcza do weryfikacji |
+| Karta WiFi | masz MT7921 i P2P-GO już działa |
+| Wzmacniacz, głośniki, subwoofer | osobna gałąź wprost z akumulatora rozruchowego, po testach |
+| Drugi ekran, kamery, graber, czujniki | odpowiednie moduły są wyłączone |
+| Moduł 9 przekaźników, HM-10, RXB6 | dochodzą razem z Nano #1 przy rozbudowie |
+
+---
+
+## Powiązane dokumenty
+
+| Dokument | Zakres |
+|----------|--------|
+| [`WDROZENIE_TESTOWE.md`](WDROZENIE_TESTOWE.md) | co z tym zrobić — krok po kroku |
+| [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) | nastawy, uzasadnienia, lista dla wersji docelowej (§10) |
+| [`SCHEMATY_POLACZEN.md`](SCHEMATY_POLACZEN.md) | tabele „skąd → dokąd" (§10 — wariant testowy) |
+| [`../schematics/schematic_test_build.svg`](../schematics/schematic_test_build.svg) | schemat ideowy |
+| [`../schematics/wiring_test_build.svg`](../schematics/wiring_test_build.svg) | schemat połączeniowy |
+| [`../schematics/ignition_sense.svg`](../schematics/ignition_sense.svg) | wykrywanie zapłonu i sterowanie przyciskiem |

--- a/docs/PODSUMOWANIE_KONSOLIDACJI.md
+++ b/docs/PODSUMOWANIE_KONSOLIDACJI.md
@@ -195,13 +195,13 @@ Podane dwie działające topologie:
 | Wariant | Rozwiązanie | Koszt |
 |---------|-------------|-------|
 | **A — zalecany** | ładowarka DC-DC B2B z presetem AGM (Victron Orion-Tr Smart, Redarc BCDC, Sterling) — buck-boost, limit prądu, kompensacja temperaturowa, detekcja pracy alternatora w jednym pudełku | 800–1000 PLN |
-| **B — DIY** | VSR (rozdział ładowania) + moduł **CC-CV boost** 300 W/10 A nastawiony na 14,40 V / 6,0 A | 120–220 PLN |
+| **B — DIY** | przekaźnik ładowania + dioda **MBR2545CT** + moduł **CC-CV boost** nastawiony na 14,40 V / 6,0 A | 70–180 PLN |
 
-W wariancie B ważny jest **VSR zamiast diody Schottky**: boost nie może dawać
-napięcia niższego niż wejściowe, więc przy zgaszonym silniku próbowałby dalej
-podawać 14,2 V i rozładowywał akumulator rozruchowy. VSR fizycznie rozłącza
-obwód poniżej 12,8 V. Dodatkowo odpada spadek 0,45 V na diodzie, którego przy
-tak małym przełożeniu bardzo brakuje.
+W wariancie B tor ładowania **musi być fizycznie rozłączany**: boost nie może
+dawać napięcia niższego niż wejściowe, więc przy zgaszonym silniku próbowałby
+dalej podawać 14,4 V i rozładowywał akumulator rozruchowy. Robi to przekaźnik
+sterowany zapłonem (albo D+ alternatora), a dioda MBR2545CT jest drugą
+barierą na wypadek zespawania styków.
 
 ### 3.3 Czas postoju „~17 dni" to pełne rozładowanie
 
@@ -277,8 +277,8 @@ w `ZASILANIE_BUFOROWANE.md` §10. Rdzeń:
 
 | Grupa | Elementy |
 |-------|----------|
-| **Ładowanie** | ładowarka DC-DC z profilem AGM (wariant A) **albo** VSR + moduł CC-CV boost (wariant B) |
-| **Ochrona** | rozłącznik nadnapięciowy 14,6 V (blokada przeładowania), moduł LVD 11,0 V, przekaźnik zapłonu 30 A, przekaźnik mocy |
+| **Ładowanie** | ładowarka DC-DC z profilem AGM (wariant A) **albo** przekaźnik + MBR2545CT + moduł CC-CV boost (wariant B) |
+| **Ochrona** | rozłącznik nadnapięciowy 15,3 V (blokada przeładowania), moduł LVD 11,0 V, przekaźnik zapłonu 30 A, przekaźnik mocy |
 | **Zabezpieczenia** | listwa dystrybucyjna 6–8 obwodów, bezpiecznik główny 30 A, 5× inline 10 A na pakiety, wkładki 5/3/20 A |
 | **Przetwornice pomocnicze** | buck 12→5 V 1 A (domena A), buck 12→5 V 3 A (wyświetlacze) |
 | **Ochrona wejścia** | dioda TVS 1.5KE33CA, kondensator 470 µF/35 V, diody gaszeniowe 1N4007 |

--- a/docs/PODSUMOWANIE_KONSOLIDACJI.md
+++ b/docs/PODSUMOWANIE_KONSOLIDACJI.md
@@ -107,7 +107,7 @@ od opisu, są oznaczone ⚠ i zebrane w §19.
 
 ### `docs/ZASILANIE_BUFOROWANE.md`
 
-Zasilanie buforowane w szczegółach: architektura dwóch domen, weryfikacja
+Zasilanie buforowane w szczegółach: architektura jednej szyny, weryfikacja
 posiadanej przetwornicy, karta katalogowa i łączenie banku CSB HR1221W, ładowanie w dwóch
 wariantach, blokada przeładowania, LVD, bezpieczniki i przekroje, budżet
 energetyczny, **lista zakupowa rozbita na „już posiadane" i „do dokupienia"**,
@@ -117,9 +117,9 @@ procedura pierwszego uruchomienia w siedmiu etapach, plan serwisowy.
 
 | Plik | Zawartość |
 |------|-----------|
-| `power_buffered_m910q.svg` | tor główny: akumulator → rozdział ładowania → CC-CV → blokada przeładowania → bank CSB HR1221W → LVD → domeny → step-up → M910q, z tabelą przekrojów i bezpieczników |
+| `power_buffered_m910q.svg` | tor główny: akumulator → rozdział ładowania → CC-CV → blokada przeładowania → bank CSB HR1221W → LVD → wyłącznik główny → step-up → M910q, z tabelą przekrojów i bezpieczników |
 | `charging_lvd.svg` | cztery warstwy ochrony, nastawy dla CSB HR1221W (AGM), dwie tabele kompensacji temperaturowej, wpływ temperatury na żywotność, przebieg CC → CV → float |
-| `power_domains_m910q.svg` | podział domen A/B, bezpieczniki odgałęzień, budżet poboru spoczynkowego, tabela czasu postoju, osobna gałąź wzmacniaczy |
+| `power_domains_m910q.svg` | rozdział odbiorników, bezpieczniki odgałęzień, budżet poboru w trzech stanach maszyny, tabela czasu postoju, osobna gałąź wzmacniaczy |
 | `README.md` | indeks, kolejność czytania przy montażu, konwencje rysunkowe |
 
 ---
@@ -278,9 +278,9 @@ w `ZASILANIE_BUFOROWANE.md` §10. Rdzeń:
 | Grupa | Elementy |
 |-------|----------|
 | **Ładowanie** | ładowarka DC-DC z profilem AGM (wariant A) **albo** przekaźnik + MBR2545CT + moduł CC-CV boost (wariant B) |
-| **Ochrona** | rozłącznik nadnapięciowy 15,3 V (blokada przeładowania), moduł LVD 11,0 V, przekaźnik zapłonu 30 A, przekaźnik mocy |
+| **Ochrona** | rozłącznik nadnapięciowy 15,3 V (blokada przeładowania), moduł LVD 11,0 V, przekaźnik ładowania 30 A, przekaźnik mocy |
 | **Zabezpieczenia** | listwa dystrybucyjna 6–8 obwodów, bezpiecznik główny 30 A, 5× inline 10 A na pakiety, wkładki 5/3/20 A |
-| **Przetwornice pomocnicze** | buck 12→5 V 1 A (domena A), buck 12→5 V 3 A (wyświetlacze) |
+| **Przetwornice pomocnicze** | buck 12→5 V 1 A (logika), buck 12→5 V 3 A (wyświetlacze) |
 | **Ochrona wejścia** | dioda TVS 1.5KE33CA, kondensator 470 µF/35 V, diody gaszeniowe 1N4007 |
 | **Okablowanie** | 6 mm² (główne + masa), 2,5 mm², 1,5 mm², 0,75 mm², konektory, peszel, przelotki |
 | **Mechanika** | skrzynka/wspornik na bank z pasami, rozłącznik masy 100 A, radiator + wentylator 40 mm do przetwornicy |
@@ -371,7 +371,7 @@ schematics/
 ├── README.md                   ← indeks (NOWY)
 ├── power_buffered_m910q.svg    ← tor główny (NOWY)
 ├── charging_lvd.svg            ← ładowanie i ochrona (NOWY)
-├── power_domains_m910q.svg     ← domeny A/B (NOWY)
+├── power_domains_m910q.svg     ← rozdział odbiorników (NOWY)
 └── audio_system.svg            ← tor audio (bez zmian)
 
 Archive/

--- a/docs/SCHEMATY_POLACZEN.md
+++ b/docs/SCHEMATY_POLACZEN.md
@@ -27,6 +27,7 @@ Dobór podzespołów i nastawy: [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE
 7. [Masy](#7-masy)
 8. [Kolejność montażu](#8-kolejność-montażu)
 9. [Lista kontrolna przed pierwszym załączeniem](#9-lista-kontrolna-przed-pierwszym-załączeniem)
+10. [Tabela połączeń — wariant testowo-rozwojowy](#10-tabela-połączeń--wariant-testowo-rozwojowy)
 
 ---
 
@@ -502,6 +503,118 @@ To samo dotyczy Arduino: wgraj firmware i sprawdź każdą płytkę przez
 
 Po odhaczeniu całości przejdź do procedury pomiarowej:
 [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) § 11, etap 4.
+
+---
+
+## 10. Tabela połączeń — wariant testowo-rozwojowy
+
+Ten rozdział dotyczy **wyłącznie** wariantu z
+[`WDROZENIE_TESTOWE.md`](WDROZENIE_TESTOWE.md): mniej modułów, brak domeny B,
+M910q zasilany stale. Tabele §2–§5 opisują wersję docelową i tutaj **nie
+obowiązują**.
+
+**Rysunki:** [`../schematics/schematic_test_build.svg`](../schematics/schematic_test_build.svg)
+(ideowy) · [`../schematics/wiring_test_build.svg`](../schematics/wiring_test_build.svg)
+(połączeniowy, numery przewodów jak niżej) ·
+[`../schematics/ignition_sense.svg`](../schematics/ignition_sense.svg)
+(wykrywanie zapłonu)
+
+### 10.1 Tor ładowania
+
+| # | Skąd | Dokąd | Przewód | Zabezpieczenie |
+|---|------|-------|---------|----------------|
+| 1 | Akumulator rozruchowy **„+”** | Bezpiecznik **F1** (wejście) | 2,5 mm² | — |
+| 2 | **F1** (wyjście) | Płytka **TVS + C1**, biegun „+” | 2,5 mm² | 15 A, ≤ 30 cm od klemy |
+| 3 | **TVS + C1** „+” | Przekaźnik **K1**, zacisk **30** | 2,5 mm² | — |
+| 4 | Zapłon / ACC (albo **D+** alternatora) | **K1** zacisk **86** | 0,75 mm² | — |
+| 5 | **K1** zacisk **87** | **D1 MBR2545CT**, anody **1 + 3** zwarte | 2,5 mm² | — |
+| 6 | **D1** katoda **2** (blaszka) | Moduł CC-CV boost **IN+** | 2,5 mm² | — |
+| **B** | Boost **OUT+** | Rozłącznik nadnapięciowy **+ zasilanie** | 2,5 mm² | — |
+| 7 | Rozłącznik **NC** | Szyna **„+”** banku | 2,5 mm² | — |
+
+Masy tego toru (K1 zacisk 85, „−” TVS/C1, boost **IN−** i **OUT−**, „−”
+zasilania rozłącznika) idą do punktu gwiazdowego — §10.4.
+
+> **Dioda 1N4007** równolegle do cewki K1 (zaciski 85–86), katodą do „+”.
+> Bez niej impuls samoindukcji cewki wraca w instalację przy każdym
+> przekręceniu kluczyka.
+
+### 10.2 Bank, LVD, wyłącznik
+
+| # | Skąd | Dokąd | Przewód | Zabezpieczenie |
+|---|------|-------|---------|----------------|
+| — | „+” każdego pakietu HR1221W | Szyna **„+”** banku | 2,5 mm² | **F2…F6** 10 A, osobno na pakiet |
+| — | „−” każdego pakietu | Szyna **„−”** banku | 2,5 mm² | — |
+| 8 | Szyna **„+”** banku | **XH-M609 VIN+** | 2,5 mm² | **F7** 15 A |
+| 9 | Szyna **„−”** banku | **XH-M609 VIN−** | 2,5 mm² | — |
+| 10 | **XH-M609 VOUT+** | **S1** wyłącznik główny, zacisk 1 | 2,5 mm² | — |
+
+Nasuwki **F2 6,35 mm** izolowane, zaciskane zaciskarką zapadkową.
+Łączenie równoległe pakietów: [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) §4.3.
+
+### 10.3 Odbiorniki — zasilane stale
+
+| # | Skąd | Dokąd | Przewód | Zabezpieczenie |
+|---|------|-------|---------|----------------|
+| 11 | **S1** zacisk 2 (szyna odbiorników) | **XL6019 IN+** | 1,5 mm² | **F8** 7,5 A |
+| 12 | **XL6019 OUT+** / **OUT−** | Wtyk M910q: środek „+”, ekran „−” | 1,5 mm² | — |
+| 13 | **S1** zacisk 2 (szyna odbiorników) | **LM2596 IN+** | 1,5 mm² | **F9** 2 A |
+| 14 | **LM2596 OUT+** / **OUT−** | Panel 7", złącze **PWM+** / **GND** | 1,5 mm² | — |
+
+> **F8 to 7,5 A, nie 5 A.** Przy 45 W na wyjściu XL6019 i sprawności 85 %
+> prąd wejściowy sięga 4,2 A przy 12,6 V i **4,6 A** przy napięciu banku
+> bliskim progu LVD. Wkładka 5 A pracowałaby na krawędzi.
+
+**Logika panelu i dotyk zostają na USB M910q** — osobno idzie wyłącznie
+podświetlenie. Panel ma jeden kabel USB do komputera i jedno złącze
+zasilania podświetlenia.
+
+### 10.4 Wykrywanie zapłonu
+
+Wartości elementów i uzasadnienie: [`../schematics/ignition_sense.svg`](../schematics/ignition_sense.svg).
+
+| # | Skąd | Dokąd | Przewód |
+|---|------|-------|---------|
+| 15 | Zapłon / ACC **12 V** | **R1** 2,2 kΩ / 0,25 W → **U1 (PC817)** pin **1** | 0,5 mm² |
+| 16 | **U1** pin **2** | **Masa instalacji auta** — NIE punkt gwiazdowy | 0,5 mm² |
+| 17 | **U1** pin **4** | Pro Micro **D0 (RXI)** | 0,5 mm² |
+| 18 | **U1** pin **3** | Pro Micro **GND** | 0,5 mm² |
+| 19 | Pro Micro **D0** | **R2** 10 kΩ → Pro Micro **+5 V** (opcjonalny) | 0,5 mm² |
+| 20 | Pro Micro **D0** | **C2** 100 nF → Pro Micro **GND** | 0,5 mm² |
+
+> **Przewody 16 i 18 celowo idą do różnych mas.** Na tym polega optoizolacja:
+> po jednej stronie PC817 jest masa auta, po drugiej masa USB M910q. Zwarcie
+> ich niweczy cały sens układu i wpuszcza do komputera wszystko, co jeździ po
+> linii ACC.
+
+### 10.5 Punkt gwiazdowy masy
+
+Lądują na nim: „−” akumulatora rozruchowego, „−” TVS/C1, zacisk **85** K1,
+**IN−** i **OUT−** boostu, „−” zasilania rozłącznika nadnapięciowego, szyna
+**„−”** banku, **VIN−** i **VOUT−** modułu XH-M609, **IN−** przetwornic
+XL6019 i LM2596.
+
+**Jedyny wyjątek:** masa układu wykrywania zapłonu (**U1 pin 2**, przewód 16)
+idzie do masy instalacji auta.
+
+### 10.6 Kolejność podłączania
+
+```
+1. S1 rozwarty, bank odłączony, F1 wyjęty z oprawki.
+2. Nastawy na zasilaczu laboratoryjnym — wszystkie pięć:
+   XL6019 19,5 V · LM2596 wg panelu · boost 14,40 V / 8 A
+   rozłącznik 15,30 V · XH-M609 11,00 / 12,60 V
+3. Punkt gwiazdowy masy — komplet z §10.5.
+4. Bank z bezpiecznikami F2…F6, pomiar napięcia na szynie.
+5. Przewody 8, 9, 10 — bank przez F7 do LVD i S1.
+6. Przewody 11 i 12 — XL6019. POMIAR 19,5 V BEZ podłączonego M910q.
+7. Dopiero teraz M910q, potem 13–14 (podświetlenie).
+8. Na końcu przewody 1–7 i B — tor ładowania, przy zgaszonym silniku.
+9. Rozruch silnika, pomiar prądu ładowania cęgami lub bocznikiem.
+```
+
+Punkt 6 pomijany „bo przecież ustawiałem" to najczęstszy sposób na zabicie
+płyty głównej. Punkt 8 pomijany — na zabicie banku.
 
 ---
 

--- a/docs/SCHEMATY_POLACZEN.md
+++ b/docs/SCHEMATY_POLACZEN.md
@@ -55,7 +55,7 @@ diagnostyce po roku od montażu to oszczędza godziny:
 |-------|-------|
 | +12 V stałe (przed LVD) | czerwony |
 | +12 V buforowane (za LVD) | czerwono-biały |
-| +12 V domeny B (za przekaźnikiem) | pomarańczowy |
+| +12 V odbiorników (za wyłącznikiem głównym) | pomarańczowy |
 | +5 V | żółty |
 | +19 V do M910q | brązowy |
 | Masa | czarny |
@@ -173,7 +173,8 @@ dioda TVS 1.5KE33CA równolegle oraz kondensator 470 µF / 35 V równolegle.
 > uruchomieniem w aucie ustaw limit poboru pakietu CPU na M910q —
 > [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) §3.5a. Wyjścia
 > przetwornicy **nie da się użyć jako wyłącznika** komputera: boost przepuszcza
-> napięcie wejściowe, więc odcina wyłącznie przekaźnik zapłonu (poz. 32).
+> napięcie wejściowe. Komputera nie odcina nic — usypia go impuls z Arduino
+> na przycisk zasilania (§10.5).
 
 ### 2.6 Gałąź wzmacniacza (niezależna)
 
@@ -280,7 +281,7 @@ analogowe**.
 Pełne tabele pinów: [`ARDUINO_SETUP_GUIDE.md`](ARDUINO_SETUP_GUIDE.md) § 7
 i § 7b. Poniżej to, co dotyczy okablowania międzymodułowego.
 
-### 4.1 Nano #1 (domena A, wyjścia)
+### 4.1 Nano #1 (wyjścia — przekaźniki, PWM)
 
 | Pin | Dokąd |
 |-----|-------|
@@ -304,7 +305,7 @@ i § 7b. Poniżej to, co dotyczy okablowania międzymodułowego.
 > bramka MOSFET-a na `M_PWM` nie ma odniesienia i podświetlenie nie
 > reaguje.
 
-### 4.2 Pro Micro (domena B, wejścia)
+### 4.2 Pro Micro (wejścia — enkoder, SWC, zapłon)
 
 | Pin | Dokąd |
 |-----|-------|
@@ -320,7 +321,7 @@ i § 7b. Poniżej to, co dotyczy okablowania międzymodułowego.
 > D4 i A6 to ten sam fizyczny pin i kolidowało z SWC Pod 2. Przy starszym
 > okablowaniu przepnij jeden przewód.
 
-### 4.3 Nano #2 (domena A, sensor hub)
+### 4.3 Nano #2 (sensor hub)
 
 Patrz §3.3 i §3.4. Funkcje włącza się `#define FEATURE_*` na górze
 `sensor_hub.ino` — wyłączony `FEATURE` zwalnia pin.
@@ -367,7 +368,7 @@ z wykryciem ekranu.
 | Mikrofon USB | — |
 | Dotyk wyświetlacza głównego | — |
 
-> **Hub musi mieć własne zasilanie** (z domeny B). Osiem urządzeń nie
+> **Hub musi mieć własne zasilanie** (z szyny buforowanej). Osiem urządzeń nie
 > wyrobi się na prądzie z portu M910q.
 
 > **Reguły udev są konieczne.** Bez nich numeracja `/dev/ttyUSBn` zmienia
@@ -420,10 +421,10 @@ brak**. Sygnały wyzwalające wchodzą przez PC817 na Nano #2.
 | 30 A | przy klemie „+”, ≤ 30 cm | cały tor główny |
 | wg karty modułu (20–30 A) | przy klemie „+”, osobno | gałąź wzmacniacza |
 | 10 A × 5 | na „+” każdego pakietu banku | zwarcie pojedynczego pakietu |
-| 30 A | listwa, obwód 2 | domena B |
+| 30 A | listwa, obwód 2 | odbiorniki 12 V |
 | 5 A | wyjście step-up, przed wtykiem | M910q |
 | 5 A | linia ACC do cewki przekaźnika | obwód sterowania |
-| 3 A | listwa, obwód 1 | domena A |
+| 3 A | listwa, obwód 1 | logika 5 V |
 | 3 A | odgałęzienie buck MP1584 | panele wyświetlaczy |
 | 3 A | odgałęzienie hub USB | hub i peryferia |
 | 15 A | między bankiem a XH-M609 **VIN +** | moduł LVD i cała szyna za nim |
@@ -489,7 +490,7 @@ To samo dotyczy Arduino: wgraj firmware i sprawdź każdą płytkę przez
 [ ] Rozłącznik nadnapięciowy: 15,30 V / 14,00 V, sprawdzony zasilaczem lab.
 [ ] XH-M609: 11,00 V / 12,60 V, sprawdzony zasilaczem laboratoryjnym
 [ ] XH-M609: potwierdzone, że przełącza plus, i zmierzony pobór własny
-[ ] Buck domeny A: 5,0 V na wyjściu (zmierzone, nie „powinno być”)
+[ ] Buck logiki: 5,0 V na wyjściu (zmierzone, nie „powinno być”)
 [ ] Buck paneli: 5,0 V na wyjściu
 [ ] Dioda 1N4007 na cewce przekaźnika — katoda do 86
 [ ] TVS i kondensator na wejściu ładowarki zamontowane
@@ -509,7 +510,7 @@ Po odhaczeniu całości przejdź do procedury pomiarowej:
 ## 10. Tabela połączeń — wariant testowo-rozwojowy
 
 Ten rozdział dotyczy **wyłącznie** wariantu z
-[`WDROZENIE_TESTOWE.md`](WDROZENIE_TESTOWE.md): mniej modułów, brak domeny B,
+[`WDROZENIE_TESTOWE.md`](WDROZENIE_TESTOWE.md): mniej modułów, mniej okablowania,
 M910q zasilany stale. Tabele §2–§5 opisują wersję docelową i tutaj **nie
 obowiązują**.
 
@@ -583,11 +584,42 @@ Wartości elementów i uzasadnienie: [`../schematics/ignition_sense.svg`](../sch
 | 20 | Pro Micro **D0** | **C2** 100 nF → Pro Micro **GND** | 0,5 mm² |
 
 > **Przewody 16 i 18 celowo idą do różnych mas.** Na tym polega optoizolacja:
-> po jednej stronie PC817 jest masa auta, po drugiej masa USB M910q. Zwarcie
+> po jednej stronie PC817 jest masa auta, po drugiej masa Pro Micro. Zwarcie
 > ich niweczy cały sens układu i wpuszcza do komputera wszystko, co jeździ po
 > linii ACC.
 
-### 10.5 Punkt gwiazdowy masy
+### 10.5 Sterowanie przyciskiem zasilania M910q
+
+Arduino nie wysyła żadnego protokołu — po prostu **zwiera przycisk
+zasilania**, a resztę robi acpid, który jest już skonfigurowany
+(§7.3 [`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md)).
+
+| # | Skąd | Dokąd | Przewód |
+|---|------|-------|---------|
+| 21 | Pro Micro **A2** | Moduł przekaźnika **IN** | 0,5 mm² |
+| 22 | Pro Micro **+5 V** / **GND** | Moduł przekaźnika **VCC** / **GND** | 0,5 mm² |
+| 23 | Przekaźnik **COM** | Przycisk zasilania M910q, zacisk 1 | 0,5 mm² |
+| 24 | Przekaźnik **NO** | Przycisk zasilania M910q, zacisk 2 | 0,5 mm² |
+| 25 | **MP1584 OUT+** / **OUT−** | Pro Micro **VCC** / **GND** | 0,75 mm² |
+
+Styki przekaźnika idą **równolegle** do przycisku — przycisk dalej działa
+normalnie i zostaje ratunkiem awaryjnym.
+
+| Impuls na A2 | Efekt |
+|--------------|-------|
+| **250 ms** przy pracy | uśpienie do S3 |
+| **250 ms** w S3 | wybudzenie w ~3 s |
+| **250 ms** po wyłączeniu | start (zimny, ~40 s) |
+| **5 s** | twarde wyłączenie — pobór spada do ~80–120 mA |
+
+> **Przetnij żyłę VBUS (czerwoną) w kablu USB do Pro Micro.** Płytka jest
+> zasilana z MP1584 (przewód 25) i musi żyć, gdy M910q śpi. Dwa źródła 5 V
+> zwarte razem to niepotrzebne ryzyko; dane po USB działają bez VBUS.
+
+> **Zaciski przycisku znajdź miernikiem** w trybie ciągłości, przy maszynie
+> odłączonej od zasilania: rozwarte, zwarte przy wciśnięciu.
+
+### 10.6 Punkt gwiazdowy masy
 
 Lądują na nim: „−” akumulatora rozruchowego, „−” TVS/C1, zacisk **85** K1,
 **IN−** i **OUT−** boostu, „−” zasilania rozłącznika nadnapięciowego, szyna
@@ -597,7 +629,7 @@ XL6019 i LM2596.
 **Jedyny wyjątek:** masa układu wykrywania zapłonu (**U1 pin 2**, przewód 16)
 idzie do masy instalacji auta.
 
-### 10.6 Kolejność podłączania
+### 10.7 Kolejność podłączania
 
 ```
 1. S1 rozwarty, bank odłączony, F1 wyjęty z oprawki.

--- a/docs/SCHEMATY_POLACZEN.md
+++ b/docs/SCHEMATY_POLACZEN.md
@@ -76,9 +76,9 @@ w tabelach poniżej odpowiadają numerom na
 | # | Skąd | Dokąd | Przewód | Zabezpieczenie |
 |---|------|-------|---------|----------------|
 | 1 | Akumulator „+” | Bezpiecznik główny (wejście) | 6 mm² | — |
-| 2 | Bezpiecznik główny (wyjście) | VSR **BAT 1** | 6 mm² | 30 A, ≤ 30 cm od klemy |
-| 3 | VSR **BAT 2** | Ładowarka **IN +** (zacisk 1) | 6 mm² | — |
-| 4 | VSR **GND** | punkt gwiazdowy masy | 2,5 mm² | — |
+| 2 | Bezpiecznik główny (wyjście) | Przekaźnik ładowania **30** | 6 mm² | 30 A, ≤ 30 cm od klemy |
+| 3 | Przekaźnik ładowania **87** | Dioda MBR2545CT — anody (1 + 3) | 6 mm² | — |
+| 4 | Dioda MBR2545CT — katoda (2 / blaszka) | Ładowarka **IN +** (zacisk 1) | 6 mm² | blaszka pod potencjałem katody — izoluj od masy |
 | 5 | Ładowarka **IN −** (2) | punkt gwiazdowy masy | 6 mm² | — |
 | 6 | Ładowarka **OUT +** (3) | Blokada przeładowania **COM** (7) | 2,5 mm² | — |
 | 7 | Ładowarka **OUT −** (4) | punkt gwiazdowy masy | 2,5 mm² | — |

--- a/docs/WDROZENIE_M910Q.md
+++ b/docs/WDROZENIE_M910Q.md
@@ -165,13 +165,19 @@ Tutaj tylko to, co trzeba wiedzieć, żeby zrozumieć resztę wdrożenia.
 
 ![Tor zasilania](../schematics/power_buffered_m910q.svg)
 
-Układ ma **dwie domeny zasilania**:
+**Wszystko wisi na jednej szynie buforowanej.** Zapłon nie odcina żadnego
+odbiornika — jest sygnałem, który Arduino zamienia na impuls na styki
+**przycisku zasilania M910q**:
 
-| | Domena A — zawsze | Domena B — za zapłonem |
-|---|---|---|
-| Odbiorniki | oba Nano, HM-10 BLE, RXB6 433 MHz, przekaźniki | M910q, hub USB, wyświetlacze, Pro Micro |
-| Pobór spoczynkowy | ~60 mA | 0 mA (przekaźnik rozwarty) |
-| Na postoju | działa — pilot szyb, bagażnik przez BLE | odcięta |
+| Stan | Pobór z banku | Postój (5 pakietów) |
+|------|---------------|---------------------|
+| Praca | 10–55 W | — |
+| **S3** (kluczyk OFF) | 400–550 mA | ~1,2 dnia |
+| **Wyłączony** (impuls 5 s po 2 h) | 100–200 mA | ~3,5–5,3 dnia |
+
+Jedyny przekaźnik w torze mocy siedzi w **ładowaniu**, nie w odbiornikach.
+Uzasadnienie i porównanie z porzuconym modelem „domena B":
+[`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) §2.2.
 
 Między akumulatorem auta a head unitem stoi **bank 5 × CSB HR1221W F2**
 (12 V / 5,1 Ah AGM, razem 25,5 Ah), ładowany przez ładowarkę CC-CV z profilem
@@ -205,7 +211,7 @@ Wejście: **F1** przy starcie.
 | **Fast Boot** | Startup | Enabled | skraca POST |
 | **Secure Boot** | Security | Disabled | wymagane przez kernel i sterowniki |
 | **USB Legacy** | USB Setup | Disabled | skraca POST |
-| **Wake on USB** | Power | Enabled | Arduino może wybudzić maszynę z S3 |
+| **Wake on USB** | Power | Enabled *(opcjonalne)* | wygodne, ale niekonieczne — wybudza impuls Arduina na przycisk zasilania |
 
 > ⚠ **After Power Loss = Power On to ustawienie krytyczne.** Przy „Last
 > State" albo „Power Off" M910q nie wstanie po chwilowym zaniku napięcia
@@ -864,9 +870,9 @@ za zakończone.
 
 ```
 [ ] Rozruch silnika przy działającym BCM — komputer NIE resetuje się
-[ ] Wyłączenie zapłonu → domena B gaśnie, pobór 0 mA
+[ ] Wyłączenie zapłonu → impuls z Arduino, M910q schodzi do S3 (400–550 mA)
 [ ] Domena A dalej działa — pilot 433 MHz i BLE bagażnika odpowiadają
-[ ] Prąd spoczynkowy domeny A ~60 mA
+[ ] Prąd spoczynkowy logiki ~60 mA
 [ ] Prąd ładowania banku ≤ 6 A przy pracującym silniku
 [ ] Napięcie banku nie przekracza 14,40 V (wg kompensacji temperaturowej)
 [ ] Po 48 h postoju auto normalnie odpala

--- a/docs/WDROZENIE_TESTOWE.md
+++ b/docs/WDROZENIE_TESTOWE.md
@@ -94,6 +94,15 @@ przechodzi do STANDBY, co oznacza wygaszenie podświetlenia i
 
 ![Tor zasilania wariantu testowego](../schematics/power_test_build.svg)
 
+| Rysunek | Co pokazuje |
+|---------|-------------|
+| [`power_test_build.svg`](../schematics/power_test_build.svg) | przegląd blokowy — ten powyżej |
+| [`schematic_test_build.svg`](../schematics/schematic_test_build.svg) | **schemat ideowy** z symbolami elektrycznymi |
+| [`wiring_test_build.svg`](../schematics/wiring_test_build.svg) | **schemat połączeniowy** — zaciski i numery przewodów |
+| [`ignition_sense.svg`](../schematics/ignition_sense.svg) | **wykrywanie zapłonu** — optoizolacja, wartości elementów |
+
+Tabele „skąd → dokąd": [`SCHEMATY_POLACZEN.md`](SCHEMATY_POLACZEN.md) §10.
+
 ```
 akumulator rozruchowy
    │  bezpiecznik 15 A przy klemie „+", przewód 2,5 mm²

--- a/docs/WDROZENIE_TESTOWE.md
+++ b/docs/WDROZENIE_TESTOWE.md
@@ -482,92 +482,18 @@ przez LVD.
 
 ## 4. Lista zakupowa
 
-Ceny orientacyjne, rynek PL, 2025/2026.
+Cała lista — jedna tabela, z cenami i uzasadnieniem każdej pozycji — jest
+w osobnym dokumencie: **[`LISTA_ZAKUPOWA.md`](LISTA_ZAKUPOWA.md)**.
 
-### 4.1 Tor ładowania i ochrona — obowiązkowe
+| | |
+|---|---|
+| **Razem do kupienia** | **~479–923 PLN** |
+| Największe pozycje | moduł CC-CV boost (50–140), rozłącznik nadnapięciowy (40–80), skrzynka na bank (60–120), rozłącznik masy (40–70) |
+| Czego **nie** kupujesz | VSR, ładowarka B2B, DAC USB, karta WiFi, buck dla panelu — pełna lista z powodami tamże |
+| Warto dołożyć | multimetr z pomiarem prądu DC 10 A — bez niego nie odbierzesz instalacji |
 
-| # | Element | Specyfikacja | Cena (PLN) |
-|---|---------|--------------|-----------|
-| 1 | **Przekaźnik ładowania + dioda** | 30 A SPDT z podstawką + **MBR2545CT** — §3.2a | 20–37 |
-| 2 | **Moduł CC-CV boost** | „900 W 15 A" z wyświetlaczem albo SZBK07 — modele w §3.2a | 50–140 |
-| 3 | **Rozłącznik nadnapięciowy** | przekaźnik napięciowy programowalny (XY-WJ01 lub odpowiednik), próg 15,30 V | 40–80 |
-| 4 | **Dioda 1N4007** | gaszeniowa, równolegle do cewki przekaźnika | 2–5 |
-| 5 | **Dioda TVS + kondensator** | 1.5KE33CA lub SMCJ26CA + 470 µF/35 V low-ESR | 10–20 |
-| 6 | **LM2596 12 → 5 V** | zasilanie podświetlenia panelu — §3.1b | 5–10 |
-| 6a | **MP1584 12 → 5 V** | zasilanie Pro Micro niezależne od USB — §3.1a | 5–15 |
-| 6b | **Moduł przekaźnika 1-kanałowy 5 V** | styki równolegle do przycisku zasilania M910q — §3.1a | 5–12 |
-| 7 | **Radiator + wentylator 40 mm** | do XL6019 — w aucie obowiązkowy | 20–35 |
-| 8 | **Radiator do MBR2545CT** | ok. 4,5 W ciągłej straty + podkładka izolacyjna | 5–15 |
-| 9 | **Kondensator wyjściowy** | 470 µF/35 V low-ESR na wyjście XL6019 | 3–6 |
-| | | **Podsuma** | **165–375** |
-
-> **Przekaźnika zapłonu do odbiorników już nie ma** — M910q jest zasilany
-> stale, a zapłon jest tylko sygnałem dla Arduino (§3.1a). Jedyny przekaźnik
-> w tym wariancie siedzi w torze ładowania.
-
-### 4.2 Bezpieczniki i okablowanie — obowiązkowe
-
-| # | Element | Specyfikacja | Cena (PLN) |
-|---|---------|--------------|-----------|
-| 10 | Bezpiecznik **15 A** + oprawka przy klemie „+” | zasilanie ładowarki | 15–25 |
-| 11 | Bezpieczniki inline **10 A × 5** + oprawki | po jednym na pakiet | 25–40 |
-| 12 | Bezpiecznik inline **15 A** + oprawka | przed VIN+ modułu XH-M609 | 8–12 |
-| 13 | Bezpiecznik **7,5 A** + oprawka | odgałęzienie do XL6019 (strona 12 V) — §3.1 | 8–12 |
-| 14 | Bezpiecznik **2 A** + oprawka | odgałęzienie do LM2596 (podświetlenie) — §3.1b | 8–12 |
-| 15 | Przewód **2,5 mm²** | FLRY, czerwony 5 m + czarny 3 m | 40–60 |
-| 16 | Przewód **1,5 mm²** | FLRY, czerwony + czarny po 3 m | 15–25 |
-| 17 | Przewód **0,75 mm²** | FLRY, kilka kolorów po 2 m (sygnał zapłonu, sterowanie) | 15–25 |
-| 18 | Nasuwki **F2 6,35 mm** izolowane | do zacisków HR1221W, komplet | 15–25 |
-| 19 | Konektory oczkowe, tulejki, koszulki | zestaw, koszulki z klejem | 30–50 |
-| 20 | **Rozłącznik masy** | 100 A — obowiązkowy, jedyne realne zero poboru (§3.1a) | 40–70 |
-| 21 | Skrzynka / wspornik na bank + pasy | na 5 pakietów, mocowanie do nadwozia | 60–120 |
-| 22 | Peszel + przelotki gumowe | przejścia przez blachę | 25–40 |
-| | | **Podsuma** | **304–516** |
-
-**Razem obowiązkowo: ~469–891 PLN.** Dolny kraniec to moduł „600 W"
-na potencjometrach, górny — boost z wyświetlaczem i droższe okablowanie.
-Przy pierwszej instalacji warto dopłacić przynajmniej za moduł CC-CV
-z odczytem cyfrowym.
-
-> **Przekrój 2,5 mm² zamiast 6 mm²** jest tu policzony pod ten wariant:
-> 8 A ładowania to ok. 9 A po stronie wejścia, a bezpiecznik 15 A chroni
-> przewód z zapasem. Przy przejściu na ładowarkę B2B (18–25 A) trzeba
-> **wymienić i przewód, i bezpiecznik** na 6 mm² / 30 A.
-
-### 4.3 Zależne od tego, co już masz
-
-| # | Element | Kiedy potrzebne | Cena (PLN) |
-|---|---------|----------------|-----------|
-| 23 | **Arduino Pro Micro** (ATmega32U4) | jeśli nie masz — pody SWC bez niego nie zadziałają | 40–60 |
-| 24 | **Wtyk zasilania do M910q** | najtaniej: odetnij kabel od oryginalnego zasilacza (koszt 0) | 0–40 |
-| 25 | **Przejściówka DP → HDMI** | tylko jeśli Twój egzemplarz M910q ma wyjścia DisplayPort — sprawdź (§5.2) | 0–25 |
-| 26 | **Kabel USB bez żyły VBUS** | do Pro Micro — albo przetnij czerwoną żyłę w zwykłym, koszt 0 | 0–20 |
-| 27 | **Zaciskarka zapadkowa** | zaciski robione kombinerkami to najczęstsza usterka instalacji | 0–150 |
-| 28 | **Ładowarka sieciowa AGM** | doładowanie w garażu przy krótkich przejazdach | 0–250 |
-
-### 4.4 Warto, ale nie na start
-
-| # | Element | Po co | Cena (PLN) |
-|---|---------|-------|-----------|
-| 29 | Woltomierz/amperomierz panelowy z bocznikiem | podgląd banku i prądu ładowania bez multimetru | 40–70 |
-| 30 | Multimetr z pomiarem prądu DC 10 A | pomiar poboru XH-M609 w S3 i prądu ładowania | 80–200 |
-
-### 4.5 Czego **nie** kupuj na tym etapie
-
-| Element | Dlaczego |
-|---------|----------|
-| Ładowarka B2B (Victron / Redarc) | wariant B robi to samo za ~1/5 ceny — §3.2 |
-| Czujnik NTC | tanie moduły CC-CV nie mają wejścia kompensacji, więc nie ma go gdzie wpiąć — §3.2 |
-| Moduł buck-boost LTC3780 | utrzyma 13,8 V, ale tylko 80 W ciągle — za mało przy pięciu pakietach, §3.2a |
-| Przewód 6 mm², bezpiecznik główny 30 A | wymiarowane pod ładowarkę B2B — §4.2 |
-| Listwa dystrybucyjna 6–8 obwodów | trzy obwody obsłużą oprawki inline |
-| Buck 12 → 5 V dla domeny A | nie ma jeszcze Nano, HM-10 ani RXB6 |
-| Buck 12 → 5 V dla panelu | panel wisi na USB M910q — §3.1 |
-| Moduł 9 przekaźników, oba Nano, HM-10, RXB6 | odpowiednie moduły są wyłączone |
-| DAC USB ES9038Q2M | mini-jack M910q wystarcza do weryfikacji — §1 |
-| Karta WiFi | **masz MT7921 i P2P-GO już działa** |
-| Wzmacniacz, głośniki | osobna gałąź z akumulatora rozruchowego, po testach |
-| Drugi ekran, kamery, graber, czujniki | odpowiednie moduły są wyłączone |
+Masz już: M910q, ekran 7", MT7921, pody SWC, modem LTE, 8 × HR1221W,
+XL6019, XH-M609, Pro Micro, Nano V3, LM2596 i MP1584.
 
 ---
 
@@ -821,6 +747,7 @@ przejdź na `bcm_config.yaml`, gdy większość będzie już podłączona.
 
 | Dokument | Zakres |
 |----------|--------|
+| [`LISTA_ZAKUPOWA.md`](LISTA_ZAKUPOWA.md) | **wszystko do kupienia w jednej tabeli** |
 | [`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md) | wdrożenie docelowe, pełne |
 | [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) | warianty ładowania, nastawy modułów, sprawdzenia przed załączeniem |
 | [`SCHEMATY_POLACZEN.md`](SCHEMATY_POLACZEN.md) | tabele połączeń dla wersji docelowej |

--- a/docs/WDROZENIE_TESTOWE.md
+++ b/docs/WDROZENIE_TESTOWE.md
@@ -7,9 +7,9 @@ Wszystko pozostałe wyłączone.
 Wdrożenie docelowe (pełne): [`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md).
 
 > **To nie jest stanowisko biurkowe.** Zestaw jedzie w aucie, więc tor
-> zasilania jest kompletny: ładowanie banku, blokada przeładowania, LVD
-> i przekaźnik zapłonu. Oszczędzamy na funkcjach BCM i na wariancie
-> ładowarki — **nie na zabezpieczeniach**.
+> zasilania jest kompletny: ładowanie banku, blokada przeładowania i LVD.
+> Oszczędzamy na funkcjach BCM i na wariancie ładowarki — **nie na
+> zabezpieczeniach**.
 
 > **Ekran 7" to konfiguracja tymczasowa.** Docelowy panel to **10,1"
 > 1280×800**, opcjonalnie drugi **6,86" 1280×480** — i tak jest ustawione
@@ -64,10 +64,12 @@ tylko **raportuje** stan łącza (`lte.connected`, `lte.signal`, `lte.ip`);
 samo połączenie robi NetworkManager. Huawei E3372 w trybie HiLink zgłasza się
 jako karta sieciowa i działa od podłączenia.
 
-**Moduł `power` zostaje wyłączony mimo przekaźnika zapłonu.** `PowerManager`
-(`src/power/power_manager.py`) reaguje na zdarzenia `hal.ignition` /
-`sim.ignition`, a na x86 nikt takich zdarzeń nie publikuje — nie ma wejścia
-GPIO. Odcięcie domeny B robi tu sprzęt (przekaźnik na ACC), nie software.
+**Moduł `power` nie usypia maszyny — nawet gdy go włączysz.**
+`PowerManager` (`src/power/power_manager.py`) na `hal.ignition = false`
+przechodzi do STANDBY, co oznacza wygaszenie podświetlenia i
+`power.active = false` — **żadnego `systemctl suspend`**. Uśpienie robi
+`bcm-power-toggle.sh` przez acpid, poza BCM. Do tego na x86 nikt
+`hal.ignition` nie publikuje. Pełne rozpisanie luki: §3.1a.
 
 ---
 
@@ -99,7 +101,10 @@ akumulator rozruchowy
 TVS + kondensator 470 µF/35 V        ← ochrona wejścia (§5.4 ZASILANIE)
    │
    ▼
-VSR  (zał. 13,3 V / wył. 12,8 V)     ← zwiera dopiero, gdy alternator pracuje
+przekaźnik ładowania 30 A            ← cewka z zapłonu, dioda 1N4007
+   │
+   ▼
+dioda MBR2545CT (obie połówki równolegle, radiator)
    │
    ▼
 moduł CC-CV boost  (CV 14,40 V, CC wg §3.3)
@@ -116,68 +121,166 @@ XH-M609 (LVD)  ── bezpiecznik 15 A przed VIN+
    ▼
 wyłącznik główny na „+"  (albo rozłącznik masy na „−" banku)
    │
-   ├── przekaźnik zapłonu (cewka z ACC, dioda 1N4007) — DOMENA B
-   │      └── bezp. 7,5 A → XL6019 12 → 19,5 V → M910q
-   │                                              └── USB: panel 7", dotyk,
-   │                                                  Pro Micro, modem LTE
+   ├── bezp. 7,5 A → XL6019 12 → 19,5 V → M910q   ← ZASILANY STALE
+   │                                     └── USB: panel 7", dotyk,
+   │                                         Pro Micro, modem LTE
    │
-   └── DOMENA A — w tym wariancie pusta (nie ma jeszcze Nano, HM-10, RXB6)
+   └── bezp. 2 A → LM2596 12 → 5 V → podświetlenie panelu (§3.1b)
+
+sygnał zapłonu ──► wejście Arduino ──► USB ──► M910q: S3 / wybudzenie
 ```
 
 Cztery rzeczy warto tu zauważyć:
 
-- **Domena A jest pusta**, więc na postoju z banku pobiera prąd wyłącznie
-  sam XH-M609. To czyni pomiar jego poboru (§7.3
-  [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md)) najważniejszą liczbą
-  całego wariantu — patrz tabela w §3.3.
-- **Przekaźnik zapłonu nie jest opcją.** Bez niego XL6019 i M910q wiszą na
-  banku na postoju i rozkładają go w kilkanaście godzin.
-- **Panel 7" wisi na USB M910q** — żadnego odgałęzienia 12 V, żadnego bucka,
-  żadnego dodatkowego bezpiecznika. Cały tor kończy się na jednym wyjściu
-  XL6019. Szczegóły i haczyki poniżej.
-- **Jedna gałąź zamiast dwóch to jeden bezpiecznik — ale większy.** Wszystko
-  idzie teraz przez XL6019, więc jego prąd wejściowy rośnie. Przy 45 W wyjścia
-  i sprawności 85 % to 4,2 A przy 12,6 V, a przy napięciu banku bliskim progu
-  LVD **4,6 A**. Bezpiecznik 5 A siedziałby na krawędzi i przepalał się
-  z powodów niezwiązanych z żadną usterką — dlatego **7,5 A**.
+- **Nie ma już domeny B.** M910q wisi na buforze na stałe, a zapłon jest
+  tylko **sygnałem** — Arduino go wykrywa i usypia albo wybudza komputer.
+  Konsekwencje w §3.1a; jedna z nich jest kosztowna.
+- **Przekaźnik przeniósł się do toru ładowania.** Rozłącza ładowanie przy
+  zgaszonym silniku — nie odcina już niczego po stronie odbiorników.
+- **Panel 7" wisi na USB M910q** — dotyk i zasilanie idą tym samym kablem,
+  więc USB musi zostać. Osobno idzie tylko **podświetlenie**, przez LM2596
+  na złącze PWM + GND panelu (§3.1b).
+- **Jeden bezpiecznik na komputer — ale większy.** Wszystko idzie przez
+  XL6019, więc przy 45 W wyjścia i sprawności 85 % to 4,2 A przy 12,6 V,
+  a przy napięciu banku bliskim progu LVD **4,6 A**. Bezpiecznik 5 A
+  siedziałby na krawędzi i przepalał się bez żadnej usterki — dlatego
+  **7,5 A**.
 
-#### Zasilanie wyświetlacza z USB — co trzeba wiedzieć
+### 3.1a Stałe zasilanie i S3 — co to kosztuje
 
-**Budżet portu.** Panel 7" 1024×600 ciągnie zwykle 0,5–1 A przy 5 V. Port
-USB 3.0 M910q daje 900 mA, USB 2.0 — 500 mA. Jeżeli panel przyszedł z kablem
-rozgałęzionym na dwa wtyki USB, to nie ozdobnik: podepnij oba, do **różnych**
-portów. Objaw niedoboru to migotanie albo restart panelu przy jaśniejszym
-obrazie, nie brak obrazu w ogóle.
+Zapłon nie odcina już komputera. Zamiast tego **Arduino wykrywa zmianę stanu
+zapłonu**, a M910q schodzi do **S3** i z niego wraca. Zysk jest realny:
+wybudzenie w ~3 s zamiast ~40 s zimnego startu, bez ryzyka ucięcia zapisu
+na dysk w połowie.
 
-**Zapas XL6019 się kurczy.** Panel przestał być osobnym odbiornikiem 12 V
-i wszedł na szynę 19,5 V razem z komputerem:
+Cena też jest realna — i to jest najważniejsza liczba w tej zmianie:
+
+| Stan na postoju | Pobór z banku |
+|-----------------|---------------|
+| M910q w S3 | 1,5–3 W |
+| straty XL6019 przy tak małym obciążeniu | 1–1,5 W |
+| XH-M609 (zmierz!) | 0,25–1,5 W |
+| **Razem** | **~3–6 W, czyli 240–480 mA** |
+
+| Pakiety | 240 mA | 350 mA | 480 mA |
+|---------|--------|--------|--------|
+| 5 (25,5 Ah) | ~2,2 dnia | ~1,5 dnia | ~1,1 dnia |
+| 8 (40,8 Ah) | ~3,5 dnia | ~2,4 dnia | ~1,8 dnia |
+
+Wszystko do 50 % DoD. Dla porównania: przy twardym odcięciu domeny B
+wychodziło **~13 dni**. Utrata jest sześciokrotna i wynika wprost z tego,
+że S3 to nie jest zero.
+
+Co z tym zrobić:
+
+- **Auto używane co dzień lub co drugi dzień** — to nie problem, bank i tak
+  doładowuje się podczas jazdy.
+- **Dłuższy postój** — użyj **wyłącznika głównego**. To jedyna rzecz, która
+  naprawdę zeruje pobór, i dlatego został na liście jako obowiązkowy.
+- **XH-M609 jest siatką bezpieczeństwa**, nie planem: odetnie przy 11,00 V,
+  więc bank przeżyje, ale wrócisz do wyłączonego zestawu.
+- Docelowo Arduino może po kilku godzinach eskalować z S3 do pełnego
+  wyłączenia — wymaga firmware'u i haka po stronie hosta, patrz niżej.
+
+#### Czego brakuje w kodzie, żeby to zadziałało
+
+Sprzętowo ścieżka jest gotowa, software'owo **nie**. Trzy elementy do
+dorobienia — warto wiedzieć, zanim to zaplanujesz:
+
+| # | Brakuje | Gdzie |
+|---|---------|-------|
+| 1 | Wejście zapłonu w Pro Micro | wolny jest tylko **D0 (RXI)** — reszta pinów zajęta (enkoder, 5 przycisków, 2 pody SWC, panel muzyczny, LDR, przycisk dźwigni). Sygnał 12 V **musi** iść przez optoizolator albo dzielnik — nie wprost na pin 5 V |
+| 2 | Reakcja hosta na sygnał | `PowerManager` na `hal.ignition = false` przechodzi tylko do STANDBY i **gasi podświetlenie — nie usypia maszyny**. Uśpienie robi `bcm-power-toggle.sh` przez acpid. Ktoś musi połączyć jedno z drugim |
+| 3 | Nic nie publikuje `hal.ignition` na x86 | na OPi robił to `bcm-ignition-watcher` po GPIO; na M910q tego wejścia nie ma |
+
+Wybudzanie **nie wymaga kodu**: dowolne naciśnięcie klawisza po USB HID budzi
+maszynę z S3, o ile w BIOS-ie włączone jest **Wake on USB** (§6.2
+[`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md)). Pro Micro jest klawiaturą HID,
+więc to działa od ręki.
+
+> **Sprawdź, czy porty USB mają zasilanie w S3.** Jeżeli M910q odcina je
+> w uśpieniu, Arduino umiera razem z komputerem i **nie ma go czym wybudzić**
+> — zestaw zostaje w S3 do rozładowania banku. To pierwsza rzecz do
+> zmierzenia, przed jakimkolwiek firmware'em. Ratunek awaryjny: przycisk
+> zasilania M910q.
+
+### 3.1b Podświetlenie panelu — osobne zasilanie
+
+Panel ma osobne złącze **PWM + GND** do sterowania podświetleniem, niezależne
+od USB. To pozwala rozdzielić dwie rzeczy:
+
+| Co | Skąd |
+|----|------|
+| logika panelu + dotyk | **USB z M910q** — tu nic się nie zmienia |
+| podświetlenie | **LM2596 12 → 5 V** wprost z bufora, bezp. 2 A |
+
+Dzięki temu podświetlenie nie zjada budżetu portu USB (patrz niżej) ani
+zapasu XL6019.
+
+**Regulacji jasności w tym wariancie nie ustawiaj z BCM** — dlaczego,
+opisuje §3.1c. Wejście PWM podaj na stały poziom, a jasność reguluj
+**fizycznymi przyciskami panelu**.
+
+> **Zgaś podświetlenie razem z komputerem.** LM2596 wisi na buforze na stałe,
+> więc jeżeli panel świeci przy M910q w S3, dokładasz **2–4 W do poboru
+> postojowego** — a to niemal podwaja liczby z §3.1a. Większość paneli gasi
+> podświetlenie sama po zaniku sygnału HDMI; **sprawdź to pomiarem**. Jeżeli
+> Twój tego nie robi, wstaw na wyjście LM2596 mały przekaźnik albo MOSFET
+> sterowany z Arduino — ono i tak zna stan zapłonu.
+
+#### Budżet portu USB
+
+Po zdjęciu podświetlenia z USB zostaje sama logika panelu i dotyk, czyli
+0,2–0,4 A przy 5 V. Port USB 3.0 M910q daje 900 mA, USB 2.0 — 500 mA, więc
+jeden port wystarcza z zapasem. Gdyby panel jednak przyszedł z kablem
+rozgałęzionym na dwa wtyki, podepnij oba do **różnych** portów — objawem
+niedoboru jest migotanie albo restart panelu, nie brak obrazu.
+
+#### Zapas XL6019
 
 | Odbiornik | Moc |
 |-----------|-----|
 | M910q (limit CPU 28 W) | 25–35 W |
-| Panel 7" + dotyk przez USB | 3–5 W |
+| Panel — logika + dotyk przez USB | 1–2 W |
 | Pro Micro + modem LTE | 3–5 W |
-| **Razem** | **31–45 W** |
+| **Razem na szynie 19,5 V** | **29–42 W** |
 
-XL6019 daje ok. **45 W**. Górny kraniec tabeli to dokładnie jego sufit,
-więc **limit poboru CPU przestaje być zaleceniem, a staje się warunkiem
-działania** — instrukcja w [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md)
-§3.5a. Drugi panel na tej samej szynie już się nie zmieści.
+XL6019 daje ok. **45 W**. Przeniesienie podświetlenia na LM2596 odzyskało
+kilka watów, ale zapas dalej jest cienki, więc **limit poboru CPU nie jest
+zaleceniem, tylko warunkiem działania** — instrukcja w
+[`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) §3.5a. Drugi panel na
+tej samej szynie i tak się nie zmieści.
 
-**PWM podświetlenia w tym wariancie nie ma.** Sterowanie jasnością realizuje
-**Arduino Nano #1** (`arduino/output_controller`, piny 9 i 10, komenda
-`{"cmd":"backlight","display":"large","brightness":80}`) — a tej płytki
-w wariancie testowym nie ma. Panel świeci na stałe, jasnością sterujesz jego
-własnym przyciskiem. Kiedy dojdzie Nano #1 i regulacja PWM, **podświetlenie
-trzeba będzie zasilić osobno** — stopień MOSFET nie da się zasilić z USB
-razem z logiką panelu.
+### 3.1c Regulacja jasności — czego nie ma w kodzie
+
+Obserwacja, że w UI nie ma suwaka jasności, jest **trafna**. Stan faktyczny
+jest jednak bardziej pokręcony niż „jest tylko czujnik":
+
+| Element | Stan |
+|---------|------|
+| Suwak jasności w **web UI** | **nie istnieje** |
+| `POST /api/config` z kluczem `brightness` | przyjmuje wartość, zapisuje `display.dashboard.brightness` i publikuje `config.changed` — **nikt tego nie konsumuje** |
+| Ekran ustawień w **Pygame** (`settings_screen.py`) | ma pozycję „Brightness" 0–100 co 10 — ten sam martwy klucz |
+| LDR na **A1 Pro Micro** | sketch czyta go i wysyła po serialu `LIGHT:<0-1023>` co 2 s |
+| Przycisk dźwigni / akcja SWC „Brightness" | wysyła **F9** → `action_dispatch` mapuje na `input.brightness_cycle` |
+| `BrightnessController` (`src/power/brightness.py`) | subskrybuje jedno i drugie, ma 6 stopni ręcznych i mapę czujnika… ale **nigdy nie jest tworzony** — `start_power()` uruchamia tylko `PowerManager`, `BacklightController` i `ShutdownHandler` |
+| Wyjście PWM do sprzętu | `BacklightController` na x86 tylko symuluje; realny PWM idzie przez `central_lock.py` → **Nano #1**, którego tu nie ma |
+
+Czyli: cały łańcuch istnieje, ale **jest rozpięty w dwóch miejscach naraz** —
+brakuje instancji kontrolera i brakuje płytki, która wystawia PWM. Ani LDR,
+ani przycisk SWC nic dziś nie robią.
+
+**Zgodnie z ustaleniem zostawiamy to jak jest.** Panel ma fizyczną regulację
+switchami i to w zupełności wystarcza na czas testów. Domknięcie tego
+łańcucha to zadanie na krok 6 roadmapy (§9), razem z Nano #1.
 
 ### 3.2 Ładowanie — wariant B, i dlaczego akurat on
 
 [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) §5 opisuje dwa warianty:
-gotową ładowarkę B2B (800–1000 PLN) albo VSR + moduł CC-CV boost
-(120–220 PLN). Na etapie testowym bierzemy **wariant B** — różnica to
-kilkaset złotych za funkcje, które przy jeździe testowej niewiele wnoszą.
+gotową ładowarkę B2B (800–1000 PLN) albo przekaźnik ładowania z diodą
+i moduł CC-CV boost (70–180 PLN). Na etapie testowym bierzemy **wariant B**
+— różnica to kilkaset złotych za funkcje, które przy jeździe testowej
+niewiele wnoszą.
 
 **CV ustawiamy na 14,40 V, nie niżej.** To nie jest wybór estetyczny: boost
 ma władzę nad prądem tylko wtedy, gdy faktycznie przetwarza, czyli gdy
@@ -192,7 +295,7 @@ Konsekwencje 14,40 V bez kompensacji temperaturowej — i co je łagodzi:
 | | |
 |---|---|
 | ✅ | CC działa zawsze, więc prąd ładowania jest naprawdę ograniczony |
-| ✅ | absorpcja podawana **tylko przy pracującym silniku** — VSR rozwiera obwód na postoju, bank nie stoi na 14,4 V |
+| ✅ | absorpcja podawana **tylko podczas jazdy** — przekaźnik ładowania jest na postoju rozwarty, bank nie stoi na 14,4 V |
 | ✅ | bank ładuje się do 100 %, nie do 90 % |
 | ⚠️ | brak kompensacji: przy 40 °C prawidłowa absorpcja to 13,95 V, czyli jedziesz 0,45 V za wysoko |
 | ⚠️ | próg warstwy 2 zostaje na **15,30 V** |
@@ -200,10 +303,12 @@ Konsekwencje 14,40 V bez kompensacji temperaturowej — i co je łagodzi:
 Jeśli bagażnik latem dochodzi do 50 °C — zejdź z CV do **14,10 V**. Nadal
 powyżej wejścia, więc CC pozostaje sprawne.
 
-**Dlaczego VSR, a nie dioda Schottky:** boost nie potrafi dać napięcia
-niższego niż wejściowe, więc przy zgaszonym silniku podawałby 14,4 V
-i **rozładowywał akumulator auta**. VSR rozłącza obwód fizycznie poniżej
-12,8 V. Szczegóły: §5.3 [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md).
+**Dlaczego tor ładowania musi być rozłączany:** boost nie potrafi dać
+napięcia niższego niż wejściowe, więc gdyby jego wejście wisiało na stałe na
+akumulatorze rozruchowym, to przy zgaszonym silniku dalej podawałby 14,4 V
+i **rozładowywał akumulator auta**. Przekaźnik przerywa obwód fizycznie,
+a dioda MBR2545CT jest drugą barierą, gdyby styki się zespawały. Szczegóły:
+§5.3c [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md).
 
 ### 3.2a Konkretne moduły
 
@@ -223,14 +328,21 @@ Modułu **buck-boost LTC3780** (WD2002SJ / XR-131) *nie* bierz do pięciu
 pakietów: utrzymałby 13,8 V, ale ciągle daje tylko 7 A / 80 W, czyli ~5,8 A
 przy 13,8 V. Po odjęciu 3,5 A obciążenia zostaje 2,3 A do banku.
 
-**VSR** — cztery opcje, od markowej do najtańszej:
+**Rozdział ładowania** — przekaźnik plus dioda, obie pozycje po kilkanaście
+złotych:
 
-| Model | Progi | Cena (PLN) | Uwaga |
-|-------|-------|-----------|-------|
-| **Durite 0-727-11** — 12 V / 140 A | zał. 13,3 V · rozł. 12,65 V | 150–250 | zalany żywicą, LED stanu, progi fabrycznie takie, jakich potrzebujesz |
-| **Victron Cyrix-ct 12/24-120** | mikroprocesorowy | 250–350 | bezobsługowy; przy 9 A przesada |
-| Bezmarkowy „VSR 12 V 140 A" | zwykle 13,3 / 12,8 V | 60–120 | **zweryfikuj progi zasilaczem** — bywają przekłamane o 0,3 V |
-| **Przekaźnik 30 A z D+ alternatora** | zwiera, gdy alternator ładuje | 15–25 | tor niesie 9 A, więc 140 A to przesada. Trzeba znaleźć zacisk **D+/L** i sprawdzić, czy lampka kontrolna dalej działa — cewka bierze ~150 mA z jej obwodu |
+| Element | Dane | Cena (PLN) | Uwaga |
+|---------|------|-----------|-------|
+| **Przekaźnik 30 A SPDT** + podstawka | cewka z zapłonu, dioda 1N4007 równolegle | 15–25 | tor niesie 9 A, więc 30 A styków to spory zapas |
+| **MBR2545CT** — 25 A / 45 V, TO-220AB | dwie połówki 12,5 A ze wspólną katodą | 5–12 | **zewrzyj obie anody** — przy 9 A łącznie Vf spada do ~0,45 V. Radiator obowiązkowy (ok. 4,5 W). Blaszka jest katodą, więc izoluj ją od masy |
+
+> **Cewka z zapłonu ma jeden koszt.** Przy kluczyku w ON bez pracującego
+> silnika przekaźnik jest zwarty i boost ładuje bank **z akumulatora
+> rozruchowego**. Przy normalnym rozruchu to kilka sekund; przy dłuższym
+> staniu z kluczykiem — już nie. Jeśli chcesz to wyciąć, podepnij cewkę pod
+> **D+/L alternatora** zamiast pod zapłon: jeden przewód inaczej, a sygnał
+> znaczy wtedy „alternator ładuje". Sprawdź potem lampkę kontrolną — cewka
+> bierze ~150 mA z jej obwodu.
 
 ### 3.3 Prąd ładowania — policz go z obciążeniem
 
@@ -259,20 +371,21 @@ i przewiewu** — traktuj katalogowe 10 A jako wartość szczytową, nie robocz�
 
 ### 3.4 Ile pakietów
 
-**Pięć (25,5 Ah)** — tak jak w wersji docelowej, więc skrzynka, mocowanie
-i okablowanie nie będą do przerobienia po testach. Trzy wystarczą, jeśli
-w fazie testowej brakuje miejsca.
+**Pięć (25,5 Ah) to minimum, osiem jest wyraźnie lepsze.** Stałe zasilanie
+i S3 podniosły pobór postojowy z kilkudziesięciu miliamperów do kilkuset
+(§3.1a), więc pojemność zaczęła realnie decydować o tym, ile dni auto może
+postać. Trzy pakiety odpadają.
 
-| Pakiety | Pojemność | Praca przy zgaszonym silniku (3,5 A) | Postój przy 40 mA | Doładowanie z 50 % |
-|---------|-----------|--------------------------------------|-------------------|--------------------|
-| 3 | 15,3 Ah | ~2,2 h | ~8,0 dnia | ~3,1 h jazdy |
-| **5** | **25,5 Ah** | **~3,6 h** | **~13,3 dnia** | **~2,8 h jazdy** |
-| 8 | 40,8 Ah | ~5,8 h | ~21,3 dnia | ~3,1 h jazdy |
+| Pakiety | Pojemność | Praca przy zgaszonym silniku (3,5 A) | Postój w S3 (350 mA) | Doładowanie z 50 % |
+|---------|-----------|--------------------------------------|----------------------|--------------------|
+| 3 | 15,3 Ah | ~2,2 h | ~0,9 dnia | ~3,1 h jazdy |
+| **5** | **25,5 Ah** | **~3,6 h** | **~1,5 dnia** | **~2,8 h jazdy** |
+| 8 | 40,8 Ah | ~5,8 h | ~2,4 dnia | ~3,1 h jazdy |
 
-Wszystko liczone do 50 % DoD. Postój wypada dłużej niż w wersji docelowej,
-bo domena A jest pusta — jedynym odbiornikiem jest XH-M609. Przy jego
-poborze 20 mA czasy się podwajają, przy 125 mA (katalogowe maksimum) spadają
-ponad trzykrotnie — **dlatego to zmierz**.
+Wszystko liczone do 50 % DoD. Kolumna „postój" zakłada środek widełek
+z §3.1a — pełny rozrzut (240–480 mA) jest tam w osobnej tabeli. Skoro
+i tak masz osiem pakietów, **na czas testów wstaw wszystkie osiem**:
+kosztuje to tylko miejsce i trzy dodatkowe bezpieczniki, a podwaja zapas.
 
 > Krótkie przejazdy po mieście nie doładują banku po dłuższym postoju.
 > Kolumna „doładowanie" zakłada ciągłą jazdę z pracującym alternatorem.
@@ -286,7 +399,7 @@ ponad trzykrotnie — **dlatego to zmierz**.
 |-------|---------|-------|
 | **XL6019** | wyjście **19,5 V** pod obciążeniem | ustaw multimetrem, zabezpiecz potencjometr |
 | **XH-M609** | odcięcie **11,00 V**, powrót **12,60 V** | sprawdź, czy pracuje stabilnie przy 11 V |
-| **VSR** | zał. **13,3 V**, wył. **12,8 V** | zwykle fabryczne, sprawdź kartę |
+| **Przekaźnik ładowania** | cewka z zapłonu (albo D+) | dioda 1N4007 równolegle, katodą do „+” |
 | **CC-CV boost** | CV **14,40 V**, CC wg §3.3 | ustaw CV **bez obciążenia**, CC na sztucznym obciążeniu; nigdy poniżej napięcia wejściowego — §3.2 |
 | **Rozłącznik nadnapięciowy** | próg **15,30 V**, powrót **14,00 V** | test zasilaczem laboratoryjnym, nie „na aucie" |
 
@@ -297,28 +410,25 @@ Obowiązkowe sprawdzenia XL6019 i XH-M609 przed pierwszym załączeniem:
 > a M910q pod pełnym obciążeniem czterech wątków dobija do 55 W. Instrukcja:
 > [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) §3.5a.
 
-### 3.6 Wyłączanie — przekaźnik tnie twardo
+### 3.6 Wyłączanie — dopóki Arduino nie usypia, robisz to ręcznie
 
-Przekaźnik zapłonu odcina domenę B **natychmiast** po przekręceniu kluczyka.
-Jeśli w tym momencie system pisze na dysk, ryzykujesz uszkodzenie
-systemu plików — a przy budowie rozwojowej cykli zasilania są dziesiątki
-dziennie.
-
-Procedura na czas testów:
+Nic już nie tnie zasilania komputera, więc **nie ma ryzyka ucięcia zapisu
+na dysk** — to główny zysk z §3.1a. Dopóki jednak brakuje trzech elementów
+z tabeli w §3.1a, przejście do S3 wywołujesz sam:
 
 ```
 1. Zaparkuj.
 2. Przycisk zasilania M910q  →  S3  (acpid + bcm-power-toggle.sh, §7.3 WDROZENIE_M910Q)
-3. Dopiero teraz kluczyk OFF.
+3. Kluczyk OFF — zasilanie i tak zostaje, więc kolejność nie ma znaczenia.
+4. Dłuższy postój? Wyłącznik główny — inaczej S3 zjada bank (§3.1a).
 ```
 
-W S3 nic nie jest zapisywane, więc odcięcie zasilania jest wtedy nieszkodliwe
-— maszyna wystartuje zimno przy następnym ACC. Zapominalskim ext4 zwykle
-wybacza, ale nie liczyłbym na to w nieskończoność.
+Wybudzenie: przycisk zasilania albo dowolny klawisz z Pro Micro, o ile
+w BIOS-ie włączone jest **Wake on USB**. Wraca w ~3 s.
 
-Automatyczne, „grzeczne" wyłączanie na zaniku ACC wymagałoby przekaźnika
-z opóźnieniem plus sygnału ACC podanego do Pro Micro i zmian w firmware —
-poza zakresem tego wariantu.
+Zapomniany krok 2 nie jest groźny — maszyna po prostu pracuje dalej i szybciej
+zjada bank. Zapomniany krok 4 przy tygodniowym postoju kończy się odcięciem
+przez LVD.
 
 ---
 
@@ -330,38 +440,44 @@ Ceny orientacyjne, rynek PL, 2025/2026.
 
 | # | Element | Specyfikacja | Cena (PLN) |
 |---|---------|--------------|-----------|
-| 1 | **VSR** | Durite 0-727-11 albo bezmarkowy 12 V / 140 A — modele w §3.2a | 60–250 |
+| 1 | **Przekaźnik ładowania + dioda** | 30 A SPDT z podstawką + **MBR2545CT** — §3.2a | 20–37 |
 | 2 | **Moduł CC-CV boost** | „900 W 15 A" z wyświetlaczem albo SZBK07 — modele w §3.2a | 50–140 |
 | 3 | **Rozłącznik nadnapięciowy** | przekaźnik napięciowy programowalny (XY-WJ01 lub odpowiednik), próg 15,30 V | 40–80 |
-| 4 | **Przekaźnik zapłonu** | Bosch 12 V / 30 A SPDT + podstawka | 15–25 |
-| 5 | **Dioda 1N4007** | gaszeniowa, równolegle do cewki | 2–5 |
-| 6 | **Dioda TVS + kondensator** | 1.5KE33CA lub SMCJ26CA + 470 µF/35 V low-ESR | 10–20 |
+| 4 | **Dioda 1N4007** | gaszeniowa, równolegle do cewki przekaźnika | 2–5 |
+| 5 | **Dioda TVS + kondensator** | 1.5KE33CA lub SMCJ26CA + 470 µF/35 V low-ESR | 10–20 |
+| 6 | **LM2596 12 → 5 V** | zasilanie podświetlenia panelu — §3.1b | 5–10 |
 | 7 | **Radiator + wentylator 40 mm** | do XL6019 — w aucie obowiązkowy | 20–35 |
-| 8 | **Kondensator wyjściowy** | 470 µF/35 V low-ESR na wyjście XL6019 | 3–6 |
-| | | **Podsuma** | **200–561** |
+| 8 | **Radiator do MBR2545CT** | ok. 4,5 W ciągłej straty + podkładka izolacyjna | 5–15 |
+| 9 | **Kondensator wyjściowy** | 470 µF/35 V low-ESR na wyjście XL6019 | 3–6 |
+| | | **Podsuma** | **155–348** |
+
+> **Przekaźnika zapłonu do odbiorników już nie ma** — M910q jest zasilany
+> stale, a zapłon jest tylko sygnałem dla Arduino (§3.1a). Jedyny przekaźnik
+> w tym wariancie siedzi w torze ładowania.
 
 ### 4.2 Bezpieczniki i okablowanie — obowiązkowe
 
 | # | Element | Specyfikacja | Cena (PLN) |
 |---|---------|--------------|-----------|
-| 9 | Bezpiecznik **15 A** + oprawka przy klemie „+" | zasilanie ładowarki | 15–25 |
-| 10 | Bezpieczniki inline **10 A × 5** + oprawki | po jednym na pakiet | 25–40 |
-| 11 | Bezpiecznik inline **15 A** + oprawka | przed VIN+ modułu XH-M609 | 8–12 |
-| 12 | Bezpiecznik **7,5 A** + oprawka | odgałęzienie do XL6019 (strona 12 V) — §3.1 | 8–12 |
-| 13 | Przewód **2,5 mm²** | FLRY, czerwony 5 m + czarny 3 m | 40–60 |
-| 14 | Przewód **1,5 mm²** | FLRY, czerwony + czarny po 3 m | 15–25 |
-| 15 | Przewód **0,75 mm²** | FLRY, kilka kolorów po 2 m (ACC, sterowanie) | 15–25 |
-| 16 | Nasuwki **F2 6,35 mm** izolowane | do zacisków HR1221W, komplet | 15–25 |
-| 17 | Konektory oczkowe, tulejki, koszulki | zestaw, koszulki z klejem | 30–50 |
-| 18 | **Rozłącznik masy** | 100 A — na czas montażu i dłuższego postoju | 40–70 |
-| 19 | Skrzynka / wspornik na bank + pasy | na 5 pakietów, mocowanie do nadwozia | 60–120 |
-| 20 | Peszel + przelotki gumowe | przejścia przez blachę | 25–40 |
-| | | **Podsuma** | **296–504** |
+| 10 | Bezpiecznik **15 A** + oprawka przy klemie „+” | zasilanie ładowarki | 15–25 |
+| 11 | Bezpieczniki inline **10 A × 5** + oprawki | po jednym na pakiet | 25–40 |
+| 12 | Bezpiecznik inline **15 A** + oprawka | przed VIN+ modułu XH-M609 | 8–12 |
+| 13 | Bezpiecznik **7,5 A** + oprawka | odgałęzienie do XL6019 (strona 12 V) — §3.1 | 8–12 |
+| 14 | Bezpiecznik **2 A** + oprawka | odgałęzienie do LM2596 (podświetlenie) — §3.1b | 8–12 |
+| 15 | Przewód **2,5 mm²** | FLRY, czerwony 5 m + czarny 3 m | 40–60 |
+| 16 | Przewód **1,5 mm²** | FLRY, czerwony + czarny po 3 m | 15–25 |
+| 17 | Przewód **0,75 mm²** | FLRY, kilka kolorów po 2 m (sygnał zapłonu, sterowanie) | 15–25 |
+| 18 | Nasuwki **F2 6,35 mm** izolowane | do zacisków HR1221W, komplet | 15–25 |
+| 19 | Konektory oczkowe, tulejki, koszulki | zestaw, koszulki z klejem | 30–50 |
+| 20 | **Rozłącznik masy** | 100 A — obowiązkowy, jedyne realne zero poboru (§3.1a) | 40–70 |
+| 21 | Skrzynka / wspornik na bank + pasy | na 5 pakietów, mocowanie do nadwozia | 60–120 |
+| 22 | Peszel + przelotki gumowe | przejścia przez blachę | 25–40 |
+| | | **Podsuma** | **304–516** |
 
-**Razem obowiązkowo: ~496–1065 PLN.** Dolny kraniec to bezmarkowy VSR
-i moduł „600 W" na potencjometrach, górny — Victron Cyrix i boost
-z wyświetlaczem. Przy pierwszej instalacji warto dopłacić przynajmniej
-za moduł CC-CV z odczytem cyfrowym.
+**Razem obowiązkowo: ~459–864 PLN.** Dolny kraniec to moduł „600 W"
+na potencjometrach, górny — boost z wyświetlaczem i droższe okablowanie.
+Przy pierwszej instalacji warto dopłacić przynajmniej za moduł CC-CV
+z odczytem cyfrowym.
 
 > **Przekrój 2,5 mm² zamiast 6 mm²** jest tu policzony pod ten wariant:
 > 8 A ładowania to ok. 9 A po stronie wejścia, a bezpiecznik 15 A chroni
@@ -372,19 +488,19 @@ za moduł CC-CV z odczytem cyfrowym.
 
 | # | Element | Kiedy potrzebne | Cena (PLN) |
 |---|---------|----------------|-----------|
-| 21 | **Arduino Pro Micro** (ATmega32U4) | jeśli nie masz — pody SWC bez niego nie zadziałają | 40–60 |
-| 22 | **Wtyk zasilania do M910q** | najtaniej: odetnij kabel od oryginalnego zasilacza (koszt 0) | 0–40 |
-| 23 | **Przejściówka DP → HDMI** | tylko jeśli Twój egzemplarz M910q ma wyjścia DisplayPort — sprawdź (§5.2) | 0–25 |
-| 24 | **Drugi kabel USB do panelu** | jeśli panel przyszedł z rozgałęzieniem na dwa wtyki — §3.1 | 0–15 |
-| 25 | **Zaciskarka zapadkowa** | zaciski robione kombinerkami to najczęstsza usterka instalacji | 0–150 |
-| 26 | **Ładowarka sieciowa AGM** | doładowanie w garażu przy krótkich przejazdach | 0–250 |
+| 23 | **Arduino Pro Micro** (ATmega32U4) | jeśli nie masz — pody SWC bez niego nie zadziałają | 40–60 |
+| 24 | **Wtyk zasilania do M910q** | najtaniej: odetnij kabel od oryginalnego zasilacza (koszt 0) | 0–40 |
+| 25 | **Przejściówka DP → HDMI** | tylko jeśli Twój egzemplarz M910q ma wyjścia DisplayPort — sprawdź (§5.2) | 0–25 |
+| 26 | **MP1584 12 → 5 V** | zapas pod przyszłą domenę A (Nano, HM-10, RXB6); w tym wariancie nieużywany | 0–15 |
+| 27 | **Zaciskarka zapadkowa** | zaciski robione kombinerkami to najczęstsza usterka instalacji | 0–150 |
+| 28 | **Ładowarka sieciowa AGM** | doładowanie w garażu przy krótkich przejazdach | 0–250 |
 
 ### 4.4 Warto, ale nie na start
 
 | # | Element | Po co | Cena (PLN) |
 |---|---------|-------|-----------|
-| 27 | Woltomierz/amperomierz panelowy z bocznikiem | podgląd banku i prądu ładowania bez multimetru | 40–70 |
-| 28 | Multimetr z pomiarem prądu DC 10 A | pomiar poboru XH-M609 i prądu ładowania | 80–200 |
+| 29 | Woltomierz/amperomierz panelowy z bocznikiem | podgląd banku i prądu ładowania bez multimetru | 40–70 |
+| 30 | Multimetr z pomiarem prądu DC 10 A | pomiar poboru XH-M609 w S3 i prądu ładowania | 80–200 |
 
 ### 4.5 Czego **nie** kupuj na tym etapie
 
@@ -583,15 +699,18 @@ Pełna procedura siedmioetapowa (z pomiarami na każdym kroku):
 [ ] Panel nie miga i nie restartuje się przy jasnym obrazie (budżet USB)
 [ ] Po 30 min pracy XL6019 nie parzy w dotyku
 [ ] XH-M609 odcina przy 11,00 V (test zasilaczem, nie rozładowywaniem banku)
-[ ] Kluczyk OFF → domena B zanika w całości (pomiar na wyjściu przekaźnika)
-[ ] Pobór z banku przy kluczyku OFF = pobór własny XH-M609 — ZMIERZ i zapisz
+[ ] Porty USB mają zasilanie przy M910q w S3 (inaczej Arduino nie wybudzi — §3.1a)
+[ ] Pobór z banku przy M910q w S3 — ZMIERZ i zapisz; od tej liczby zależy,
+    ile dni auto może postać (§3.1a)
 ```
 
 **Zasilanie — ładowanie**
 
 ```
-[ ] Silnik zgaszony → VSR rozwarty, zerowy prąd z akumulatora rozruchowego
-[ ] Silnik pracuje → VSR zwiera się w ciągu kilku sekund
+[ ] Kluczyk OFF → przekaźnik ładowania rozwarty, zerowy prąd z akumulatora
+    rozruchowego
+[ ] Kluczyk ON → przekaźnik zwiera się, prąd ładowania rusza
+[ ] Dioda MBR2545CT po 30 min jazdy ciepła, ale nie parząca (radiator)
 [ ] Prąd wyjściowy boostu nie przekracza nastawy CC (§3.3)
 [ ] Napięcie na banku po godzinie jazdy w przedziale 14,35–14,45 V
 [ ] Prąd ładowania spada w miarę ładowania (dowód, że moduł REGULUJE,
@@ -600,8 +719,9 @@ Pełna procedura siedmioetapowa (z pomiarami na każdym kroku):
 [ ] Moduł boost po 30 min jazdy w granicach temperatury (radiator, przewiew)
 ```
 
-Wynik pomiaru poboru XH-M609 zapisz — od niego zależy, czy na dłuższy postój
-wystarczy 5 pakietów, czy trzeba dołożyć pozostałe trzy (§3.4).
+Pomiar poboru w S3 jest tu ważniejszy niż cokolwiek innego na tej liście —
+decyduje, czy zestaw przeżyje weekendowy postój, czy trzeba będzie za każdym
+razem pamiętać o wyłączniku głównym (§3.1a).
 
 ---
 
@@ -609,10 +729,11 @@ wystarczy 5 pakietów, czy trzeba dołożyć pozostałe trzy (§3.4).
 
 | Nie ma | Wróci przy |
 |--------|-----------|
-| Domeny A (Nano ×2, HM-10, RXB6, przekaźniki) | dokupieniu płytek + buck 12 → 5 V |
+| Domeny A (Nano ×2, HM-10, RXB6, przekaźniki) | dokupieniu płytek + MP1584 12 → 5 V |
 | Kompensacji temperaturowej ładowania | ładowarce B2B (wariant A, §5.2 `ZASILANIE_BUFOROWANE.md`) |
-| Modułu `power` w BCM | wejściu zapłonu, którego x86 nie ma — §1 |
-| Regulacji jasności (PWM podświetlenia) | Nano #1 + osobne zasilanie podświetlenia — §3.1 |
+| Automatycznego S3 na zapłon | wejściu zapłonu w Pro Micro + hakowi po stronie hosta — §3.1a |
+| Eskalacji S3 → pełne wyłączenie po kilku godzinach | temu samemu firmware'owi co wyżej — §3.1a |
+| Regulacji jasności z BCM | instancji `BrightnessController` **i** Nano #1 — §3.1c |
 | Drugiego ekranu | panelu 6,86" — hot-plug, ale **nie na USB M910q**: dwa panele nie zmieszczą się w zapasie XL6019 (§3.1) |
 | OBD / K-Line | CP2102 + L9637D |
 | Kamer, parkowania, czujników | grabera, HC-SR04, DS18B20, obu Nano |
@@ -633,11 +754,11 @@ i weryfikowalny osobno:
 | 3 | DAC USB ES9038Q2M | bez zmian — zmiana domyślnego sinka PipeWire |
 | 4 | CP2102 + L9637D | `obd`, `obd.use_real_hardware: true` |
 | 5 | Nano #2 (sensor hub) | `environment`, `rain_sensor`, `blinker_monitor` |
-| 6 | Nano #1 + przekaźniki + buck domeny A | `central_lock`, `lighting` — wtedy też **PWM podświetlenia i osobne zasilanie paneli** |
+| 6 | Nano #1 + przekaźniki + MP1584 domeny A | `central_lock`, `lighting` — wtedy dopina się też **regulacja jasności** z §3.1c |
 | 7 | kamery + graber | `camera`, `crash_detect` |
 | 8 | GPS | `location`, `tracking` |
 | 9 | ekran 6,86" | `small_display` (hotplug — wystarczy wpiąć) |
-| 10 | ładowarka B2B zamiast VSR + boost | bez zmian w configu — absorpcja 14,4 V, próg 15,30 V, przewód 6 mm² |
+| 10 | ładowarka B2B zamiast przekaźnika + boostu | bez zmian w configu — absorpcja 14,4 V z kompensacją, przewód 6 mm² |
 
 Po każdym kroku przełóż odpowiedni klucz z `bcm_config_test.yaml` albo
 przejdź na `bcm_config.yaml`, gdy większość będzie już podłączona.

--- a/docs/WDROZENIE_TESTOWE.md
+++ b/docs/WDROZENIE_TESTOWE.md
@@ -176,6 +176,12 @@ Cena też jest realna — i to jest najważniejsza liczba w tej zmianie:
 | 5 (25,5 Ah) | ~2,2 dnia | ~1,5 dnia | ~1,1 dnia |
 | 8 (40,8 Ah) | ~3,5 dnia | ~2,4 dnia | ~1,8 dnia |
 
+Po **twardym wyłączeniu** (a nie S3) zostaje sam pobór przetwornic i LVD,
+czyli ~80–120 mA — wtedy 5 pakietów daje **4,4–5,3 dnia**, a 8 pakietów
+**7,1–8,5 dnia**. Dlatego eskalacja z S3 do pełnego wyłączenia po kilku
+godzinach jest tu naprawdę warta zachodu — a przy sterowaniu przyciskiem
+zasilania kosztuje tyle, co dłuższy impuls.
+
 Wszystko do 50 % DoD. Dla porównania: przy twardym odcięciu domeny B
 wychodziło **~13 dni**. Utrata jest sześciokrotna i wynika wprost z tego,
 że S3 to nie jest zero.
@@ -188,30 +194,63 @@ Co z tym zrobić:
   naprawdę zeruje pobór, i dlatego został na liście jako obowiązkowy.
 - **XH-M609 jest siatką bezpieczeństwa**, nie planem: odetnie przy 11,00 V,
   więc bank przeżyje, ale wrócisz do wyłączonego zestawu.
-- Docelowo Arduino może po kilku godzinach eskalować z S3 do pełnego
-  wyłączenia — wymaga firmware'u i haka po stronie hosta, patrz niżej.
+- **Eskalacja S3 → pełne wyłączenie** po 2 h postoju: przy sterowaniu
+  przyciskiem zasilania to jedna linijka firmware'u (impuls 5 s zamiast
+  250 ms), a powrót to znowu krótki impuls. Patrz niżej.
 
-#### Czego brakuje w kodzie, żeby to zadziałało
+#### Jak to zrobić najmniejszym kosztem — przez fizyczny przycisk zasilania
 
-Sprzętowo ścieżka jest gotowa, software'owo **nie**. Trzy elementy do
-dorobienia — warto wiedzieć, zanim to zaplanujesz:
+![Wykrywanie zapłonu i sterowanie przyciskiem](../schematics/ignition_sense.svg)
 
-| # | Brakuje | Gdzie |
-|---|---------|-------|
-| 1 | Wejście zapłonu w Pro Micro | wolny jest tylko **D0 (RXI)** — reszta pinów zajęta (enkoder, 5 przycisków, 2 pody SWC, panel muzyczny, LDR, przycisk dźwigni). Sygnał 12 V **musi** iść przez optoizolator albo dzielnik — nie wprost na pin 5 V |
-| 2 | Reakcja hosta na sygnał | `PowerManager` na `hal.ignition = false` przechodzi tylko do STANDBY i **gasi podświetlenie — nie usypia maszyny**. Uśpienie robi `bcm-power-toggle.sh` przez acpid. Ktoś musi połączyć jedno z drugim |
-| 3 | Nic nie publikuje `hal.ignition` na x86 | na OPi robił to `bcm-ignition-watcher` po GPIO; na M910q tego wejścia nie ma |
+Przycisk zasilania M910q to zwykły **przycisk chwilowy zwierny**, a Linux ma
+na nim już zbudowaną całą potrzebną logikę:
 
-Wybudzanie **nie wymaga kodu**: dowolne naciśnięcie klawisza po USB HID budzi
-maszynę z S3, o ile w BIOS-ie włączone jest **Wake on USB** (§6.2
-[`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md)). Pro Micro jest klawiaturą HID,
-więc to działa od ręki.
+| Stan maszyny | Krótkie wciśnięcie |
+|--------------|--------------------|
+| praca | acpid → `bcm-power-toggle.sh` → **S3** |
+| S3 | **wybudzenie** w ~3 s |
+| wyłączona | **start** |
+| dowolny, przytrzymanie > 4 s | twarde wyłączenie |
 
-> **Sprawdź, czy porty USB mają zasilanie w S3.** Jeżeli M910q odcina je
-> w uśpieniu, Arduino umiera razem z komputerem i **nie ma go czym wybudzić**
-> — zestaw zostaje w S3 do rozładowania banku. To pierwsza rzecz do
-> zmierzenia, przed jakimkolwiek firmware'em. Ratunek awaryjny: przycisk
-> zasilania M910q.
+Czyli **jeden impuls obsługuje oba kierunki**. Wystarczy, żeby Arduino umiało
+ten przycisk „nacisnąć" — styki **modułu przekaźnika 1-kanałowego wpięte
+równolegle** do przycisku, sterowane impulsem 250 ms z pinu **A2**.
+
+Co to daje w porównaniu z wysyłaniem klawiszy HID i osobnym hakiem na hoście:
+
+| | |
+|---|---|
+| ✅ | **zero zmian po stronie hosta** — `acpid` + `bcm-power-toggle.sh` już są skonfigurowane (§7.3 [`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md), `HandlePowerKey=ignore` w `logind.conf`) |
+| ✅ | wybudzanie **nie zależy od „Wake on USB"** — przycisk zasilania działa zawsze, także po twardym wyłączeniu |
+| ✅ | eskalacja S3 → pełne wyłączenie po kilku godzinach to po prostu **dłuższy impuls** (5 s), a powrót — znowu krótki |
+| ⚠️ | układ jest **otwarty**: Arduino nie wie, czy maszyna śpi. Pulsujemy na *zmianę* stanu zapłonu, więc rozjazd wymaga zdarzenia z zewnątrz i naprawia się przy następnym cyklu kluczyka |
+
+Domknięcie pętli, jeśli kiedyś zacznie przeszkadzać: wejście z **diody
+zasilania panelu przedniego** (świeci = praca, miga = S3). Jeden przewód
+więcej, za to stan czytany zamiast zakładanego.
+
+**Zostaje jedna rzecz do dorobienia — firmware Pro Micro:**
+
+| Element | Szczegóły |
+|---------|-----------|
+| Wejście zapłonu na **D0 (RXI)** | jedyny fizycznie wolny pin. Sygnał 12 V **musi** iść przez optoizolator PC817 — nie wprost na pin 5 V |
+| Wyjście na przekaźnik na **A2** | pin jest zajęty przez przycisk dźwigni „brightness cycle”, ale ta funkcja **i tak dziś nic nie robi** (§3.1c), więc jest wolny w praktyce |
+| Debounce zapłonu 2 s + impuls 250 ms / 5 s | żeby migotanie na linii ACC nie usypiało maszyny w kółko |
+
+`modules.power` zostaje wyłączony i nie ma to znaczenia: `PowerManager`
+w stanie STANDBY gasi podświetlenie, a nie usypia maszynę — uśpienie robi
+acpid, poza BCM.
+
+> **Pro Micro musi mieć własne 5 V.** Jeżeli wisi na USB M910q, a ten odcina
+> zasilanie portów w S3 — Arduino gaśnie razem z komputerem i nie ma czym
+> nacisnąć przycisku. Zasil je z **MP1584** z bufora i **przetnij żyłę VBUS
+> w kablu USB** (albo użyj kabla data-only): dwa źródła 5 V zwarte razem to
+> proszenie się o kłopoty. Dane po USB zostają.
+
+> **Zanim cokolwiek zlutujesz — zmierz przycisk.** Miernik w tryb ciągłości,
+> maszyna odłączona od zasilania: zaciski mają być rozwarte, a przy wciśnięciu
+> zwarte. To potwierdza, że to zwykły przycisk chwilowy, i pokazuje, gdzie
+> wpiąć styki przekaźnika.
 
 ### 3.1b Podświetlenie panelu — osobne zasilanie
 
@@ -455,10 +494,12 @@ Ceny orientacyjne, rynek PL, 2025/2026.
 | 4 | **Dioda 1N4007** | gaszeniowa, równolegle do cewki przekaźnika | 2–5 |
 | 5 | **Dioda TVS + kondensator** | 1.5KE33CA lub SMCJ26CA + 470 µF/35 V low-ESR | 10–20 |
 | 6 | **LM2596 12 → 5 V** | zasilanie podświetlenia panelu — §3.1b | 5–10 |
+| 6a | **MP1584 12 → 5 V** | zasilanie Pro Micro niezależne od USB — §3.1a | 5–15 |
+| 6b | **Moduł przekaźnika 1-kanałowy 5 V** | styki równolegle do przycisku zasilania M910q — §3.1a | 5–12 |
 | 7 | **Radiator + wentylator 40 mm** | do XL6019 — w aucie obowiązkowy | 20–35 |
 | 8 | **Radiator do MBR2545CT** | ok. 4,5 W ciągłej straty + podkładka izolacyjna | 5–15 |
 | 9 | **Kondensator wyjściowy** | 470 µF/35 V low-ESR na wyjście XL6019 | 3–6 |
-| | | **Podsuma** | **155–348** |
+| | | **Podsuma** | **165–375** |
 
 > **Przekaźnika zapłonu do odbiorników już nie ma** — M910q jest zasilany
 > stale, a zapłon jest tylko sygnałem dla Arduino (§3.1a). Jedyny przekaźnik
@@ -483,7 +524,7 @@ Ceny orientacyjne, rynek PL, 2025/2026.
 | 22 | Peszel + przelotki gumowe | przejścia przez blachę | 25–40 |
 | | | **Podsuma** | **304–516** |
 
-**Razem obowiązkowo: ~459–864 PLN.** Dolny kraniec to moduł „600 W"
+**Razem obowiązkowo: ~469–891 PLN.** Dolny kraniec to moduł „600 W"
 na potencjometrach, górny — boost z wyświetlaczem i droższe okablowanie.
 Przy pierwszej instalacji warto dopłacić przynajmniej za moduł CC-CV
 z odczytem cyfrowym.
@@ -500,7 +541,7 @@ z odczytem cyfrowym.
 | 23 | **Arduino Pro Micro** (ATmega32U4) | jeśli nie masz — pody SWC bez niego nie zadziałają | 40–60 |
 | 24 | **Wtyk zasilania do M910q** | najtaniej: odetnij kabel od oryginalnego zasilacza (koszt 0) | 0–40 |
 | 25 | **Przejściówka DP → HDMI** | tylko jeśli Twój egzemplarz M910q ma wyjścia DisplayPort — sprawdź (§5.2) | 0–25 |
-| 26 | **MP1584 12 → 5 V** | zapas pod przyszłą domenę A (Nano, HM-10, RXB6); w tym wariancie nieużywany | 0–15 |
+| 26 | **Kabel USB bez żyły VBUS** | do Pro Micro — albo przetnij czerwoną żyłę w zwykłym, koszt 0 | 0–20 |
 | 27 | **Zaciskarka zapadkowa** | zaciski robione kombinerkami to najczęstsza usterka instalacji | 0–150 |
 | 28 | **Ładowarka sieciowa AGM** | doładowanie w garażu przy krótkich przejazdach | 0–250 |
 
@@ -708,7 +749,9 @@ Pełna procedura siedmioetapowa (z pomiarami na każdym kroku):
 [ ] Panel nie miga i nie restartuje się przy jasnym obrazie (budżet USB)
 [ ] Po 30 min pracy XL6019 nie parzy w dotyku
 [ ] XH-M609 odcina przy 11,00 V (test zasilaczem, nie rozładowywaniem banku)
-[ ] Porty USB mają zasilanie przy M910q w S3 (inaczej Arduino nie wybudzi — §3.1a)
+[ ] Pro Micro pracuje przy M910q w S3 (zasilany z MP1584, nie z USB — §3.1a)
+[ ] Impuls 250 ms z A2 usypia maszynę, kolejny ją budzi
+[ ] Impuls 5 s wyłącza twardo, krótki startuje z powrotem
 [ ] Pobór z banku przy M910q w S3 — ZMIERZ i zapisz; od tej liczby zależy,
     ile dni auto może postać (§3.1a)
 ```
@@ -741,7 +784,7 @@ razem pamiętać o wyłączniku głównym (§3.1a).
 | Domeny A (Nano ×2, HM-10, RXB6, przekaźniki) | dokupieniu płytek + MP1584 12 → 5 V |
 | Kompensacji temperaturowej ładowania | ładowarce B2B (wariant A, §5.2 `ZASILANIE_BUFOROWANE.md`) |
 | Automatycznego S3 na zapłon | wejściu zapłonu w Pro Micro + hakowi po stronie hosta — §3.1a |
-| Eskalacji S3 → pełne wyłączenie po kilku godzinach | temu samemu firmware'owi co wyżej — §3.1a |
+| Sprzężenia zwrotnego o stanie maszyny | wejściu z diody zasilania panelu przedniego — §3.1a |
 | Regulacji jasności z BCM | instancji `BrightnessController` **i** Nano #1 — §3.1c |
 | Drugiego ekranu | panelu 6,86" — hot-plug, ale **nie na USB M910q**: dwa panele nie zmieszczą się w zapasie XL6019 (§3.1) |
 | OBD / K-Line | CP2102 + L9637D |

--- a/docs/ZASILANIE_BUFOROWANE.md
+++ b/docs/ZASILANIE_BUFOROWANE.md
@@ -2,7 +2,7 @@
 
 Kompletny opis układu zasilania head unitu BCM v8.5: bufor z akumulatorów
 CSB HR1221W (AGM), ładowanie, blokada przeładowania, ochrona przed głębokim
-rozładowaniem, podział na domeny i przetwornica step-up do 19 V.
+rozładowaniem, sterowanie stanem komputera i przetwornica step-up do 19 V.
 
 **Schematy blokowe:** [`../schematics/power_buffered_m910q.svg`](../schematics/power_buffered_m910q.svg) ·
 [`../schematics/charging_lvd.svg`](../schematics/charging_lvd.svg) ·
@@ -17,7 +17,7 @@ rozładowaniem, podział na domeny i przetwornica step-up do 19 V.
 ## Spis treści
 
 1. [Po co bufor](#1-po-co-bufor)
-2. [Architektura — dwie domeny](#2-architektura--dwie-domeny)
+2. [Architektura — jedna szyna, trzy stany maszyny](#2-architektura--jedna-szyna-trzy-stany-maszyny)
 3. [Przetwornica step-up XL6019 — weryfikacja](#3-przetwornica-step-up-xl6019--weryfikacja)
 4. [Bank akumulatorów CSB HR1221W](#4-bank-akumulatorów-csb-hr1221w)
 5. [Ładowanie — dwa warianty](#5-ładowanie--dwa-warianty)
@@ -48,38 +48,53 @@ zawsze odpali, choćby bank był pusty.
 
 ---
 
-## 2. Architektura — dwie domeny
+## 2. Architektura — jedna szyna, trzy stany maszyny
 
-![Domeny A/B](../schematics/power_domains_m910q.svg)
+![Rozdział zasilania](../schematics/power_domains_m910q.svg)
 
-| | **Domena A — zawsze zasilana** | **Domena B — za zapłonem** |
+Wszystko wisi na **jednej szynie buforowanej** za LVD i wyłącznikiem
+głównym. Zapłon nie odcina już żadnego odbiornika — jest wyłącznie
+**sygnałem**, który Arduino zamienia na „naciśnięcie" przycisku zasilania
+M910q.
+
+| | |
+|---|---|
+| **Odbiorniki stale zasilane** | M910q, hub USB, oba wyświetlacze, Arduino Pro Micro, Nano #1, Nano #2, HM-10 BLE, RXB6 433 MHz, moduł 9 przekaźników, DAC USB, graber AHD |
+| **Jedyny przekaźnik w torze mocy** | w **ładowaniu**, nie w odbiornikach — rozłącza bank od instalacji auta przy zgaszonym silniku (§5.3c) |
+| **Rola zapłonu** | sygnał do Arduino → impuls na styki przycisku zasilania → S3 albo wybudzenie |
+
+### 2.1 Trzy stany i trzy poziomy poboru
+
+| Stan | Co pobiera | Pobór z banku | 5 pakietów | 8 pakietów |
+|------|-----------|---------------|-----------|-----------|
+| **Praca** | wszystko | 10–55 W | — | — |
+| **S3** | logika + M910q w S3 + straty przetwornic | **400–550 mA** | ~1,2 dnia | ~1,9 dnia |
+| **Wyłączony** (impuls 5 s) | logika + straty przetwornic | **100–200 mA** | ~3,5–5,3 dnia | ~5,7–8,5 dnia |
+
+Wszystko do 50 % DoD. Wniosek jest praktyczny: **S3 do krótkich postojów,
+twarde wyłączenie do długich**. Arduino przełącza między nimi samo — po
+2 godzinach zgaszonego zapłonu daje dłuższy impuls i maszyna gaśnie
+całkowicie. Powrót to znowu krótki impuls.
+
+### 2.2 Dlaczego nie przekaźnik odcinający komputer
+
+Wcześniejsze wydanie tej dokumentacji odcinało M910q i wyświetlacze
+przekaźnikiem zapłonu („domena B"). Model został **porzucony** — oto
+dlaczego:
+
+| | Przekaźnik odcinający | Stałe zasilanie + S3 |
 |---|---|---|
-| **Źródło** | szyna buforowana (bank AGM) | szyna buforowana przez przekaźnik ACC |
-| **Odbiorniki** | Arduino Nano #1 (output controller), Arduino Nano #2 (sensor hub), HM-10 BLE, RXB6 433 MHz, moduł 9 przekaźników | M910q, hub USB, oba wyświetlacze, Arduino Pro Micro, DAC USB, graber AHD |
-| **Pobór spoczynkowy** | ~60 mA (0,7 W) | 0 mA — przekaźnik rozwarty |
-| **Pobór w pracy** | ~60 mA + chwilowe załączenia cewek | ~10 W typowo, do ~55 W w szczycie |
-| **Na postoju** | działa — nasłuchuje pilota i BLE | całkowicie odcięta |
+| Postój (5 pakietów) | ~6,6 dnia | ~1,2 dnia w S3, ~3,5–5,3 po wyłączeniu |
+| Wybudzenie | zimny start ~40 s | **~3 s** z S3 |
+| Ryzyko ucięcia zapisu na dysk | **przy każdym przekręceniu kluczyka** | brak — maszyna schodzi do S3 sama |
+| Elementy w torze mocy | przekaźnik 30 A + okablowanie | **brak** |
+| Kod / firmware | brak | impuls z Arduino, po stronie hosta zero zmian |
 
-**Dlaczego przekaźnik, a nie S3.** M910q obsługuje natywne S3 (~0,2 A przy
-12 V ≈ 2,4 W), ale to i tak **czterdzieści razy więcej** niż cała domena A.
-Przekaźnik rozwiera obwód fizycznie: zero poboru huba USB, zero upływów
-przetwornic, zero ryzyka, że coś obudzi maszynę na parkingu. BCM budzi się
-zimnym startem na ACC — startuje w ~15 s, co przy samochodzie jest
-akceptowalne.
-
-> **Wariant testowy robi to odwrotnie — świadomie.**
-> [`WDROZENIE_TESTOWE.md`](WDROZENIE_TESTOWE.md) §3.1a rezygnuje z domeny B:
-> M910q wisi na buforze na stałe, zapłon jest tylko sygnałem do Arduino,
-> a maszyna schodzi do S3 i z niego wraca. Kupuje to wybudzenie w ~3 s
-> zamiast zimnego startu i zerowe ryzyko ucięcia zapisu na dysk — kosztem
-> poboru postojowego, który rośnie z ~60 mA do 240–480 mA, czyli z ~13 dni
-> postoju do ~1,5–2,5 dnia.
->
-> Która wersja jest właściwa, zależy od tego, jak często auto jeździ.
-> Wersja docelowa zostaje przy przekaźniku, bo z domeną A na pokładzie
-> (nasłuch pilota i BLE) i tak musi wytrzymać długi postój. Gdy Nano #2
-> zacznie publikować `hal.ignition`, przejście na model z S3 będzie możliwe
-> także tutaj — decyzja stanie się wtedy czysto energetyczna.
+Twarde odcięcie zasilania pracującemu Linuksowi kilka razy dziennie to
+proszenie się o uszkodzenie systemu plików, a różnica w czasie postoju
+znika, gdy tylko dołożymy eskalację do pełnego wyłączenia. Realizacja
+i pomiary: [`../schematics/ignition_sense.svg`](../schematics/ignition_sense.svg)
+oraz [`WDROZENIE_TESTOWE.md`](WDROZENIE_TESTOWE.md) §3.1a.
 
 **Dlaczego wyświetlacze mają własny buck, a nie USB.** Same panele
 spokojnie zasiliłyby się z portów USB M910q — i tak właśnie robi wariant
@@ -92,7 +107,8 @@ wpiąć w zasilanie logiki panelu idące po USB. Drugi powód jest energetyczny
 **Wzmacniacz idzie osobną gałęzią** prosto z akumulatora rozruchowego —
 gotowy moduł samochodowy, podłączany jak radio: własny bezpiecznik przy klemie
 (wg karty modułu, zwykle 20–30 A), przewód 6 mm², **własna masa lokalna**
-i wyzwalanie sygnałem REM z domeny B.
+i wyzwalanie sygnałem **REM wprost z linii zapłonu** — wzmacniacz ma grać,
+gdy jedziesz, a nie gdy komputer jest w S3.
 
 Powód: 4 × 50 W RMS to w szczytach 20–30 A. Taki prąd rozłożyłby bank AGM
 w kilkanaście minut i przekroczyłby przekaźnik LVD (20 A). Z systemem
@@ -183,7 +199,9 @@ ale też się nie uszkodzi.
 
 Praktyczna konsekwencja: **wyjścia XL6019 nie da się użyć jako wyłącznika
 komputera**. Odcinać musi przekaźnik zapłonu po stronie wejścia — i dokładnie
-tak jest w tym projekcie (§2, domena B).
+tak było w poprzednim modelu. Dziś M910q jest zasilany stale, a wyłącza go
+impuls na przycisk zasilania (§2.1) — wyjście XL6019 i tak nie służy do
+odcinania.
 
 ### 3.2b Prąd rozruchowy
 
@@ -299,7 +317,7 @@ Przetwornica przy 65 W i sprawności 88 % rozprasza ~9 W. W zamkniętej
 zabudowie za deską rozdzielczą, latem, to wystarczy do przegrzania.
 
 - radiator na układzie scalonym i na cewce, klej termoprzewodzący,
-- wentylator 40 mm zasilany z domeny B (5 V albo 12 V),
+- wentylator 40 mm zasilany z szyny buforowanej (5 V albo 12 V),
 - montaż na blasze albo profilu aluminiowym pełniącym rolę radiatora,
 - **nie** montuj płytki bezpośrednio na tapicerce ani wykładzinie.
 
@@ -781,12 +799,12 @@ z zaleceniem producenta modułu).
 
 ### 7.5 Co odcina LVD
 
-Całą szynę — obie domeny. Domena A też przestaje działać (pilot szyb i BLE
+Całą szynę buforowaną. Logika też przestaje działać (pilot szyb i BLE
 bagażnika nie odpowiadają), ale to celowe: bank przetrwa i naładuje się przy
 następnym uruchomieniu silnika. Alternatywa — pozwolić Nano dojechać bank
 do 9 V — kończy się wymianą kompletu pakietów.
 
-Moduł montuj **za bankiem, przed rozgałęzieniem domen** — patrz
+Moduł montuj **za bankiem, przed rozgałęzieniem odbiorników** — patrz
 [`power_buffered_m910q.svg`](../schematics/power_buffered_m910q.svg).
 
 > **XH-M609 nie zastąpi blokady przeładowania z §6.** To moduł ochrony
@@ -804,8 +822,8 @@ Moduł montuj **za bankiem, przed rozgałęzieniem domen** — patrz
 | Główny | 30 A | **maks. 30 cm od klemy „+"** akumulatora rozruchowego |
 | Na pakiet banku | 10 A × 5 | na zacisku F2 „+" każdego pakietu |
 | Wyjście step-up | 5 A | między przetwornicą a wtykiem M910q |
-| Odgałęzienie domeny A | 3 A | przed buckiem 12 → 5 V |
-| Odgałęzienie wyświetlaczy | 3 A | przed buckiem 12 → 5 V domeny B |
+| Odgałęzienie logiki (Nano, HM-10, RXB6) | 3 A | przed buckiem 12 → 5 V |
+| Odgałęzienie wyświetlaczy | 3 A | przed buckiem 12 → 5 V wyświetlaczy |
 | Gałąź wzmacniacza | wg karty modułu (20–30 A) | osobno, przy klemie akumulatora rozruchowego |
 
 Bezpiecznik główny **przy klemie**, nie przy urządzeniu — zwarcie przewodu
@@ -824,7 +842,7 @@ Dla trasy ok. 3 m (komora silnika → deska rozdzielcza) przy spadku < 3 %:
 | Pakiet HR1221W → szyna | do 10 A | 1,5 mm² |
 | Szyna → LVD → przekaźnik → step-up | do 7 A | 2,5 mm² |
 | Step-up → M910q | 3,5 A @ 19 V | 1,5 mm² |
-| Odgałęzienie domeny A | < 1 A | 0,75 mm² |
+| Odgałęzienie logiki (Nano, HM-10, RXB6) | < 1 A | 0,75 mm² |
 | Gałąź wzmacniacza | wg karty modułu | 6 mm² (trasa ~4 m do bagażnika) |
 | Masa do nadwozia | — | **6 mm²** |
 
@@ -856,7 +874,7 @@ linka, nie drut, i izolacja odporna na temperaturę i oleje.
 
 ## 9. Budżet energetyczny i czas postoju
 
-### 9.1 Pobór domeny A
+### 9.1 Pobór odbiorników stałych (bez komputera)
 
 | Element | Pobór |
 |---------|-------|
@@ -865,20 +883,20 @@ linka, nie drut, i izolacja odporna na temperaturę i oleje.
 | RXB6 433 MHz (nasłuch) | ~5 mA |
 | Moduł przekaźników (spoczynek) | ~10 mA |
 | Straty przetwornicy buck | ~5 mA |
-| **Podsuma — odbiorniki domeny A** | **~60 mA (0,7 W)** |
+| **Podsuma — logika i przekaźniki** | **~60 mA (0,7 W)** |
 | **XH-M609 (LVD)** | **do zmierzenia — patrz §7.3** |
 
 > **Pobór własny LVD jest częścią budżetu postoju.** XH-M609 ma wyświetlacz
 > LED i przekaźnik trzymany w stanie załączonym, więc nie jest to element
 > pomijalny — katalogowe „< 1,5 W" przy 12 V oznaczałoby aż 125 mA, czyli
-> **dwukrotnie więcej niż cała reszta domeny A**. Realny pobór przy 12 V jest
+> **dwukrotnie więcej niż cała reszta logiki**. Realny pobór przy 12 V jest
 > zwykle znacznie niższy (spec obejmuje cały zakres do 36 V), ale dopóki nie
 > zmierzysz, nie wiesz, w której kolumnie tabeli poniżej jesteś.
 
 ### 9.2 Czas postoju
 
 Czas zależy od tego, ile pobiera XH-M609 — dlatego tabela jest rozpisana
-wg **sumarycznego poboru**. Odbiorniki domeny A to stałe 60 mA; reszta to
+wg **sumarycznego poboru**. Logika i przekaźniki to stałe 60 mA; reszta to
 moduł LVD.
 
 **Bank 5 pakietów — 25,5 Ah:**
@@ -922,7 +940,7 @@ dłuższym postoju 50 % DoD jest w porządku; jako **rutyna** lepiej trzymać 30
 
 Samorozładowanie HR1221W (> 75 % pojemności po 6 miesiącach @ 25 °C, czyli
 ≤ 4 %/miesiąc) odpowiada ok. **1,4 mA** przy banku 25,5 Ah — wobec 60 mA
-domeny A jest pomijalne. W upale rośnie kilkukrotnie, ale nadal nie zmienia
+logiki jest pomijalne. W upale rośnie kilkukrotnie, ale nadal nie zmienia
 obrazu.
 
 Kolumna „do progu LVD" zakłada zejście do ~75 % DoD (11,0 V pod bardzo
@@ -952,7 +970,7 @@ dłuższym postoju; jeśli tak wygląda Twój profil użytkowania, rozważ
 
 | Element | Rola w torze | Uwaga |
 |---------|--------------|-------|
-| **XL6019** — moduł step-up | 12 V → 19,5 V dla M910q (domena B) | ok. **45 W ciągle**, nie 65 W — wymaga ograniczenia poboru CPU, §3.2 i §3.5a |
+| **XL6019** — moduł step-up | 12 V → 19,5 V dla M910q | ok. **45 W ciągle**, nie 65 W — wymaga ograniczenia poboru CPU, §3.2 i §3.5a |
 | **XH-M609** — moduł ochrony | **LVD** (warstwa 3), 11,00 / 12,60 V | przekaźnik 20 A wystarcza; zmierz pobór własny, §7.3 |
 | **CSB HR1221W F2** × 8 (12 V / 5,1 Ah AGM) | bank buforowy | użyj 5 (25,5 Ah) albo 8 (40,8 Ah) — decyzja po pomiarze z §7.3 |
 | Lenovo ThinkCentre M910q Tiny | komputer | |
@@ -971,7 +989,7 @@ dłuższym postoju; jeśli tak wygląda Twój profil użytkowania, rozważ
 | 7 | **Bezpiecznik główny + oprawka** | 30 A, oprawka do montażu przy klemie | 1 | 15–25 |
 | 8 | **Bezpieczniki inline** | 10 A × 5–8 (pakiety) + oprawki, oraz 15 A przed VIN+ modułu XH-M609 | 6–9 | 20–35 |
 | 9 | **Bezpieczniki nożowe** | 5 A, 3 A × 2, 20 A + zapas | kpl. | 10–15 |
-| 10 | **Buck 12 → 5 V** (domena A) | LM2596, min. 1 A | 1 | 5–10 |
+| 10 | **Buck 12 → 5 V** (logika) | LM2596, min. 1 A | 1 | 5–10 |
 | 11 | **Buck 12 → 5 V** (wyświetlacze) | MP1584 / MP2307, min. 3 A — potrzebny przez **PWM podświetlenia**, patrz niżej | 1 | 5–15 |
 | 12 | **Dioda TVS** | 1.5KE33CA lub SMCJ26CA | 2 | 5–10 |
 | 13 | **Kondensator elektrolityczny** | 470 µF / 35 V, low-ESR, 105 °C | 2 | 5–10 |
@@ -1048,7 +1066,7 @@ Pozostałe
 [ ] Ładowarka: CV 14,40 V (lub 13,80 V w wariancie B bez kompensacji)
 [ ] Ładowarka: limit prądu CC 6,0 A (sufit katalogowy 10,5 A dla 5 pakietów)
 [ ] Rozłącznik nadnapięciowy: rozwarcie 15,30 V, powrót 14,00 V (§6.4)
-[ ] Buck domeny A: wyjście 5,0 V
+[ ] Buck logiki: wyjście 5,0 V
 [ ] Buck wyświetlaczy: wyjście 5,0 V
 ```
 
@@ -1085,7 +1103,7 @@ Pozostałe
 [ ] Pomiar: napięcie na szynie buforowanej (silnik zgaszony)
 [ ] Rozłącznik masy banku ZWARTY
 [ ] Pomiar: napięcie banku = napięcie szyny
-[ ] Pomiar prądu spoczynkowego domeny A → oczekiwane ~60 mA
+[ ] Pomiar prądu spoczynkowego logiki → oczekiwane ~60 mA
     (rozbieżność > 100 mA = szukaj upływu, NIE jedź dalej)
 ```
 
@@ -1102,7 +1120,7 @@ Pozostałe
 [ ] Pomiar: brak prądu z banku do akumulatora rozruchowego
 ```
 
-### Etap 6 — domena B i komputer
+### Etap 6 — komputer i sterowanie zapłonem
 
 ```
 [ ] Przekręcenie kluczyka na ACC → przekaźnik zapłonu zwiera
@@ -1110,7 +1128,9 @@ Pozostałe
 [ ] M910q startuje, dashboard pojawia się na wyświetlaczu głównym
 [ ] Rozruch silnika przy działającym BCM → komputer NIE resetuje się
     (to jest test, dla którego cały ten bufor powstał)
-[ ] Wyłączenie zapłonu → domena B gaśnie, pomiar poboru = 0 mA
+[ ] Wyłączenie zapłonu → Arduino daje impuls, M910q schodzi do S3
+[ ] Pomiar poboru w S3 — oczekiwane 400–550 mA (§2.1)
+[ ] Po 2 h → impuls 5 s, maszyna gaśnie, pobór spada do 100–200 mA
 [ ] Domena A dalej działa — test pilota 433 MHz i BLE bagażnika
 ```
 
@@ -1133,7 +1153,7 @@ Pozostałe
 | Co 3 miesiące | Napięcie każdego pakietu osobno | rozrzut < 0,2 V |
 | Co 3 miesiące | Dokręcenie połączeń na szynie i biegunach | bez luzu |
 | Co 6 miesięcy | Napięcie ładowania przy pracującym silniku | ≤ 14,40 V (lub wg kompensacji) |
-| Co 6 miesięcy | Prąd spoczynkowy domeny A | ~60 mA ± 20 % |
+| Co 6 miesięcy | Prąd spoczynkowy logiki | ~60 mA ± 20 % |
 | Co 12 miesięcy | Test pojemności banku (rozładowanie kontrolowane) | > 70 % pojemności znamionowej |
 | Co 12 miesięcy | Kontrola przewodów: przetarcia, korozja konektorów | bez zmian |
 
@@ -1259,6 +1279,6 @@ przed zabudową, a nie po.
 | [`X86_PLATFORM_SETUP.md`](X86_PLATFORM_SETUP.md) | referencja krok-po-kroku (EN) — pamiętaj o §13 |
 | [`x86-production/10-power-suspend.html`](x86-production/10-power-suspend.html) | zasilanie + S3 w wersji ilustrowanej |
 | [`x86-production/02-assembly.html`](x86-production/02-assembly.html) | montaż mechaniczny, layout USB |
-| [`ARDUINO_SETUP_GUIDE.md`](ARDUINO_SETUP_GUIDE.md) | okablowanie trzech płytek Arduino, domeny A/B po stronie sygnałów |
+| [`ARDUINO_SETUP_GUIDE.md`](ARDUINO_SETUP_GUIDE.md) | okablowanie trzech płytek Arduino, sygnały pojazdu |
 | [`SCHEMATY_POLACZEN.md`](SCHEMATY_POLACZEN.md) | tabele połączeń, przekroje, bezpieczniki, kolejność montażu |
 | [`../schematics/README.md`](../schematics/README.md) | indeks schematów |

--- a/docs/ZASILANIE_BUFOROWANE.md
+++ b/docs/ZASILANIE_BUFOROWANE.md
@@ -966,6 +966,9 @@ dłuższym postoju; jeśli tak wygląda Twój profil użytkowania, rozważ
 
 ## 10. Lista zakupowa
 
+> Ta lista dotyczy **wersji docelowej**. Budujesz wariant testowy?
+> Wszystko w jednej tabeli: [`LISTA_ZAKUPOWA.md`](LISTA_ZAKUPOWA.md).
+
 ### 10.1 Już posiadane
 
 | Element | Rola w torze | Uwaga |

--- a/docs/ZASILANIE_BUFOROWANE.md
+++ b/docs/ZASILANIE_BUFOROWANE.md
@@ -43,7 +43,7 @@ Trzy niezależne powody — każdy sam w sobie wystarczyłby:
 | **Jakość napięcia** | Instalacja auta to śmietnik EMI: przepięcia od cewek, load dump z alternatora, tętnienia. | Bank o pojemności 25,5 Ah to gigantyczny kondensator — wygładza wszystko, co jest za nim. |
 
 Kluczowa konsekwencja architektury: **akumulator rozruchowy nigdy nie zasila
-head unitu na postoju**. Rozdziela je dioda albo przekaźnik VSR, więc auto
+head unitu na postoju**. Rozdziela je przekaźnik ładowania z diodą, więc auto
 zawsze odpali, choćby bank był pusty.
 
 ---
@@ -66,6 +66,20 @@ Przekaźnik rozwiera obwód fizycznie: zero poboru huba USB, zero upływów
 przetwornic, zero ryzyka, że coś obudzi maszynę na parkingu. BCM budzi się
 zimnym startem na ACC — startuje w ~15 s, co przy samochodzie jest
 akceptowalne.
+
+> **Wariant testowy robi to odwrotnie — świadomie.**
+> [`WDROZENIE_TESTOWE.md`](WDROZENIE_TESTOWE.md) §3.1a rezygnuje z domeny B:
+> M910q wisi na buforze na stałe, zapłon jest tylko sygnałem do Arduino,
+> a maszyna schodzi do S3 i z niego wraca. Kupuje to wybudzenie w ~3 s
+> zamiast zimnego startu i zerowe ryzyko ucięcia zapisu na dysk — kosztem
+> poboru postojowego, który rośnie z ~60 mA do 240–480 mA, czyli z ~13 dni
+> postoju do ~1,5–2,5 dnia.
+>
+> Która wersja jest właściwa, zależy od tego, jak często auto jeździ.
+> Wersja docelowa zostaje przy przekaźniku, bo z domeną A na pokładzie
+> (nasłuch pilota i BLE) i tak musi wytrzymać długi postój. Gdy Nano #2
+> zacznie publikować `hal.ignition`, przejście na model z S3 będzie możliwe
+> także tutaj — decyzja stanie się wtedy czysto energetyczna.
 
 **Dlaczego wyświetlacze mają własny buck, a nie USB.** Same panele
 spokojnie zasiliłyby się z portów USB M910q — i tak właśnie robi wariant
@@ -490,22 +504,24 @@ Prąd nastaw i tak na **6 A** (katalogowy sufit dla pięciu HR1221W to 10,5 A)
 — większy model to tylko zapas i mniejsze grzanie. Dla banku 25,5 Ah
 **najmniejsza dostępna wersja w zupełności wystarcza**.
 
-**Co odpada przy wariancie A:** VSR (ładowarka sama wykrywa pracę silnika),
-dioda Schottky (izolacja jest w środku), osobny czujnik NTC (jest wbudowany
-albo w komplecie).
+**Co odpada przy wariancie A:** przekaźnik ładowania (ładowarka sama wykrywa
+pracę silnika), dioda Schottky (izolacja jest w środku), osobny czujnik NTC
+(jest wbudowany albo w komplecie).
 
 ### 5.3 Wariant B — DIY
 
 Tańszy, ale wymaga uwagi przy nastawianiu i regularnej kontroli.
 
 ```
-akumulator → bezp. 30 A → VSR → moduł CC-CV boost → blokada nadnapięcia → bank
+akumulator → bezp. 15 A → TVS + C → przekaźnik ładowania → dioda MBR2545CT
+           → moduł CC-CV boost → blokada nadnapięcia → bank
 ```
 
 | Element | Rola | Nastawa | Cena |
 |---------|------|---------|------|
-| **VSR** (voltage sensitive relay) 12 V / 140 A | zwiera obwód dopiero, gdy alternator pracuje | zał. 13,3 V, wył. 12,8 V | 60–250 PLN |
-| **Moduł CC-CV boost** z regulacją prądu i napięcia | podnosi 13,75 V → 14,4 V i limituje prąd | CV 14,40 V, CC 6,0 A | 50–140 PLN |
+| **Przekaźnik ładowania** 30 A SPDT | rozłącza tor ładowania, gdy silnik nie pracuje | cewka z zapłonu (patrz §5.3c) | 15–25 PLN |
+| **Dioda Schottky MBR2545CT** | blokuje wsteczny przepływ do instalacji auta | obie połówki równolegle, na radiatorze | 5–12 PLN |
+| **Moduł CC-CV boost** z regulacją prądu i napięcia | podnosi 13,7 V → 14,4 V i limituje prąd | CV 14,40 V, CC 6,0 A | 50–140 PLN |
 
 #### 5.3a Konkretne moduły CC-CV
 
@@ -547,11 +563,15 @@ Dlatego **CV = 14,40 V**, a nie 13,80 V. Konsekwencje przyjmujesz świadomie:
 próg warstwy 2 zostaje na **15,30 V** (§6.2), a kompensacji temperaturowej
 nie ma.
 
-**Co to łagodzi:** przy VSR napięcie absorpcji jest podawane **wyłącznie
-podczas pracy silnika**. Na postoju VSR rozwiera obwód i bank stoi na własnym
-napięciu spoczynkowym — nie jest trzymany na 14,4 V na okrągło. To zupełnie
-inny reżim niż stały float 14,4 V i dla pracy buforowej całkowicie
-akceptowalny.
+**Co to łagodzi:** napięcie absorpcji jest podawane **wyłącznie przy
+załączonym przekaźniku ładowania**, czyli podczas jazdy. Na postoju przekaźnik
+jest rozwarty i bank stoi na własnym napięciu spoczynkowym — nie jest trzymany
+na 14,4 V na okrągło. To zupełnie inny reżim niż stały float 14,4 V i dla
+pracy buforowej całkowicie akceptowalny.
+
+Dioda MBR2545CT dodatkowo obniża wejście boostu o ~0,5 V, czyli **powiększa
+zapas nad nastawą CV** — pass-through z §5.3b staje się jeszcze mniej
+prawdopodobny.
 
 **Jeżeli mimo wszystko chcesz 13,80 V**, potrzebujesz topologii z władzą
 w obie strony — modułu **buck-boost**:
@@ -560,25 +580,43 @@ w obie strony — modułu **buck-boost**:
 |-------|------|------|--------|
 | **LTC3780** (moduł WD2002SJ / XR-131, wej. 5–32 V, wyj. 1–30 V) | buck-boost, CC + CV + próg podnapięciowy (trzy potencjometry), 10 A szczytowo | 50–90 PLN | **7 A i 80 W ciągle** — przy 13,8 V to tylko ~5,8 A, więc po odjęciu obciążenia do banku idzie mało. Do trzech pakietów w porządku, do ośmiu bez sensu |
 
-#### 5.3c Konkretne VSR-y
+#### 5.3c Przekaźnik ładowania i dioda MBR2545CT
 
-| Model | Progi | Cena | Uwaga |
-|-------|-------|------|-------|
-| **Durite 0-727-11** — 12 V / 140 A | zał. 13,3 V · rozł. 12,65 V | 150–250 PLN | markowy, zalany żywicą, dioda LED stanu; progi fabrycznie dokładnie takie, jakich potrzebujesz |
-| **Victron Cyrix-ct 12/24-120** | sterowany mikroprocesorem | 250–350 PLN | najbardziej odporny i bezobsługowy; przy 6–9 A mocno przewymiarowany |
-| Bezmarkowy „VSR 12 V 140 A dual battery isolator" | zwykle 13,3 / 12,8 V | 60–120 PLN | działa, ale **zweryfikuj progi zasilaczem laboratoryjnym** przed montażem — potrafią być przekłamane o 0,3 V |
-| **Zamiennik: przekaźnik 30 A sterowany z D+** | zwiera, gdy alternator ładuje | 15–25 PLN | tor ładowania niesie 6–9 A, więc 140 A to przesada. Wymaga znalezienia zacisku **D+/L** alternatora i sprawdzenia, czy lampka kontrolna dalej działa — cewka pobiera ~150 mA z jej obwodu |
+Rozdział ładowania robią tu dwa tanie elementy zamiast modułu napięciowego.
 
-**Dlaczego VSR, a nie dioda Schottky.** Boost nie może dawać napięcia
-niższego niż wejściowe — przy zgaszonym silniku (12,4 V na akumulatorze
-rozruchowym) próbowałby dalej podawać 14,2 V i **rozładowywałby akumulator
-auta**. VSR fizycznie rozłącza obwód poniżej 12,8 V, więc problem znika.
-Dodatkowo odpada spadek 0,45 V na diodzie, którego przy tak małym przełożeniu
-bardzo brakuje.
+**Dlaczego w ogóle coś tu musi być.** Boost nie potrafi dać napięcia niższego
+niż wejściowe. Gdyby jego wejście wisiało na stałe na akumulatorze
+rozruchowym, to przy zgaszonym silniku (12,4 V) dalej próbowałby podawać
+14,4 V i **rozładowywałby akumulator auta**. Tor ładowania musi więc być
+fizycznie rozłączany, gdy silnik nie pracuje.
 
-Jeżeli mimo wszystko zostajesz przy diodzie Schottky (MBR2045), to **musisz**
-dołożyć przekaźnik sterowany z ACC, który odcina ładowarkę przy zgaszonym
-silniku.
+| Element | Rola | Uwaga |
+|---------|------|-------|
+| **Przekaźnik 30 A SPDT** + podstawka | rozłącza tor, gdy silnik nie pracuje | dioda 1N4007 równolegle do cewki |
+| **MBR2545CT** — 25 A / 45 V, TO-220AB | druga bariera: blokuje przepływ wsteczny, gdyby styki przekaźnika się zespawały | dwie połówki po 12,5 A ze **wspólną katodą** |
+
+**Czym sterować cewkę.** Najprościej **zapłonem** i tak jest w tej
+dokumentacji założone. Ma to jeden koszt, który warto znać: przy kluczyku
+w pozycji ON bez pracującego silnika przekaźnik jest zwarty, więc boost
+ładuje bank **z akumulatora rozruchowego**. Przy normalnym uruchamianiu
+to kilka sekund i nie ma znaczenia; przy dłuższym staniu z kluczykiem
+(radio na postoju, diagnostyka) — ma.
+
+Jeżeli chcesz to wyeliminować, podepnij cewkę pod **D+/L alternatora**
+zamiast pod zapłon. To dosłownie jeden przewód inaczej, a sygnał znaczy
+wtedy „alternator ładuje", a nie „kluczyk przekręcony". Sprawdź potem, czy
+lampka kontrolna ładowania dalej działa poprawnie — cewka pobiera ~150 mA
+z jej obwodu.
+
+**Montaż diody.** MBR2545CT to dwie diody ze wspólną katodą, a **katoda jest
+połączona z blaszką montażową**:
+
+- **zewrzyj obie anody** (piny 1 i 3) i podaj na nie plus z przekaźnika,
+  katodę (pin 2 / blaszka) na wejście boostu — dostajesz pełne 25 A i niższy
+  spadek: przy 9 A łącznie każda połówka wiezie 4,5 A, czyli Vf ≈ 0,45–0,50 V,
+- **radiator obowiązkowy** — 9 A × 0,5 V to ok. **4,5 W** ciągłej straty,
+- blaszka jest pod potencjałem katody, więc albo **izoluj ją podkładką
+  mikową**, albo przykręcaj do radiatora, który nie dotyka masy nadwozia.
 
 **Kompensacja temperaturowa w wariancie B** jest ręczna: tanie moduły CC-CV
 jej nie mają, a — jak pokazuje §5.3b — zejście z CV do „bezpiecznych" 13,8 V
@@ -586,7 +624,7 @@ kupuje spokój kosztem utraty ograniczenia prądowego, czyli w złą stronę.
 Zostaje **14,40 V bez kompensacji**, z trzema rzeczami, które to trzymają
 w ryzach:
 
-- VSR podaje to napięcie **tylko przy pracującym silniku**, nie na postoju,
+- przekaźnik ładowania podaje to napięcie **tylko podczas jazdy**, nie na postoju,
 - rozłącznik nadnapięciowy 15,30 V łapie awarię modułu (§6),
 - bank w bagażniku rzadko przekracza 30 °C, a przy 40 °C prawidłowa absorpcja
   to 13,95 V — czyli 14,40 V to przegrzanie o 0,45 V przez kilka godzin jazdy,
@@ -781,7 +819,7 @@ Dla trasy ok. 3 m (komora silnika → deska rozdzielcza) przy spadku < 3 %:
 
 | Odcinek | Prąd | Przekrój |
 |---------|------|----------|
-| Akumulator → bezpiecznik → VSR/ładowarka | do 30 A | **6 mm²** |
+| Akumulator → bezpiecznik → przekaźnik/ładowarka | do 30 A | **6 mm²** |
 | Ładowarka → bank | do 6 A | 2,5 mm² |
 | Pakiet HR1221W → szyna | do 10 A | 1,5 mm² |
 | Szyna → LVD → przekaźnik → step-up | do 7 A | 2,5 mm² |
@@ -924,7 +962,7 @@ dłuższym postoju; jeśli tak wygląda Twój profil użytkowania, rozważ
 | # | Element | Specyfikacja | Szt. | Cena (PLN) |
 |---|---------|--------------|------|-----------|
 | 1 | **Ładowarka DC-DC** *(wariant A)* | Victron Orion-Tr Smart 12/12-18 lub odpowiednik z presetem **AGM** | 1 | 800–1000 |
-| | *albo:* VSR + moduł CC-CV boost *(wariant B)* | VSR: **Durite 0-727-11** / Victron Cyrix-ct 12/24-120 / bezmarkowy 140 A · boost: **„900 W 15 A" z wyświetlaczem** albo **SZBK07** — pełne zestawienie w §5.3a i §5.3c | 1+1 | 110–390 |
+| | *albo:* przekaźnik + dioda + moduł CC-CV boost *(wariant B)* | przekaźnik 30 A SPDT + **MBR2545CT** na radiatorze · boost: **„900 W 15 A" z wyświetlaczem** albo **SZBK07** — pełne zestawienie w §5.3a i §5.3c | 1+1+1 | 70–180 |
 | 2 | **Rozłącznik nadnapięciowy** | programowalny przekaźnik napięciowy, próg 15,3 V / powrót 14,0 V | 1 | 40–80 |
 | 3 | ~~Moduł LVD~~ | **posiadany — XH-M609** | — | 0 |
 | 4 | **Przekaźnik zapłonu** | Bosch 12 V / 30 A SPDT + podstawka | 1 | 15–25 |
@@ -951,7 +989,7 @@ dłuższym postoju; jeśli tak wygląda Twój profil użytkowania, rozważ
 | 24a | **Kondensator wyjściowy** | 470 µF / 35 V low-ESR na wyjście XL6019 | 1 | 3–6 |
 | 24b | **Termistor NTC** | 5 Ω / 5 A, ogranicznik prądu rozruchowego (tylko jeśli §3.2b) | 1 | 3–6 |
 | | | | **Razem wariant A** | **~1280–1870 PLN** |
-| | | | **Razem wariant B** | **~570–1240 PLN** |
+| | | | **Razem wariant B** | **~530–1030 PLN** |
 
 Kwoty są niższe niż w pierwszej wersji listy, bo moduł LVD i przetwornica
 step-up są już na stanie.
@@ -1056,11 +1094,11 @@ Pozostałe
 ```
 [ ] Uruchomienie silnika
 [ ] Pomiar: napięcie na akumulatorze rozruchowym (13,8–14,5 V)
-[ ] Pomiar: VSR zwarty / ładowarka aktywna
+[ ] Pomiar: przekaźnik ładowania zwarty / ładowarka aktywna
 [ ] Pomiar: prąd ładowania banku ≤ 6 A
 [ ] Pomiar: napięcie banku rośnie, nie przekracza 14,40 V (wg kompensacji temp.)
 [ ] Po 30 min: temperatura pakietów ręką — letnie, nie gorące
-[ ] Zgaszenie silnika → VSR rozwiera się w ciągu kilku sekund
+[ ] Zgaszenie silnika → przekaźnik ładowania rozwiera się, prąd spada do zera
 [ ] Pomiar: brak prądu z banku do akumulatora rozruchowego
 ```
 

--- a/schematics/README.md
+++ b/schematics/README.md
@@ -26,6 +26,9 @@ M910q Tiny**.
 
 | Plik | Co przedstawia |
 |------|----------------|
+| [`schematic_test_build.svg`](schematic_test_build.svg) | **Schemat ideowy wariantu testowego** — symbole elektryczne, nie bloczki: akumulator, bezpieczniki, TVS, przekaźnik ładowania, MBR2545CT, boost, rozłącznik nadnapięciowy, bank z bezpiecznikami pakietów, LVD, wyłącznik główny, XL6019 i LM2596. Opis: [`../docs/WDROZENIE_TESTOWE.md`](../docs/WDROZENIE_TESTOWE.md). |
+| [`ignition_sense.svg`](ignition_sense.svg) | **Wykrywanie zapłonu → S3** — układ wejściowy z optoizolacją PC817 i wartościami elementów (R1 2,2 kΩ, R2 10 kΩ, C2 100 nF), przebieg uśpienia i wybudzania, oraz spis tego, czego brakuje w kodzie i firmwarze. |
+| [`wiring_test_build.svg`](wiring_test_build.svg) | **Schemat połączeniowy wariantu testowego** — każdy zacisk podpisany, każdy przewód ponumerowany (1–20 + złącze B), punkt gwiazdowy masy, kolejność podłączania, przekroje. Tabele: [`../docs/SCHEMATY_POLACZEN.md`](../docs/SCHEMATY_POLACZEN.md) § 10. |
 | [`wiring_power_modules.svg`](wiring_power_modules.svg) | **Moduły zasilania zacisk po zacisku** — każdy zacisk podpisany i ponumerowany, przekroje przewodów, bezpieczniki, punkty masy, kolejność podłączania. |
 | [`wiring_vehicle_arduino.svg`](wiring_vehicle_arduino.svg) | **Sygnały pojazdu → Arduino** — punkty poboru w aucie, stopień PC817, dzielniki napięcia, podciągnięcia, rozpiska pinów trzech płytek, tor K-Line. |
 | [`wiring_usb_av.svg`](wiring_usb_av.svg) | **USB, obraz, audio, kamery** — co idzie przez hub, a co bezpośrednio w port, przejściówki DP → HDMI, tor audio i przypisanie kamer. |
@@ -47,6 +50,17 @@ M910q Tiny**.
 
 Zanim zaczniesz cokolwiek wiercić i prowadzić: **`vehicle_layout_m910q.svg`**
 — pokazuje, co gdzie ląduje w aucie i którędy idą wiązki.
+
+### Wariant testowo-rozwojowy — osobny komplet
+
+Budujesz wariant z [`../docs/WDROZENIE_TESTOWE.md`](../docs/WDROZENIE_TESTOWE.md)?
+Powyższa kolejność Cię **nie** dotyczy — tam nie ma domeny A ani przekaźnika
+odcinającego odbiorniki. Czytaj trzy rysunki w tej kolejności:
+
+1. **`schematic_test_build.svg`** — co z czym się łączy i dlaczego.
+2. **`ignition_sense.svg`** — układ wejściowy zapłonu, wartości elementów.
+3. **`wiring_test_build.svg`** — dopiero teraz zaciski, numery przewodów
+   i kolejność podłączania.
 
 ---
 

--- a/schematics/README.md
+++ b/schematics/README.md
@@ -16,9 +16,9 @@ M910q Tiny**.
 
 | Plik | Co przedstawia |
 |------|----------------|
-| [`power_buffered_m910q.svg`](power_buffered_m910q.svg) | **Tor główny zasilania** — od klemy akumulatora, przez rozdział ładowania, ładowarkę CC-CV, blokadę przeładowania, bank CSB HR1221W i LVD, po przekaźnik zapłonu, przetwornicę step-up 19 V i M910q. Zawiera tabelę przekrojów przewodów i bezpieczników. |
+| [`power_buffered_m910q.svg`](power_buffered_m910q.svg) | **Tor główny zasilania** — od klemy akumulatora, przez przekaźnik ładowania, ładowarkę CC-CV, blokadę przeładowania, bank CSB HR1221W i LVD, po wyłącznik główny, przetwornicę step-up 19 V i M910q. Zawiera tabelę przekrojów przewodów i bezpieczników. |
 | [`charging_lvd.svg`](charging_lvd.svg) | **Ładowanie i ochrona banku** — cztery warstwy (przekaźnik ładowania → CC-CV → rozłącznik nadnapięciowy → LVD), komplet nastaw dla **CSB HR1221W (AGM)**, dwie tabele kompensacji temperaturowej, wpływ temperatury na żywotność, przebieg CC → CV → float. |
-| [`power_domains_m910q.svg`](power_domains_m910q.svg) | **Domeny A/B** — rozdział obciążeń między część zawsze zasilaną a część załączaną zapłonem, bezpieczniki odgałęzień, budżet poboru spoczynkowego, tabela czasu postoju, osobna gałąź wzmacniaczy. |
+| [`power_domains_m910q.svg`](power_domains_m910q.svg) | **Rozdział odbiorników** — co wisi na szynie buforowanej, bezpieczniki odgałęzień, budżet poboru w trzech stanach maszyny (praca / S3 / wyłączona), tabela czasu postoju, osobna gałąź wzmacniaczy. |
 | [`audio_system.svg`](audio_system.svg) | **Tor audio** — ES9038Q2M (USB DAC) → RCA → **gotowy wzmacniacz samochodowy** → głośniki 4 Ω. Wzmacniacz zasilany wprost z akumulatora rozruchowego, z własną masą — całkowicie odseparowany od systemu buforowanego. |
 | [`power_test_build.svg`](power_test_build.svg) | **Wariant testowo-rozwojowy** — uproszczony tor dla instalacji jeżdżącej z minimalnym zestawem funkcji: ładowanie wariantem B (przekaźnik + MBR2545CT + CC-CV boost), bank, LVD, XL6019 i panel 7". M910q zasilany stale, zapłon tylko jako sygnał. Bez domeny A i bez wzmacniacza. Opis: [`../docs/WDROZENIE_TESTOWE.md`](../docs/WDROZENIE_TESTOWE.md). |
 
@@ -38,8 +38,8 @@ M910q Tiny**.
 
 ## Kolejność czytania przy montażu
 
-1. **`power_domains_m910q.svg`** — najpierw ustal, co gdzie ma wisieć.
-   Podział na domeny determinuje całą resztę okablowania.
+1. **`power_domains_m910q.svg`** — najpierw ustal, co gdzie ma wisieć
+   i jaki jest budżet poboru w każdym ze stanów maszyny.
 2. **`power_buffered_m910q.svg`** — trasa zasilania, przekroje, bezpieczniki.
 3. **`charging_lvd.svg`** — nastaw ładowarkę, rozłącznik nadnapięciowy i LVD
    **przed** pierwszym podłączeniem banku.
@@ -69,12 +69,12 @@ odcinającego odbiorniki. Czytaj trzy rysunki w tej kolejności:
 | Element | Znaczenie |
 |---------|-----------|
 | Gruba czerwona linia | Zasilanie 12 V (moc) |
-| Zielona linia | Odgałęzienie domeny A (zawsze zasilana) |
-| Niebieska linia | Odgałęzienie domeny B (za zapłonem) |
+| Zielona linia | Tor ładowania |
+| Niebieska linia | Odgałęzienie odbiorników (za LVD i wyłącznikiem) |
 | Linia przerywana | Sygnał sterujący (ACC, NTC), nie moc |
 | Ramka pomarańczowa | Element zabezpieczający (bezpiecznik, LVD, rozłącznik) |
-| Ramka zielona | Domena A / bank akumulatorów |
-| Ramka niebieska | Domena B |
+| Ramka zielona | Tor ładowania / bank akumulatorów |
+| Ramka niebieska | Odbiorniki |
 | Ramka czerwona | Gałąź niezależna (wzmacniacze) |
 
 ---

--- a/schematics/README.md
+++ b/schematics/README.md
@@ -17,10 +17,10 @@ M910q Tiny**.
 | Plik | Co przedstawia |
 |------|----------------|
 | [`power_buffered_m910q.svg`](power_buffered_m910q.svg) | **Tor główny zasilania** — od klemy akumulatora, przez rozdział ładowania, ładowarkę CC-CV, blokadę przeładowania, bank CSB HR1221W i LVD, po przekaźnik zapłonu, przetwornicę step-up 19 V i M910q. Zawiera tabelę przekrojów przewodów i bezpieczników. |
-| [`charging_lvd.svg`](charging_lvd.svg) | **Ładowanie i ochrona banku** — cztery warstwy (VSR → CC-CV → rozłącznik nadnapięciowy → LVD), komplet nastaw dla **CSB HR1221W (AGM)**, dwie tabele kompensacji temperaturowej, wpływ temperatury na żywotność, przebieg CC → CV → float. |
+| [`charging_lvd.svg`](charging_lvd.svg) | **Ładowanie i ochrona banku** — cztery warstwy (przekaźnik ładowania → CC-CV → rozłącznik nadnapięciowy → LVD), komplet nastaw dla **CSB HR1221W (AGM)**, dwie tabele kompensacji temperaturowej, wpływ temperatury na żywotność, przebieg CC → CV → float. |
 | [`power_domains_m910q.svg`](power_domains_m910q.svg) | **Domeny A/B** — rozdział obciążeń między część zawsze zasilaną a część załączaną zapłonem, bezpieczniki odgałęzień, budżet poboru spoczynkowego, tabela czasu postoju, osobna gałąź wzmacniaczy. |
 | [`audio_system.svg`](audio_system.svg) | **Tor audio** — ES9038Q2M (USB DAC) → RCA → **gotowy wzmacniacz samochodowy** → głośniki 4 Ω. Wzmacniacz zasilany wprost z akumulatora rozruchowego, z własną masą — całkowicie odseparowany od systemu buforowanego. |
-| [`power_test_build.svg`](power_test_build.svg) | **Wariant testowo-rozwojowy** — uproszczony tor dla instalacji jeżdżącej z minimalnym zestawem funkcji: ładowanie wariantem B (VSR + CC-CV boost), bank, LVD, przekaźnik zapłonu, XL6019 i panel 7". Bez domeny A i bez wzmacniacza. Opis: [`../docs/WDROZENIE_TESTOWE.md`](../docs/WDROZENIE_TESTOWE.md). |
+| [`power_test_build.svg`](power_test_build.svg) | **Wariant testowo-rozwojowy** — uproszczony tor dla instalacji jeżdżącej z minimalnym zestawem funkcji: ładowanie wariantem B (przekaźnik + MBR2545CT + CC-CV boost), bank, LVD, XL6019 i panel 7". M910q zasilany stale, zapłon tylko jako sygnał. Bez domeny A i bez wzmacniacza. Opis: [`../docs/WDROZENIE_TESTOWE.md`](../docs/WDROZENIE_TESTOWE.md). |
 
 ### Schematy połączeniowe — montaż
 

--- a/schematics/audio_system.svg
+++ b/schematics/audio_system.svg
@@ -120,8 +120,8 @@
   <text class="note" x="738" y="434">masa przy wzmacniaczu — NIE punkt gwiazdowy</text>
 
   <rect class="mod" x="906" y="312" width="264" height="96"/>
-  <text class="mt" x="1038" y="334">REM ← domena B</text>
-  <text class="ms" x="1038" y="356">z zacisku 87 przekaźnika zapłonu</text>
+  <text class="mt" x="1038" y="334">REM ← zapłon</text>
+  <text class="ms" x="1038" y="356">wprost z linii ACC / zapłonu</text>
   <text class="ms" x="1038" y="376">wzmacniacz wstaje i gaśnie</text>
   <text class="ms" x="1038" y="394">razem z head unitem</text>
 

--- a/schematics/charging_lvd.svg
+++ b/schematics/charging_lvd.svg
@@ -36,7 +36,7 @@
 
   <rect class="box" x="262" y="90" width="196" height="92"/>
   <text class="h" x="360" y="112">WARSTWA 0 — rozdział</text>
-  <text class="t" x="360" y="132">VSR: zwiera przy 13,3 V,</text>
+  <text class="t" x="360" y="132">przekaźnik z zapłonu (albo D+),</text>
   <text class="t" x="360" y="150">rozwiera przy 12,8 V</text>
   <text class="t" x="360" y="168">ładowanie tylko przy alternatorze</text>
 

--- a/schematics/charging_lvd.svg
+++ b/schematics/charging_lvd.svg
@@ -74,7 +74,7 @@
   <text class="t" x="616" y="458">przekaźnik 20 A · pobór własny DO ZMIERZENIA</text>
 
   <path class="wire" d="M616 466 L616 500"/>
-  <text class="tb" x="640" y="490">→ domena A + domena B</text>
+  <text class="tb" x="640" y="490">→ cała szyna odbiorników</text>
 
   <!-- NTC control line -->
   <path class="ctrl" d="M420 292 L396 292 L396 200 L616 200 L616 182"/>

--- a/schematics/ignition_sense.svg
+++ b/schematics/ignition_sense.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1200" height="880" viewBox="0 0 1200 880" font-family="DejaVu Sans, Verdana, sans-serif">
-  <title>BCM v8.5 — wykrywanie zapłonu, uśpienie do S3 i wybudzanie (M910q)</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1240" height="1120" viewBox="0 0 1240 1120" font-family="DejaVu Sans, Verdana, sans-serif">
+  <title>BCM v8.5 — wykrywanie zapłonu i sterowanie przyciskiem zasilania M910q (S3)</title>
   <style>
     .bg   { fill: #ffffff; }
     .wp   { stroke: #c0392b; stroke-width: 2.4; fill: none; stroke-linecap: round; }
@@ -11,19 +11,21 @@
     .iso  { fill: none; stroke: #9a6b12; stroke-width: 2; stroke-dasharray: 7 5; rx: 6; }
     .blk  { fill: #f7f9fb; stroke: #2b3a45; stroke-width: 2; rx: 4; }
     .blkb { fill: #eef2fa; stroke: #2b4a8a; stroke-width: 2; rx: 4; }
+    .blkg { fill: #eef7ee; stroke: #2d6a2d; stroke-width: 2; rx: 4; }
     .note { fill: #fbfcfd; stroke: #c8d2da; stroke-width: 1.5; rx: 5; }
     .warn { fill: #fdf2f2; stroke: #a8321a; stroke-width: 1.8; rx: 5; }
+    .good { fill: #f1f8f1; stroke: #2d6a2d; stroke-width: 1.8; rx: 5; }
     .ttl  { font-size: 19px; font-weight: bold; fill: #10202b; }
     .sub  { font-size: 12px; fill: #5a6b78; }
     .sec  { font-size: 13px; font-weight: bold; fill: #2b4a8a; letter-spacing: 0.5px; }
     .lbl  { font-size: 11px; fill: #33424e; }
     .lbc  { font-size: 11px; fill: #33424e; text-anchor: middle; }
     .lbb  { font-size: 11.5px; font-weight: bold; fill: #10202b; text-anchor: middle; }
-    .ref  { font-size: 11.5px; font-weight: bold; fill: #a8321a; }
     .nh   { font-size: 12.5px; font-weight: bold; fill: #10202b; }
     .nt   { font-size: 11px; fill: #4a5a66; }
     .wh   { font-size: 12.5px; font-weight: bold; fill: #a8321a; }
     .wt   { font-size: 11px; fill: #7a3020; }
+    .gh   { font-size: 12.5px; font-weight: bold; fill: #2d6a2d; }
   </style>
 
   <defs>
@@ -33,13 +35,11 @@
       <line class="wg" x1="-8" y1="13" x2="8" y2="13"/>
       <line class="wg" x1="-3" y1="18" x2="3" y2="18"/>
     </g>
-    <!-- resistor, horizontal, origin left lead -->
     <g id="res">
       <line class="sym" x1="0" y1="0" x2="8" y2="0"/>
       <rect class="sym" x="8" y="-9" width="40" height="18" fill="#ffffff"/>
       <line class="sym" x1="48" y1="0" x2="56" y2="0"/>
     </g>
-    <!-- resistor, vertical, origin top lead -->
     <g id="resV">
       <line class="sym" x1="0" y1="0" x2="0" y2="8"/>
       <rect class="sym" x="-9" y="8" width="18" height="40" fill="#ffffff"/>
@@ -53,32 +53,28 @@
     </g>
   </defs>
 
-  <rect class="bg" x="0" y="0" width="1200" height="880"/>
-  <text class="ttl" x="24" y="32">Wykrywanie zapłonu · uśpienie do S3 · wybudzanie</text>
-  <text class="sub" x="24" y="54">Wariant testowo-rozwojowy. M910q jest zasilany stale — zapłon jest wyłącznie sygnałem. Tor zasilania: schematic_test_build.svg</text>
-  <line x1="24" y1="66" x2="1176" y2="66" stroke="#c8d2da" stroke-width="1.5"/>
+  <rect class="bg" x="0" y="0" width="1240" height="1120"/>
+  <text class="ttl" x="24" y="32">Zapłon → uśpienie i wybudzenie M910q</text>
+  <text class="sub" x="24" y="54">Arduino czyta zapłon i „naciska” fizyczny przycisk zasilania. Bez własnego protokołu, bez zmian po stronie hosta. Tor zasilania: schematic_test_build.svg</text>
+  <line x1="24" y1="66" x2="1216" y2="66" stroke="#c8d2da" stroke-width="1.5"/>
 
-  <!-- ============ CIRCUIT ============ -->
-  <text class="sec" x="24" y="96">UKŁAD WEJŚCIOWY — IZOLACJA OPTYCZNA</text>
+  <!-- ============ A. INPUT ============ -->
+  <text class="sec" x="24" y="96">A · WEJŚCIE — SYGNAŁ ZAPŁONU (optoizolowany)</text>
 
-  <!-- ACC source -->
   <circle class="sym" cx="64" cy="180" r="7" fill="#ffffff"/>
   <text class="lbb" x="64" y="152">ACC / zapłon</text>
   <text class="lbc" x="64" y="166">12 V</text>
   <line class="wp" x1="71" y1="180" x2="132" y2="180"/>
 
-  <!-- R1 -->
   <use xlink:href="#res" x="132" y="180"/>
   <text class="lbb" x="160" y="164">R1</text>
   <text class="lbc" x="160" y="212">2,2 kΩ</text>
   <text class="lbc" x="160" y="226">0,25 W</text>
   <line class="wp" x1="188" y1="180" x2="242" y2="180"/>
 
-  <!-- optocoupler PC817 -->
   <rect class="iso" x="242" y="128" width="180" height="180"/>
   <text class="lbb" x="332" y="120">U1 · PC817</text>
 
-  <!-- LED side -->
   <line class="ws" x1="242" y1="180" x2="272" y2="180"/>
   <path class="symf" d="M272 168 L272 192 L292 180 Z"/>
   <line class="ws" x1="292" y1="168" x2="292" y2="192"/>
@@ -92,7 +88,6 @@
   <use xlink:href="#gnd" x="200" y="286"/>
   <text class="lbl" x="120" y="292" text-anchor="end">masa instalacji auta</text>
 
-  <!-- phototransistor side -->
   <line class="ws" x1="374" y1="150" x2="374" y2="168"/>
   <text class="lbc" x="388" y="146">4</text>
   <path class="ws" d="M374 168 L374 210"/>
@@ -101,18 +96,16 @@
   <line class="ws" x1="374" y1="210" x2="374" y2="252"/>
   <text class="lbc" x="388" y="272">3</text>
   <line class="wg" x1="374" y1="252" x2="374" y2="330"/>
-
   <line class="ws" x1="374" y1="150" x2="374" y2="140"/>
   <line class="ws" x1="374" y1="140" x2="504" y2="140"/>
 
-  <!-- pull-up + node -->
   <circle class="symf" cx="504" cy="140" r="3"/>
   <use xlink:href="#resV" x="504" y="84"/>
   <text class="lbl" x="450" y="104" text-anchor="end">R2</text>
   <text class="lbl" x="450" y="118" text-anchor="end">10 kΩ (opc.)</text>
   <line class="wp" x1="504" y1="84" x2="504" y2="76"/>
   <line class="wp" x1="452" y1="76" x2="556" y2="76"/>
-  <text class="lbl" x="564" y="80">+5 V z Pro Micro</text>
+  <text class="lbl" x="564" y="80">+5 V Pro Micro</text>
 
   <line class="ws" x1="504" y1="140" x2="576" y2="140"/>
   <circle class="symf" cx="576" cy="140" r="3"/>
@@ -120,100 +113,147 @@
   <text class="lbl" x="590" y="164">C2 · 100 nF</text>
   <line class="wg" x1="576" y1="171" x2="576" y2="330"/>
 
-  <!-- Pro Micro -->
   <line class="ws" x1="576" y1="140" x2="660" y2="140"/>
-  <rect class="blkb" x="660" y="104" width="212" height="128"/>
-  <text class="lbb" x="766" y="128">Arduino Pro Micro</text>
-  <text class="lbc" x="766" y="148">wejście D0 (RXI)</text>
-  <text class="lbc" x="766" y="168">pinMode(D0, INPUT_PULLUP)</text>
-  <text class="lbc" x="766" y="192">LOW  = zapłon ON</text>
-  <text class="lbc" x="766" y="210">HIGH = zapłon OFF</text>
-  <line class="wg" x1="766" y1="232" x2="766" y2="330"/>
+  <rect class="blkb" x="660" y="104" width="240" height="188"/>
+  <text class="lbb" x="780" y="128">Arduino Pro Micro</text>
+  <text class="lbc" x="780" y="150">D0 (RXI) — wejście zapłonu</text>
+  <text class="lbc" x="780" y="168">INPUT_PULLUP · LOW = zapłon ON</text>
+  <line x1="676" y1="184" x2="884" y2="184" stroke="#c8d2da"/>
+  <text class="lbc" x="780" y="206">A2 — wyjście na przekaźnik</text>
+  <text class="lbc" x="780" y="224">impuls 250 ms = krótkie wciśnięcie</text>
+  <text class="lbc" x="780" y="242">impuls 5 s = twarde wyłączenie</text>
+  <text class="lbc" x="780" y="272">zasilanie: 5 V z MP1584, nie z USB</text>
+  <line class="wg" x1="780" y1="292" x2="780" y2="330"/>
 
-  <!-- ground bus -->
-  <line class="wg" x1="374" y1="330" x2="766" y2="330"/>
-  <use xlink:href="#gnd" x="570" y="330"/>
-  <text class="lbl" x="592" y="348">masa Pro Micro (przez USB M910q)</text>
+  <line class="wg" x1="374" y1="330" x2="780" y2="330"/>
+  <use xlink:href="#gnd" x="578" y="330"/>
+  <text class="lbl" x="600" y="348">masa Pro Micro</text>
 
-  <!-- USB to M910q -->
-  <line class="ws" x1="872" y1="168" x2="924" y2="168"/>
-  <path class="symf" d="M924 162 L924 174 L936 168 Z"/>
-  <text class="lbc" x="898" y="158">USB</text>
-  <rect class="blk" x="936" y="104" width="228" height="128"/>
-  <text class="lbb" x="1050" y="128">M910q</text>
-  <text class="lbc" x="1050" y="150">zasilany stale z bufora</text>
-  <text class="lbc" x="1050" y="172">S3 ⇄ praca</text>
-  <text class="lbc" x="1050" y="196">Wake on USB = Enabled</text>
-  <text class="lbc" x="1050" y="214">(BIOS, §6.2 WDROZENIE_M910Q)</text>
+  <text class="lbl" x="930" y="150">A2 →</text>
+  <path class="wd" d="M900 168 L1224 168 L1224 414"/>
 
-  <line x1="24" y1="376" x2="1176" y2="376" stroke="#e2e8ed" stroke-width="1.5"/>
+  <line x1="24" y1="376" x2="1216" y2="376" stroke="#e2e8ed" stroke-width="1.5"/>
 
-  <!-- ============ SEQUENCE ============ -->
-  <text class="sec" x="24" y="406">PRZEBIEG — CO SIĘ DZIEJE PO PRZEKRĘCENIU KLUCZYKA</text>
+  <!-- ============ B. OUTPUT ============ -->
+  <text class="sec" x="24" y="406">B · WYJŚCIE — RÓWNOLEGLE DO PRZYCISKU ZASILANIA M910q</text>
 
-  <rect class="blk" x="24" y="426" width="256" height="118"/>
-  <text class="lbb" x="152" y="450">Kluczyk → ON</text>
-  <text class="lbc" x="152" y="472">D0 przechodzi w LOW</text>
-  <text class="lbc" x="152" y="492">Pro Micro wysyła dowolny</text>
-  <text class="lbc" x="152" y="510">klawisz HID</text>
-  <text class="lbc" x="152" y="530">M910q wraca z S3 w ~3 s</text>
+  <rect class="blkg" x="24" y="426" width="236" height="142"/>
+  <text class="lbb" x="142" y="450">Moduł przekaźnika 1-kan.</text>
+  <text class="lbc" x="142" y="470">5 V, z optoizolacją</text>
+  <text class="lbc" x="142" y="494">IN · VCC · GND</text>
+  <text class="lbc" x="142" y="512">COM · NO</text>
+  <text class="lbc" x="142" y="538">wiele modułów wyzwala się</text>
+  <text class="lbc" x="142" y="554">stanem NISKIM — sprawdź swój</text>
+  <line class="wd" x1="1224" y1="414" x2="270" y2="414"/>
+  <path class="wd" d="M270 414 L270 458"/>
+  <line class="ws" x1="260" y1="458" x2="270" y2="458"/>
+  <text class="lbl" x="276" y="446">z A2</text>
 
-  <path class="wd" d="M280 486 L318 486"/>
-  <path class="symf" d="M318 480 L318 492 L330 486 Z"/>
+  <line class="ws" x1="260" y1="512" x2="330" y2="512"/>
+  <line class="ws" x1="330" y1="512" x2="330" y2="480"/>
+  <line class="ws" x1="330" y1="480" x2="400" y2="480"/>
+  <line class="ws" x1="260" y1="530" x2="310" y2="530"/>
+  <line class="ws" x1="310" y1="530" x2="310" y2="560"/>
+  <line class="ws" x1="310" y1="560" x2="400" y2="560"/>
+  <text class="lbl" x="336" y="472">COM</text>
+  <text class="lbl" x="316" y="578">NO</text>
 
-  <rect class="blk" x="336" y="426" width="256" height="118"/>
-  <text class="lbb" x="464" y="450">Praca</text>
-  <text class="lbc" x="464" y="472">bcm-resume.service</text>
-  <text class="lbc" x="464" y="492">przepina huby USB</text>
-  <text class="lbc" x="464" y="510">i startuje bcm-headunit</text>
-  <text class="lbc" x="464" y="530">(§9.3 WDROZENIE_M910Q)</text>
+  <!-- power button block -->
+  <rect class="blk" x="400" y="426" width="300" height="176"/>
+  <text class="lbb" x="550" y="450">M910q — przycisk zasilania</text>
+  <text class="lbc" x="550" y="468">płytka panelu przedniego</text>
+  <circle class="symf" cx="440" cy="480" r="4"/>
+  <circle class="symf" cx="440" cy="560" r="4"/>
+  <line class="ws" x1="440" y1="480" x2="490" y2="480"/>
+  <line class="ws" x1="440" y1="560" x2="490" y2="560"/>
+  <line class="ws" x1="490" y1="480" x2="490" y2="500"/>
+  <line class="ws" x1="490" y1="560" x2="490" y2="540"/>
+  <circle class="symf" cx="490" cy="500" r="3"/>
+  <circle class="symf" cx="490" cy="540" r="3"/>
+  <line class="ws" x1="490" y1="500" x2="522" y2="516"/>
+  <text class="lbc" x="604" y="548">przycisk chwilowy (NO)</text>
+  <text class="lbc" x="550" y="580">styki przekaźnika wpięte RÓWNOLEGLE</text>
 
-  <path class="wd" d="M592 486 L630 486"/>
-  <path class="symf" d="M630 480 L630 492 L642 486 Z"/>
+  <rect class="blkb" x="760" y="426" width="256" height="176"/>
+  <text class="lbb" x="888" y="450">Co robi krótkie wciśnięcie</text>
+  <text class="lbc" x="888" y="476">praca  →  S3</text>
+  <text class="lbc" x="888" y="496">S3  →  praca (~3 s)</text>
+  <text class="lbc" x="888" y="516">wyłączony  →  start</text>
+  <line x1="778" y1="534" x2="998" y2="534" stroke="#c8d2da"/>
+  <text class="lbc" x="888" y="556">przytrzymanie &gt; 4 s:</text>
+  <text class="lbc" x="888" y="576">twarde wyłączenie</text>
 
-  <rect class="blk" x="648" y="426" width="256" height="118"/>
-  <text class="lbb" x="776" y="450">Kluczyk → OFF</text>
-  <text class="lbc" x="776" y="472">D0 wraca do HIGH</text>
-  <text class="lbc" x="776" y="492">Pro Micro sygnalizuje</text>
-  <text class="lbc" x="776" y="510">hostowi „usypiaj”</text>
-  <text class="lbc" x="776" y="530">— tego jeszcze NIE MA</text>
+  <text class="lbl" x="1040" y="452">Ścieżkę „praca → S3” obsługuje</text>
+  <text class="lbl" x="1040" y="470">już acpid:</text>
+  <text class="lbl" x="1040" y="492">event=button/power</text>
+  <text class="lbl" x="1040" y="510">→ bcm-power-toggle.sh</text>
+  <text class="lbl" x="1040" y="532">plus HandlePowerKey=ignore</text>
+  <text class="lbl" x="1040" y="550">w logind.conf.</text>
+  <text class="lbl" x="1040" y="576">§7.3 WDROZENIE_M910Q</text>
 
-  <path class="wd" d="M904 486 L942 486"/>
-  <path class="symf" d="M942 480 L942 492 L954 486 Z"/>
+  <line x1="24" y1="632" x2="1216" y2="632" stroke="#e2e8ed" stroke-width="1.5"/>
 
-  <rect class="blk" x="960" y="426" width="216" height="118"/>
-  <text class="lbb" x="1068" y="450">S3</text>
-  <text class="lbc" x="1068" y="472">bcm-power-toggle.sh</text>
-  <text class="lbc" x="1068" y="492">odpina modem LTE</text>
-  <text class="lbc" x="1068" y="510">i robi systemctl suspend</text>
-  <text class="lbc" x="1068" y="530">pobór 240–480 mA</text>
+  <!-- ============ C. SEQUENCE ============ -->
+  <text class="sec" x="24" y="662">C · PRZEBIEG</text>
+
+  <rect class="blk" x="24" y="682" width="272" height="112"/>
+  <text class="lbb" x="160" y="706">Kluczyk → ON</text>
+  <text class="lbc" x="160" y="728">D0 w LOW (debounce 2 s)</text>
+  <text class="lbc" x="160" y="748">A2: impuls 250 ms</text>
+  <text class="lbc" x="160" y="770">M910q wstaje z S3 w ~3 s</text>
+
+  <path class="wd" d="M296 738 L330 738"/><path class="symf" d="M330 732 L330 744 L342 738 Z"/>
+
+  <rect class="blk" x="352" y="682" width="272" height="112"/>
+  <text class="lbb" x="488" y="706">Kluczyk → OFF</text>
+  <text class="lbc" x="488" y="728">D0 w HIGH (debounce 2 s)</text>
+  <text class="lbc" x="488" y="748">A2: impuls 250 ms</text>
+  <text class="lbc" x="488" y="770">acpid → suspend, pobór ~300 mA</text>
+
+  <path class="wd" d="M624 738 L658 738"/><path class="symf" d="M658 732 L658 744 L670 738 Z"/>
+
+  <rect class="blk" x="680" y="682" width="272" height="112"/>
+  <text class="lbb" x="816" y="706">Postój &gt; 2 h</text>
+  <text class="lbc" x="816" y="728">A2: impuls 5 s</text>
+  <text class="lbc" x="816" y="748">twarde wyłączenie</text>
+  <text class="lbc" x="816" y="770">pobór spada do ~80–120 mA</text>
+
+  <path class="wd" d="M952 738 L986 738"/><path class="symf" d="M986 732 L986 744 L998 738 Z"/>
+
+  <rect class="blk" x="1008" y="682" width="208" height="112"/>
+  <text class="lbb" x="1112" y="706">Powrót</text>
+  <text class="lbc" x="1112" y="728">impuls 250 ms</text>
+  <text class="lbc" x="1112" y="748">zimny start</text>
+  <text class="lbc" x="1112" y="770">~40 s zamiast 3 s</text>
 
   <!-- ============ NOTES ============ -->
-  <rect class="warn" x="24" y="578" width="568" height="128"/>
-  <text class="wh" x="40" y="602">Zmierz to, zanim napiszesz choćby linijkę firmware'u</text>
-  <text class="wt" x="40" y="626">Czy porty USB M910q mają zasilanie w S3? Jeśli nie, Pro Micro gaśnie razem</text>
-  <text class="wt" x="40" y="644">z komputerem i nie ma go czym wybudzić — zestaw zostaje w S3 aż do odcięcia</text>
-  <text class="wt" x="40" y="662">przez LVD. Sprawdzenie: multimetr na 5 V portu po wejściu maszyny w S3.</text>
-  <text class="wt" x="40" y="686">Ratunek awaryjny w każdym przypadku: przycisk zasilania M910q.</text>
+  <rect class="good" x="24" y="820" width="580" height="128"/>
+  <text class="gh" x="40" y="844">Dlaczego to jest prostsze niż wysyłanie klawiszy HID</text>
+  <text class="nt" x="40" y="868">• Ścieżka po stronie hosta JUŻ ISTNIEJE — acpid + bcm-power-toggle.sh.</text>
+  <text class="nt" x="40" y="886">   Nie trzeba dopisywać ani linijki w BCM.</text>
+  <text class="nt" x="40" y="906">• Jeden impuls obsługuje oba kierunki: usypia i wybudza.</text>
+  <text class="nt" x="40" y="926">• Wybudzenie nie zależy od „Wake on USB” — przycisk działa zawsze.</text>
 
-  <rect class="note" x="608" y="578" width="568" height="128"/>
-  <text class="nh" x="624" y="602">Czego brakuje w kodzie (stan na dziś)</text>
-  <text class="nt" x="624" y="626">1.  Sketch rotary_encoder nie ma wejścia zapłonu — D0 (RXI) to jedyny wolny pin.</text>
-  <text class="nt" x="624" y="646">2.  Nic nie publikuje `hal.ignition` na x86.</text>
-  <text class="nt" x="624" y="666">3.  PowerManager na `hal.ignition = false` idzie do STANDBY (gasi podświetlenie),</text>
-  <text class="nt" x="624" y="684">     ale NIE woła `systemctl suspend` — to robi bcm-power-toggle.sh przez acpid.</text>
+  <rect class="warn" x="624" y="820" width="592" height="128"/>
+  <text class="wh" x="640" y="844">Dwie rzeczy, które trzeba zrobić, żeby to zadziałało</text>
+  <text class="wt" x="640" y="868">1.  Pro Micro musi mieć WŁASNE 5 V (MP1584 z bufora), inaczej gaśnie</text>
+  <text class="wt" x="640" y="886">     razem z komputerem i nie ma czym nacisnąć. Przetnij żyłę VBUS w kablu</text>
+  <text class="wt" x="640" y="904">     USB — dwa źródła 5 V zwarte razem to proszenie się o kłopoty.</text>
+  <text class="wt" x="640" y="926">2.  Znajdź zaciski przycisku miernikiem: rozwarte, zwarte przy wciśnięciu.</text>
 
-  <rect class="note" x="24" y="726" width="568" height="128"/>
-  <text class="nh" x="40" y="750">Dlaczego optoizolacja, a nie dzielnik</text>
-  <text class="nt" x="40" y="774">Masa Pro Micro to masa USB M910q. Podanie na nią sygnału wprost z instalacji</text>
-  <text class="nt" x="40" y="792">auta wpuszcza do komputera wszystko, co jeździ po linii ACC — rozruch, cewki,</text>
-  <text class="nt" x="40" y="810">alternator. PC817 rozdziela te dwie masy całkowicie, a kosztuje kilka złotych.</text>
-  <text class="nt" x="40" y="834">Wariant bez izolacji (dzielnik 10 k / 4,7 k + zener 5,1 V) działa, ale nie warto.</text>
+  <rect class="note" x="24" y="968" width="580" height="128"/>
+  <text class="nh" x="40" y="992">Układ jest otwarty — Arduino nie wie, czy maszyna śpi</text>
+  <text class="nt" x="40" y="1016">Pulsujemy na ZMIANĘ stanu zapłonu, nie cyklicznie, więc rozjazd wymaga</text>
+  <text class="nt" x="40" y="1034">zdarzenia z zewnątrz (ręczne wciśnięcie, zawieszenie). Wtedy kolejny cykl</text>
+  <text class="nt" x="40" y="1052">kluczyka wraca do synchronizacji.</text>
+  <text class="nt" x="40" y="1076">Domknięcie pętli: wejście z diody zasilania panelu przedniego (świeci = praca,</text>
+  <text class="nt" x="40" y="1090">miga = S3). Jeden przewód więcej, za to stan czytany, a nie zakładany.</text>
 
-  <rect class="note" x="608" y="726" width="568" height="128"/>
-  <text class="nh" x="624" y="750">Dobór R1</text>
-  <text class="nt" x="624" y="774">Prąd diody U1: (12 V − 1,2 V) / 2,2 kΩ ≈ 4,9 mA, a przy pracującym alternatorze</text>
-  <text class="nt" x="624" y="792">(14,4 V) ≈ 6,0 mA. PC817 przy 5 mA ma CTR 50–600 %, więc tranzystor nasyca się</text>
-  <text class="nt" x="624" y="810">z ogromnym zapasem. Straty na R1: ok. 0,08 W — rezystor 0,25 W wystarcza.</text>
-  <text class="nt" x="624" y="834">C2 100 nF tłumi szpilki z linii ACC; R2 dubluje wewnętrzny pull-up ATmega32U4.</text>
+  <rect class="note" x="624" y="968" width="592" height="128"/>
+  <text class="nh" x="640" y="992">Piny Pro Micro — skąd wziąć A2</text>
+  <text class="nt" x="640" y="1016">A2 jest dziś zajęte przez przycisk dźwigni „brightness cycle”, który wysyła F9</text>
+  <text class="nt" x="640" y="1034">— a F9 nie ma odbiorcy, bo BrightnessController nie jest nigdzie tworzony</text>
+  <text class="nt" x="640" y="1052">(WDROZENIE_TESTOWE §3.1c). Pin jest więc wolny w praktyce, nie tylko na papierze.</text>
+  <text class="nt" x="640" y="1076">Gdy dojdzie Nano #1 i regulacja jasności, przenieś sterowanie przyciskiem</text>
+  <text class="nt" x="640" y="1090">zasilania na Nano — ma wolnych pinów pod dostatkiem.</text>
 </svg>

--- a/schematics/ignition_sense.svg
+++ b/schematics/ignition_sense.svg
@@ -1,0 +1,219 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1200" height="880" viewBox="0 0 1200 880" font-family="DejaVu Sans, Verdana, sans-serif">
+  <title>BCM v8.5 — wykrywanie zapłonu, uśpienie do S3 i wybudzanie (M910q)</title>
+  <style>
+    .bg   { fill: #ffffff; }
+    .wp   { stroke: #c0392b; stroke-width: 2.4; fill: none; stroke-linecap: round; }
+    .ws   { stroke: #1b2b36; stroke-width: 2; fill: none; stroke-linecap: round; }
+    .wg   { stroke: #46586a; stroke-width: 2; fill: none; stroke-linecap: round; }
+    .wd   { stroke: #7a8b99; stroke-width: 1.6; fill: none; stroke-dasharray: 5 4; }
+    .sym  { stroke: #1b2b36; stroke-width: 2; fill: none; }
+    .symf { stroke: #1b2b36; stroke-width: 2; fill: #1b2b36; }
+    .iso  { fill: none; stroke: #9a6b12; stroke-width: 2; stroke-dasharray: 7 5; rx: 6; }
+    .blk  { fill: #f7f9fb; stroke: #2b3a45; stroke-width: 2; rx: 4; }
+    .blkb { fill: #eef2fa; stroke: #2b4a8a; stroke-width: 2; rx: 4; }
+    .note { fill: #fbfcfd; stroke: #c8d2da; stroke-width: 1.5; rx: 5; }
+    .warn { fill: #fdf2f2; stroke: #a8321a; stroke-width: 1.8; rx: 5; }
+    .ttl  { font-size: 19px; font-weight: bold; fill: #10202b; }
+    .sub  { font-size: 12px; fill: #5a6b78; }
+    .sec  { font-size: 13px; font-weight: bold; fill: #2b4a8a; letter-spacing: 0.5px; }
+    .lbl  { font-size: 11px; fill: #33424e; }
+    .lbc  { font-size: 11px; fill: #33424e; text-anchor: middle; }
+    .lbb  { font-size: 11.5px; font-weight: bold; fill: #10202b; text-anchor: middle; }
+    .ref  { font-size: 11.5px; font-weight: bold; fill: #a8321a; }
+    .nh   { font-size: 12.5px; font-weight: bold; fill: #10202b; }
+    .nt   { font-size: 11px; fill: #4a5a66; }
+    .wh   { font-size: 12.5px; font-weight: bold; fill: #a8321a; }
+    .wt   { font-size: 11px; fill: #7a3020; }
+  </style>
+
+  <defs>
+    <g id="gnd">
+      <line class="wg" x1="0" y1="0" x2="0" y2="8"/>
+      <line class="wg" x1="-13" y1="8" x2="13" y2="8"/>
+      <line class="wg" x1="-8" y1="13" x2="8" y2="13"/>
+      <line class="wg" x1="-3" y1="18" x2="3" y2="18"/>
+    </g>
+    <!-- resistor, horizontal, origin left lead -->
+    <g id="res">
+      <line class="sym" x1="0" y1="0" x2="8" y2="0"/>
+      <rect class="sym" x="8" y="-9" width="40" height="18" fill="#ffffff"/>
+      <line class="sym" x1="48" y1="0" x2="56" y2="0"/>
+    </g>
+    <!-- resistor, vertical, origin top lead -->
+    <g id="resV">
+      <line class="sym" x1="0" y1="0" x2="0" y2="8"/>
+      <rect class="sym" x="-9" y="8" width="18" height="40" fill="#ffffff"/>
+      <line class="sym" x1="0" y1="48" x2="0" y2="56"/>
+    </g>
+    <g id="capV">
+      <line class="sym" x1="0" y1="0" x2="0" y2="12"/>
+      <line class="sym" x1="-10" y1="12" x2="10" y2="12"/>
+      <line class="sym" x1="-10" y1="19" x2="10" y2="19"/>
+      <line class="sym" x1="0" y1="19" x2="0" y2="31"/>
+    </g>
+  </defs>
+
+  <rect class="bg" x="0" y="0" width="1200" height="880"/>
+  <text class="ttl" x="24" y="32">Wykrywanie zapłonu · uśpienie do S3 · wybudzanie</text>
+  <text class="sub" x="24" y="54">Wariant testowo-rozwojowy. M910q jest zasilany stale — zapłon jest wyłącznie sygnałem. Tor zasilania: schematic_test_build.svg</text>
+  <line x1="24" y1="66" x2="1176" y2="66" stroke="#c8d2da" stroke-width="1.5"/>
+
+  <!-- ============ CIRCUIT ============ -->
+  <text class="sec" x="24" y="96">UKŁAD WEJŚCIOWY — IZOLACJA OPTYCZNA</text>
+
+  <!-- ACC source -->
+  <circle class="sym" cx="64" cy="180" r="7" fill="#ffffff"/>
+  <text class="lbb" x="64" y="152">ACC / zapłon</text>
+  <text class="lbc" x="64" y="166">12 V</text>
+  <line class="wp" x1="71" y1="180" x2="132" y2="180"/>
+
+  <!-- R1 -->
+  <use xlink:href="#res" x="132" y="180"/>
+  <text class="lbb" x="160" y="164">R1</text>
+  <text class="lbc" x="160" y="212">2,2 kΩ</text>
+  <text class="lbc" x="160" y="226">0,25 W</text>
+  <line class="wp" x1="188" y1="180" x2="242" y2="180"/>
+
+  <!-- optocoupler PC817 -->
+  <rect class="iso" x="242" y="128" width="180" height="180"/>
+  <text class="lbb" x="332" y="120">U1 · PC817</text>
+
+  <!-- LED side -->
+  <line class="ws" x1="242" y1="180" x2="272" y2="180"/>
+  <path class="symf" d="M272 168 L272 192 L292 180 Z"/>
+  <line class="ws" x1="292" y1="168" x2="292" y2="192"/>
+  <line class="ws" x1="292" y1="180" x2="292" y2="252"/>
+  <path class="ws" d="M298 162 L310 150 M304 150 L310 150 L310 156"/>
+  <path class="ws" d="M306 174 L318 162 M312 162 L318 162 L318 168"/>
+  <text class="lbc" x="278" y="146">1</text>
+  <text class="lbc" x="278" y="270">2</text>
+  <line class="wg" x1="292" y1="252" x2="292" y2="286"/>
+  <line class="wg" x1="292" y1="286" x2="200" y2="286"/>
+  <use xlink:href="#gnd" x="200" y="286"/>
+  <text class="lbl" x="120" y="292" text-anchor="end">masa instalacji auta</text>
+
+  <!-- phototransistor side -->
+  <line class="ws" x1="374" y1="150" x2="374" y2="168"/>
+  <text class="lbc" x="388" y="146">4</text>
+  <path class="ws" d="M374 168 L374 210"/>
+  <line class="ws" x1="360" y1="172" x2="360" y2="206"/>
+  <path class="ws" d="M360 180 L374 172 M360 198 L374 206"/>
+  <line class="ws" x1="374" y1="210" x2="374" y2="252"/>
+  <text class="lbc" x="388" y="272">3</text>
+  <line class="wg" x1="374" y1="252" x2="374" y2="330"/>
+
+  <line class="ws" x1="374" y1="150" x2="374" y2="140"/>
+  <line class="ws" x1="374" y1="140" x2="504" y2="140"/>
+
+  <!-- pull-up + node -->
+  <circle class="symf" cx="504" cy="140" r="3"/>
+  <use xlink:href="#resV" x="504" y="84"/>
+  <text class="lbl" x="450" y="104" text-anchor="end">R2</text>
+  <text class="lbl" x="450" y="118" text-anchor="end">10 kΩ (opc.)</text>
+  <line class="wp" x1="504" y1="84" x2="504" y2="76"/>
+  <line class="wp" x1="452" y1="76" x2="556" y2="76"/>
+  <text class="lbl" x="564" y="80">+5 V z Pro Micro</text>
+
+  <line class="ws" x1="504" y1="140" x2="576" y2="140"/>
+  <circle class="symf" cx="576" cy="140" r="3"/>
+  <use xlink:href="#capV" x="576" y="140"/>
+  <text class="lbl" x="590" y="164">C2 · 100 nF</text>
+  <line class="wg" x1="576" y1="171" x2="576" y2="330"/>
+
+  <!-- Pro Micro -->
+  <line class="ws" x1="576" y1="140" x2="660" y2="140"/>
+  <rect class="blkb" x="660" y="104" width="212" height="128"/>
+  <text class="lbb" x="766" y="128">Arduino Pro Micro</text>
+  <text class="lbc" x="766" y="148">wejście D0 (RXI)</text>
+  <text class="lbc" x="766" y="168">pinMode(D0, INPUT_PULLUP)</text>
+  <text class="lbc" x="766" y="192">LOW  = zapłon ON</text>
+  <text class="lbc" x="766" y="210">HIGH = zapłon OFF</text>
+  <line class="wg" x1="766" y1="232" x2="766" y2="330"/>
+
+  <!-- ground bus -->
+  <line class="wg" x1="374" y1="330" x2="766" y2="330"/>
+  <use xlink:href="#gnd" x="570" y="330"/>
+  <text class="lbl" x="592" y="348">masa Pro Micro (przez USB M910q)</text>
+
+  <!-- USB to M910q -->
+  <line class="ws" x1="872" y1="168" x2="924" y2="168"/>
+  <path class="symf" d="M924 162 L924 174 L936 168 Z"/>
+  <text class="lbc" x="898" y="158">USB</text>
+  <rect class="blk" x="936" y="104" width="228" height="128"/>
+  <text class="lbb" x="1050" y="128">M910q</text>
+  <text class="lbc" x="1050" y="150">zasilany stale z bufora</text>
+  <text class="lbc" x="1050" y="172">S3 ⇄ praca</text>
+  <text class="lbc" x="1050" y="196">Wake on USB = Enabled</text>
+  <text class="lbc" x="1050" y="214">(BIOS, §6.2 WDROZENIE_M910Q)</text>
+
+  <line x1="24" y1="376" x2="1176" y2="376" stroke="#e2e8ed" stroke-width="1.5"/>
+
+  <!-- ============ SEQUENCE ============ -->
+  <text class="sec" x="24" y="406">PRZEBIEG — CO SIĘ DZIEJE PO PRZEKRĘCENIU KLUCZYKA</text>
+
+  <rect class="blk" x="24" y="426" width="256" height="118"/>
+  <text class="lbb" x="152" y="450">Kluczyk → ON</text>
+  <text class="lbc" x="152" y="472">D0 przechodzi w LOW</text>
+  <text class="lbc" x="152" y="492">Pro Micro wysyła dowolny</text>
+  <text class="lbc" x="152" y="510">klawisz HID</text>
+  <text class="lbc" x="152" y="530">M910q wraca z S3 w ~3 s</text>
+
+  <path class="wd" d="M280 486 L318 486"/>
+  <path class="symf" d="M318 480 L318 492 L330 486 Z"/>
+
+  <rect class="blk" x="336" y="426" width="256" height="118"/>
+  <text class="lbb" x="464" y="450">Praca</text>
+  <text class="lbc" x="464" y="472">bcm-resume.service</text>
+  <text class="lbc" x="464" y="492">przepina huby USB</text>
+  <text class="lbc" x="464" y="510">i startuje bcm-headunit</text>
+  <text class="lbc" x="464" y="530">(§9.3 WDROZENIE_M910Q)</text>
+
+  <path class="wd" d="M592 486 L630 486"/>
+  <path class="symf" d="M630 480 L630 492 L642 486 Z"/>
+
+  <rect class="blk" x="648" y="426" width="256" height="118"/>
+  <text class="lbb" x="776" y="450">Kluczyk → OFF</text>
+  <text class="lbc" x="776" y="472">D0 wraca do HIGH</text>
+  <text class="lbc" x="776" y="492">Pro Micro sygnalizuje</text>
+  <text class="lbc" x="776" y="510">hostowi „usypiaj”</text>
+  <text class="lbc" x="776" y="530">— tego jeszcze NIE MA</text>
+
+  <path class="wd" d="M904 486 L942 486"/>
+  <path class="symf" d="M942 480 L942 492 L954 486 Z"/>
+
+  <rect class="blk" x="960" y="426" width="216" height="118"/>
+  <text class="lbb" x="1068" y="450">S3</text>
+  <text class="lbc" x="1068" y="472">bcm-power-toggle.sh</text>
+  <text class="lbc" x="1068" y="492">odpina modem LTE</text>
+  <text class="lbc" x="1068" y="510">i robi systemctl suspend</text>
+  <text class="lbc" x="1068" y="530">pobór 240–480 mA</text>
+
+  <!-- ============ NOTES ============ -->
+  <rect class="warn" x="24" y="578" width="568" height="128"/>
+  <text class="wh" x="40" y="602">Zmierz to, zanim napiszesz choćby linijkę firmware'u</text>
+  <text class="wt" x="40" y="626">Czy porty USB M910q mają zasilanie w S3? Jeśli nie, Pro Micro gaśnie razem</text>
+  <text class="wt" x="40" y="644">z komputerem i nie ma go czym wybudzić — zestaw zostaje w S3 aż do odcięcia</text>
+  <text class="wt" x="40" y="662">przez LVD. Sprawdzenie: multimetr na 5 V portu po wejściu maszyny w S3.</text>
+  <text class="wt" x="40" y="686">Ratunek awaryjny w każdym przypadku: przycisk zasilania M910q.</text>
+
+  <rect class="note" x="608" y="578" width="568" height="128"/>
+  <text class="nh" x="624" y="602">Czego brakuje w kodzie (stan na dziś)</text>
+  <text class="nt" x="624" y="626">1.  Sketch rotary_encoder nie ma wejścia zapłonu — D0 (RXI) to jedyny wolny pin.</text>
+  <text class="nt" x="624" y="646">2.  Nic nie publikuje `hal.ignition` na x86.</text>
+  <text class="nt" x="624" y="666">3.  PowerManager na `hal.ignition = false` idzie do STANDBY (gasi podświetlenie),</text>
+  <text class="nt" x="624" y="684">     ale NIE woła `systemctl suspend` — to robi bcm-power-toggle.sh przez acpid.</text>
+
+  <rect class="note" x="24" y="726" width="568" height="128"/>
+  <text class="nh" x="40" y="750">Dlaczego optoizolacja, a nie dzielnik</text>
+  <text class="nt" x="40" y="774">Masa Pro Micro to masa USB M910q. Podanie na nią sygnału wprost z instalacji</text>
+  <text class="nt" x="40" y="792">auta wpuszcza do komputera wszystko, co jeździ po linii ACC — rozruch, cewki,</text>
+  <text class="nt" x="40" y="810">alternator. PC817 rozdziela te dwie masy całkowicie, a kosztuje kilka złotych.</text>
+  <text class="nt" x="40" y="834">Wariant bez izolacji (dzielnik 10 k / 4,7 k + zener 5,1 V) działa, ale nie warto.</text>
+
+  <rect class="note" x="608" y="726" width="568" height="128"/>
+  <text class="nh" x="624" y="750">Dobór R1</text>
+  <text class="nt" x="624" y="774">Prąd diody U1: (12 V − 1,2 V) / 2,2 kΩ ≈ 4,9 mA, a przy pracującym alternatorze</text>
+  <text class="nt" x="624" y="792">(14,4 V) ≈ 6,0 mA. PC817 przy 5 mA ma CTR 50–600 %, więc tranzystor nasyca się</text>
+  <text class="nt" x="624" y="810">z ogromnym zapasem. Straty na R1: ok. 0,08 W — rezystor 0,25 W wystarcza.</text>
+  <text class="nt" x="624" y="834">C2 100 nF tłumi szpilki z linii ACC; R2 dubluje wewnętrzny pull-up ATmega32U4.</text>
+</svg>

--- a/schematics/power_buffered_m910q.svg
+++ b/schematics/power_buffered_m910q.svg
@@ -43,7 +43,7 @@
   <!-- 3. SPLIT CHARGE -->
   <rect class="box" x="40" y="280" width="270" height="86"/>
   <text class="h" x="175" y="302">Rozdział ładowania</text>
-  <text class="t" x="175" y="320">VSR 12 V / 140 A (zał. 13,3 V, wył. 12,8 V)</text>
+  <text class="t" x="175" y="320">Przekaźnik 30 A z zapłonu + dioda MBR2545CT</text>
   <text class="t" x="175" y="336">— albo dioda Schottky MBR2045 —</text>
   <text class="t" x="175" y="352">blokuje oddawanie prądu do auta</text>
 
@@ -179,7 +179,7 @@
   <!-- Legend -->
   <rect x="430" y="740" width="330" height="200" fill="#fbfcfd" stroke="#c8d2da" stroke-width="1.5" rx="6"/>
   <text class="h" x="595" y="762">Przekroje i zabezpieczenia</text>
-  <text class="tl" x="446" y="784">akumulator → bezpiecznik → VSR</text>
+  <text class="tl" x="446" y="784">akumulator → bezpiecznik → przekaźnik</text>
   <text class="tl" x="700" y="784" text-anchor="end">6 mm²</text>
   <text class="tl" x="446" y="804">ładowarka → bank (do 6 A)</text>
   <text class="tl" x="700" y="804" text-anchor="end">2,5 mm²</text>

--- a/schematics/power_buffered_m910q.svg
+++ b/schematics/power_buffered_m910q.svg
@@ -128,7 +128,7 @@
 
   <!-- Ignition relay -->
   <rect class="box" x="800" y="560" width="330" height="104"/>
-  <text class="h" x="965" y="582">Przekaźnik zapłonu (domena B)</text>
+  <text class="h" x="965" y="582">Wyłącznik główny (szyna odbiorników)</text>
   <text class="t" x="965" y="600">Bosch 12 V / 30 A SPDT</text>
   <text class="t" x="965" y="618">cewka: linia ACC (kluczyk poz. I/II)</text>
   <text class="t" x="965" y="636">styk: szyna buforowana → step-up</text>

--- a/schematics/power_domains_m910q.svg
+++ b/schematics/power_domains_m910q.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1180" height="880" viewBox="0 0 1180 880" font-family="DejaVu Sans, Verdana, sans-serif">
-  <title>BCM v8.5 — Domeny zasilania A/B, rozdział obciążeń i bezpieczniki (M910q)</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="1180" height="900" viewBox="0 0 1180 900" font-family="DejaVu Sans, Verdana, sans-serif">
+  <title>BCM v8.5 — rozdział odbiorników, bezpieczniki i budżet poboru w trzech stanach (M910q)</title>
   <style>
     .bg   { fill: #ffffff; }
     .box  { fill: #f7f9fb; stroke: #2b3a45; stroke-width: 2; rx: 6; }
@@ -19,131 +19,128 @@
     .fuse { font-size: 10.5px; font-weight: bold; fill: #a8321a; text-anchor: middle; }
   </style>
 
-  <rect class="bg" x="0" y="0" width="1180" height="880"/>
-  <text class="ttl" x="24" y="32">Domeny zasilania A / B — rozdział obciążeń, bezpieczniki, przekaźniki</text>
-  <text class="sub" x="24" y="52">Domena A żyje z banku AGM przez cały postój. Domena B jest w pełni odcinana przekaźnikiem zapłonu — zero poboru na postoju.</text>
+  <rect class="bg" x="0" y="0" width="1180" height="900"/>
+  <text class="ttl" x="24" y="32">Rozdział odbiorników, bezpieczniki i budżet poboru</text>
+  <text class="sub" x="24" y="52">Jedna szyna buforowana — zapłon nie odcina niczego. Stan komputera zmienia impuls z Arduino na styki przycisku zasilania.</text>
   <line x1="24" y1="62" x2="1156" y2="62" stroke="#c8d2da" stroke-width="1.5"/>
 
   <!-- BUS -->
-  <rect class="box" x="410" y="86" width="360" height="58"/>
-  <text class="h" x="590" y="110">Szyna buforowana 12 V (za XH-M609)</text>
-  <text class="t" x="590" y="130">bank 5 × CSB HR1221W · 25,5 Ah · listwa dystrybucyjna z bezpiecznikami</text>
+  <rect class="box" x="360" y="86" width="460" height="62"/>
+  <text class="h" x="590" y="110">Szyna buforowana 12 V — za XH-M609 i wyłącznikiem głównym</text>
+  <text class="t" x="590" y="132">bank 5 × CSB HR1221W · 25,5 Ah · listwa dystrybucyjna z bezpiecznikami</text>
 
-  <path class="wire" d="M590 144 L590 176"/>
-  <path class="wire" d="M240 176 L940 176"/>
-  <path class="wA" d="M240 176 L240 214"/>
-  <path class="wB" d="M940 176 L940 214"/>
-  <circle cx="590" cy="176" r="4" fill="#c0392b"/>
+  <path class="wire" d="M590 148 L590 180"/>
+  <path class="wire" d="M240 180 L940 180"/>
+  <path class="wA" d="M240 180 L240 218"/>
+  <path class="wB" d="M940 180 L940 218"/>
+  <circle cx="590" cy="180" r="4" fill="#c0392b"/>
 
-  <!-- ============ DOMAIN A ============ -->
-  <text class="tb" x="70" y="204" fill="#2d6a2d" font-size="14">DOMENA A — zawsze zasilana</text>
-  <rect class="boxA" x="60" y="214" width="420" height="330"/>
+  <!-- ============ LOGIC ============ -->
+  <text class="tb" x="70" y="208" fill="#2d6a2d" font-size="14">LOGIKA I I/O POJAZDU — pobór stały</text>
+  <rect class="boxA" x="60" y="218" width="420" height="300"/>
 
-  <text class="fuse" x="240" y="236">bezpiecznik odgałęzienia 3 A</text>
+  <text class="fuse" x="240" y="240">bezpiecznik odgałęzienia 3 A</text>
 
-  <rect class="box" x="86" y="248" width="170" height="60"/>
-  <text class="h" x="171" y="270">Buck 12 → 5 V</text>
-  <text class="t" x="171" y="288">LM2596, min. 1 A</text>
-  <text class="t" x="171" y="302">zasilanie logiki</text>
+  <rect class="box" x="86" y="252" width="170" height="58"/>
+  <text class="h" x="171" y="274">Buck 12 → 5 V</text>
+  <text class="t" x="171" y="292">LM2596, min. 1 A</text>
+  <text class="t" x="171" y="306">zasilanie logiki</text>
 
-  <rect class="box" x="288" y="248" width="170" height="60"/>
-  <text class="h" x="373" y="270">Zasilanie 12 V</text>
-  <text class="t" x="373" y="288">wprost z szyny</text>
-  <text class="t" x="373" y="302">cewki przekaźników</text>
+  <rect class="box" x="288" y="252" width="170" height="58"/>
+  <text class="h" x="373" y="274">Zasilanie 12 V</text>
+  <text class="t" x="373" y="292">wprost z szyny</text>
+  <text class="t" x="373" y="306">cewki przekaźników</text>
 
-  <path class="wA" d="M240 236 L240 248"/>
-  <path class="wA" d="M171 308 L171 336"/>
-  <path class="wA" d="M373 308 L373 336"/>
+  <path class="wA" d="M240 240 L240 252"/>
+  <path class="wA" d="M171 310 L171 338"/>
+  <path class="wA" d="M373 310 L373 338"/>
 
-  <rect class="box" x="86" y="336" width="170" height="128"/>
-  <text class="h" x="171" y="358">Odbiorniki 5 V</text>
-  <text class="tl" x="98" y="380">Arduino Nano #1</text>
-  <text class="tl" x="98" y="398">Arduino Nano #2</text>
-  <text class="tl" x="98" y="416">HM-10 BLE</text>
-  <text class="tl" x="98" y="434">RXB6 433 MHz</text>
-  <text class="t" x="171" y="456">razem ~50 mA</text>
+  <rect class="box" x="86" y="338" width="170" height="128"/>
+  <text class="h" x="171" y="360">Odbiorniki 5 V</text>
+  <text class="tl" x="98" y="382">Arduino Nano #1</text>
+  <text class="tl" x="98" y="400">Arduino Nano #2</text>
+  <text class="tl" x="98" y="418">HM-10 BLE</text>
+  <text class="tl" x="98" y="436">RXB6 433 MHz</text>
+  <text class="t" x="171" y="458">razem ~50 mA</text>
 
-  <rect class="box" x="288" y="336" width="170" height="128"/>
-  <text class="h" x="373" y="358">Odbiorniki 12 V</text>
-  <text class="tl" x="300" y="380">moduł 9 przekaźników</text>
-  <text class="tl" x="300" y="398">— 4 szyby × 2 kierunki</text>
-  <text class="tl" x="300" y="416">— zamek bagażnika</text>
-  <text class="t" x="373" y="440">spoczynkowo ~10 mA</text>
-  <text class="t" x="373" y="456">(cewki tylko chwilowo)</text>
+  <rect class="box" x="288" y="338" width="170" height="128"/>
+  <text class="h" x="373" y="360">Odbiorniki 12 V</text>
+  <text class="tl" x="300" y="382">moduł 9 przekaźników</text>
+  <text class="tl" x="300" y="400">— 4 szyby × 2 kierunki</text>
+  <text class="tl" x="300" y="418">— zamek bagażnika</text>
+  <text class="t" x="373" y="442">spoczynkowo ~10 mA</text>
+  <text class="t" x="373" y="458">(cewki tylko chwilowo)</text>
 
-  <text class="tb" x="270" y="488" text-anchor="middle">Pobór spoczynkowy domeny A: ~60 mA (0,7 W)</text>
-  <text class="note" x="270" y="506" text-anchor="middle">Nano 25 mA + HM-10 15 mA + RXB6 5 mA</text>
-  <text class="note" x="270" y="520" text-anchor="middle">+ przekaźniki 10 mA + straty przetwornic 5 mA</text>
-  <text class="note" x="270" y="534" text-anchor="middle">Ten pobór wyznacza czas postoju — patrz tabela poniżej.</text>
+  <text class="tb" x="270" y="492" text-anchor="middle">Pobór stały: ~60 mA (0,7 W)</text>
+  <text class="note" x="270" y="510" text-anchor="middle">niezależnie od tego, czy komputer pracuje, śpi czy jest wyłączony</text>
 
-  <!-- ============ DOMAIN B ============ -->
-  <text class="tb" x="700" y="204" fill="#2b4a8a" font-size="14">DOMENA B — załączana zapłonem</text>
-  <rect class="boxB" x="700" y="214" width="420" height="330"/>
+  <!-- ============ COMPUTER ============ -->
+  <text class="tb" x="700" y="208" fill="#2b4a8a" font-size="14">KOMPUTER I OBRAZ — zasilane stale</text>
+  <rect class="boxB" x="700" y="218" width="420" height="300"/>
 
-  <rect class="box" x="726" y="234" width="368" height="62"/>
-  <text class="h" x="910" y="256">Przekaźnik zapłonu Bosch 30 A SPDT</text>
-  <text class="t" x="910" y="274">cewka: ACC · dioda 1N4007 równolegle</text>
-  <text class="t" x="910" y="290">rozwarty = 0 mA poboru z banku</text>
+  <rect class="box" x="726" y="252" width="188" height="88"/>
+  <text class="fuse" x="786" y="244">7,5 A</text>
+  <text class="h" x="820" y="274">XL6019 12 → 19,5 V</text>
+  <text class="t" x="820" y="292">ok. 45 W ciągle</text>
+  <text class="t" x="820" y="310">→ M910q (limit CPU 28 W)</text>
+  <text class="t" x="820" y="328">→ hub USB zasilany</text>
 
-  <path class="wB" d="M940 214 L940 234"/>
-  <path class="wB" d="M910 296 L910 318"/>
-  <path class="wB" d="M820 318 L1020 318"/>
-  <path class="wB" d="M820 318 L820 344"/>
-  <path class="wB" d="M1020 318 L1020 344"/>
+  <rect class="box" x="932" y="252" width="162" height="88"/>
+  <text class="fuse" x="1054" y="244">3 A</text>
+  <text class="h" x="1013" y="274">Buck 12 → 5 V</text>
+  <text class="t" x="1013" y="292">MP1584, min. 3 A</text>
+  <text class="t" x="1013" y="310">→ panele wyświetlaczy</text>
+  <text class="t" x="1013" y="328">→ podświetlenie PWM</text>
 
-  <rect class="box" x="726" y="344" width="188" height="88"/>
-  <text class="fuse" x="786" y="336">5 A</text>
-  <text class="h" x="820" y="366">XL6019 12 → 19,5 V</text>
-  <text class="t" x="820" y="384">ok. 45 W ciągle</text>
-  <text class="t" x="820" y="402">→ M910q (limit CPU 28 W)</text>
-  <text class="t" x="820" y="420">→ hub USB zasilany</text>
+  <path class="wB" d="M940 218 L940 236"/>
+  <path class="wB" d="M820 236 L1013 236"/>
+  <path class="wB" d="M820 236 L820 252"/>
+  <path class="wB" d="M1013 236 L1013 252"/>
+  <path class="wB" d="M820 340 L820 366"/>
+  <path class="wB" d="M1013 340 L1013 366"/>
 
-  <rect class="box" x="932" y="344" width="162" height="88"/>
-  <text class="fuse" x="1054" y="336">3 A</text>
-  <text class="h" x="1013" y="366">Buck 12 → 5 V</text>
-  <text class="t" x="1013" y="384">MP1584, min. 3 A</text>
-  <text class="t" x="1013" y="402">→ panele wyświetlaczy</text>
-  <text class="t" x="1013" y="420">→ podświetlenie PWM</text>
+  <rect class="box" x="726" y="366" width="188" height="70"/>
+  <text class="tl" x="738" y="386">M910q · 19 V · 10–55 W</text>
+  <text class="tl" x="738" y="404">hub USB 7-portowy</text>
+  <text class="tl" x="738" y="422">Pro Micro, GPS, LTE, mikrofon</text>
 
-  <path class="wB" d="M820 432 L820 458"/>
-  <path class="wB" d="M1013 432 L1013 458"/>
+  <rect class="box" x="932" y="366" width="162" height="70"/>
+  <text class="tl" x="944" y="386">wyświetlacz 10,1"</text>
+  <text class="tl" x="944" y="404">wyświetlacz 6,86" (opc.)</text>
+  <text class="tl" x="944" y="422">DAC USB, graber AHD</text>
 
-  <rect class="box" x="726" y="458" width="188" height="70"/>
-  <text class="tl" x="738" y="478">M910q · 19 V · 10–55 W</text>
-  <text class="tl" x="738" y="496">hub USB 7-portowy</text>
-  <text class="tl" x="738" y="514">Pro Micro, GPS, LTE, mikrofon</text>
+  <text class="tb" x="910" y="464" text-anchor="middle">Zapłon niczego tu nie odcina — zmienia tylko stan maszyny</text>
+  <text class="note" x="910" y="484" text-anchor="middle">kluczyk → Arduino → impuls na przycisk → S3 / wybudzenie / wyłączenie</text>
+  <text class="note" x="910" y="502" text-anchor="middle">szczegóły: ignition_sense.svg</text>
 
-  <rect class="box" x="932" y="458" width="162" height="70"/>
-  <text class="tl" x="944" y="478">wyświetlacz 10,1"</text>
-  <text class="tl" x="944" y="496">wyświetlacz 6,86" (opc.)</text>
-  <text class="tl" x="944" y="514">DAC USB, graber AHD</text>
+  <!-- ============ AMP ============ -->
+  <text class="tb" x="70" y="562" fill="#97324a" font-size="14">GAŁĄŹ NIEZALEŻNA — wzmacniacze</text>
+  <rect class="boxC" x="60" y="572" width="420" height="112"/>
+  <text class="t" x="270" y="596">Prosto z akumulatora rozruchowego, z pominięciem banku buforowego</text>
+  <text class="tl" x="80" y="618">• bezpiecznik wg karty wzmacniacza, przy klemie „+”, przewód 6 mm²</text>
+  <text class="tl" x="80" y="638">• gotowy wzmacniacz samochodowy 4-kanałowy (nie DIY)</text>
+  <text class="tl" x="80" y="658">• REM wprost z linii zapłonu · masa lokalna, przy wzmacniaczu</text>
+  <text class="note" x="80" y="676">Szczyty 20–30 A rozłożyłyby bank AGM w kilkanaście minut.</text>
 
-  <!-- ============ SEPARATE AMP BRANCH ============ -->
-  <text class="tb" x="70" y="586" fill="#97324a" font-size="14">GAŁĄŹ NIEZALEŻNA — wzmacniacze</text>
-  <rect class="boxC" x="60" y="596" width="420" height="112"/>
-  <text class="t" x="270" y="620">Prosto z akumulatora rozruchowego, z pominięciem banku buforowego</text>
-  <text class="tl" x="80" y="642">• bezpiecznik wg karty wzmacniacza, przy klemie „+”, przewód 6 mm²</text>
-  <text class="tl" x="80" y="662">• gotowy wzmacniacz samochodowy 4-kanałowy (nie DIY)</text>
-  <text class="tl" x="80" y="682">• REM z zacisku 87 · masa lokalna, przy wzmacniaczu</text>
-  <text class="note" x="80" y="700">Szczyty 20–30 A rozłożyłyby bank AGM w kilkanaście minut i przekroczyły przekaźnik LVD.</text>
+  <!-- ============ BUDGET ============ -->
+  <rect x="700" y="536" width="420" height="216" fill="#fbfcfd" stroke="#c8d2da" stroke-width="1.5" rx="6"/>
+  <text class="h" x="910" y="560">Trzy stany maszyny — trzy poziomy poboru</text>
+  <line x1="716" y1="570" x2="1104" y2="570" stroke="#c8d2da"/>
+  <text class="tb" x="722" y="590">Stan</text>
+  <text class="tb" x="852" y="590">Pobór</text>
+  <text class="tb" x="960" y="590">5 pak.</text>
+  <text class="tb" x="1036" y="590">8 pak.</text>
+  <line x1="716" y1="598" x2="1104" y2="598" stroke="#c8d2da"/>
+  <text class="tl" x="722" y="618">Praca</text><text class="tl" x="852" y="618">10–55 W</text><text class="tl" x="960" y="618">—</text><text class="tl" x="1036" y="618">—</text>
+  <text class="tl" x="722" y="642">S3 (kluczyk OFF)</text><text class="tl" x="852" y="642">400–550 mA</text><text class="tl" x="960" y="642">~1,2 d</text><text class="tl" x="1036" y="642">~1,9 d</text>
+  <text class="tl" x="722" y="666">Wyłączony</text><text class="tl" x="852" y="666">100–200 mA</text><text class="tl" x="960" y="666">3,5–5,3 d</text><text class="tl" x="1036" y="666">5,7–8,5 d</text>
+  <line x1="716" y1="680" x2="1104" y2="680" stroke="#c8d2da"/>
+  <text class="note" x="722" y="700">Czasy do 50 % DoD. Arduino przechodzi z S3 do pełnego wyłączenia po 2 h</text>
+  <text class="note" x="722" y="716">zgaszonego zapłonu — dłuższy impuls na ten sam przycisk.</text>
+  <text class="note" x="722" y="740">Pobór własny XH-M609 (20–125 mA) jest w tych liczbach — ZMIERZ go.</text>
 
-  <!-- ============ STANDBY TABLE ============ -->
-  <rect x="700" y="596" width="420" height="196" fill="#fbfcfd" stroke="#c8d2da" stroke-width="1.5" rx="6"/>
-  <text class="h" x="910" y="620">Czas postoju — zależy od poboru XH-M609</text>
-  <line x1="716" y1="630" x2="1104" y2="630" stroke="#c8d2da"/>
-  <text class="tb" x="722" y="650">Pobór łączny</text>
-  <text class="tb" x="828" y="650">z tego LVD</text>
-  <text class="tb" x="930" y="650">5 pakietów</text>
-  <text class="tb" x="1030" y="650">8 pakietów</text>
-  <line x1="716" y1="658" x2="1104" y2="658" stroke="#c8d2da"/>
-  <text class="tl" x="722" y="678">80 mA</text><text class="tl" x="828" y="678">20 mA</text><text class="tl" x="930" y="678">~6,6 dnia</text><text class="tl" x="1030" y="678">~10,6 dnia</text>
-  <text class="tl" x="722" y="698">100 mA</text><text class="tl" x="828" y="698">40 mA</text><text class="tl" x="930" y="698">~5,3 dnia</text><text class="tl" x="1030" y="698">~8,5 dnia</text>
-  <text class="tl" x="722" y="718">130 mA</text><text class="tl" x="828" y="718">70 mA</text><text class="tl" x="930" y="718">~4,1 dnia</text><text class="tl" x="1030" y="718">~6,5 dnia</text>
-  <text class="tl" x="722" y="738">185 mA</text><text class="tl" x="828" y="738">125 mA</text><text class="tl" x="930" y="738">~2,9 dnia</text><text class="tl" x="1030" y="738">~4,6 dnia</text>
-  <line x1="716" y1="752" x2="1104" y2="752" stroke="#c8d2da"/>
-  <text class="note" x="722" y="770">Czasy do 50 % DoD. 60 mA to odbiorniki domeny A, reszta to pobór</text>
-  <text class="note" x="722" y="784">własny XH-M609 — zmierz go, bo spec podaje tylko maksimum 1,5 W.</text>
-
-  <text class="note" x="24" y="826">Budzenie M910q z RTC (np. co 15 min na ping pozycji) dokłada ok. 5 Ah tygodniowo i mniej więcej połowi powyższe czasy. Przy dłuższym postoju wyłącz je w UI.</text>
-  <text class="note" x="24" y="848">Wszystkie bezpieczniki: wkładki nożowe ATO/ATC w listwie dystrybucyjnej z pokrywą, w miejscu dostępnym bez demontażu deski rozdzielczej.</text>
+  <text class="note" x="24" y="778">Wyłącznik główny to jedyne realne zero poboru. Na postój dłuższy niż tydzień rozłączaj bank — inaczej LVD odetnie go przy 11,00 V.</text>
+  <text class="note" x="24" y="800">Wszystkie bezpieczniki: wkładki nożowe ATO/ATC w listwie dystrybucyjnej z pokrywą, w miejscu dostępnym bez demontażu deski rozdzielczej.</text>
+  <text class="note" x="24" y="830">Model z przekaźnikiem odcinającym komputer („domena B”) został porzucony — porównanie: docs/ZASILANIE_BUFOROWANE.md §2.2.</text>
+  <text class="note" x="24" y="852">Jedyny przekaźnik w torze mocy siedzi w ładowaniu (docs/ZASILANIE_BUFOROWANE.md §5.3c), nie po stronie odbiorników.</text>
 </svg>

--- a/schematics/power_test_build.svg
+++ b/schematics/power_test_build.svg
@@ -22,7 +22,7 @@
 
   <rect class="bg" x="0" y="0" width="960" height="1164"/>
   <text class="ttl" x="24" y="32">Wariant testowo-rozwojowy — kompletny tor zasilania</text>
-  <text class="sub" x="24" y="52">Ładowanie wariantem B (VSR + CC-CV boost), bank 5 × CSB HR1221W, LVD XH-M609, domena B za przekaźnikiem zapłonu.</text>
+  <text class="sub" x="24" y="52">Ładowanie wariantem B (przekaźnik + MBR2545CT + CC-CV boost). M910q zasilany stale; zapłon tylko jako sygnał do Arduino.</text>
   <line x1="24" y1="64" x2="936" y2="64" stroke="#c8d2da" stroke-width="1.5"/>
 
   <!-- ============== SPINE ============== -->
@@ -42,8 +42,8 @@
   <path class="wire" d="M300 248 L300 282"/>
 
   <rect class="boxC" x="90" y="282" width="420" height="62"/>
-  <text class="h" x="300" y="305">VSR — przekaźnik napięciowy 12 V / 140 A</text>
-  <text class="t" x="300" y="324">załączenie 13,3 V · rozłączenie 12,8 V</text>
+  <text class="h" x="300" y="305">Przekaźnik ładowania 30 A + MBR2545CT</text>
+  <text class="t" x="300" y="324">cewka z zapłonu (albo D+) · obie anody diody zwarte, radiator</text>
 
   <path class="wire" d="M300 344 L300 378"/>
 
@@ -66,7 +66,7 @@
   <text class="h" x="300" y="607">BANK 5 × CSB HR1221W F2 — 25,5 Ah</text>
   <text class="t" x="300" y="626">bezpiecznik 10 A na „+” każdego pakietu, osobno</text>
   <text class="t" x="300" y="644">nasuwki F2 6,35 mm · łączenie równoległe wg §4.3 ZASILANIE</text>
-  <text class="t" x="300" y="661">3 pakiety wystarczą na czas testów; 8 = dłuższy postój</text>
+  <text class="t" x="300" y="661">5 to minimum, 8 wyraźnie lepsze — patrz tabela obok</text>
 
   <path class="wire" d="M300 668 L300 702"/>
   <text class="fuse" x="312" y="690">bezp. 15 A przed VIN+</text>
@@ -85,25 +85,26 @@
 
   <path class="wire" d="M300 854 L300 888"/>
 
-  <rect class="boxL" x="90" y="888" width="420" height="62"/>
-  <text class="h" x="300" y="911">Przekaźnik zapłonu 30 A SPDT — domena B</text>
-  <text class="t" x="300" y="930">cewka z ACC · dioda gaszeniowa 1N4007 równolegle</text>
+  <rect class="boxL" x="90" y="888" width="420" height="80"/>
+  <text class="h" x="300" y="909">Wyjście na odbiorniki — ZASILANE STALE</text>
+  <text class="t" x="300" y="928">zapłon nie odcina komputera — usypia go Arduino (S3)</text>
+  <text class="t" x="300" y="946">bezp. 7,5 A → XL6019 · bezp. 2 A → LM2596 (podświetlenie)</text>
 
-  <path class="wire" d="M300 950 L300 1000"/>
-  <text class="fuse" x="312" y="978">bezp. 7,5 A</text>
+  <path class="wire" d="M300 968 L300 1000"/>
+  <text class="fuse" x="312" y="990">bezp. 7,5 A</text>
 
   <rect class="box" x="90" y="1000" width="420" height="88"/>
   <text class="h" x="300" y="1023">XL6019 12 → 19,5 V → M910q</text>
   <text class="t" x="300" y="1042">limit CPU 28 W · radiator + wentylator 40 mm · C 470 µF/35 V</text>
   <text class="t" x="300" y="1060">USB M910q: panel 7" 1024×600 + dotyk, Pro Micro, modem LTE</text>
-  <text class="t" x="300" y="1078">razem 31–45 W na szynie 19,5 V — sufit XL6019 to ok. 45 W</text>
+  <text class="t" x="300" y="1078">razem 29–42 W na szynie 19,5 V — sufit XL6019 to ok. 45 W</text>
 
   <!-- ============== NOTES ============== -->
   <rect class="note" x="560" y="282" width="376" height="96"/>
-  <text class="nh" x="576" y="304">Dlaczego VSR, a nie dioda Schottky</text>
+  <text class="nh" x="576" y="304">Dlaczego tor ładowania musi się rozłączać</text>
   <text class="nt" x="576" y="325">Boost nie da napięcia niższego niż wejściowe, więc przy</text>
   <text class="nt" x="576" y="342">zgaszonym silniku podawałby 14,4 V i rozładowywał</text>
-  <text class="nt" x="576" y="359">akumulator auta. VSR rozłącza obwód fizycznie.</text>
+  <text class="nt" x="576" y="359">akumulator auta. Przekaźnik przerywa go fizycznie.</text>
 
   <rect class="note" x="560" y="394" width="376" height="130"/>
   <text class="nh" x="576" y="416">Prąd CC liczysz razem z obciążeniem</text>
@@ -114,11 +115,11 @@
   <text class="nt" x="576" y="513">Sufit katalogowy CSB: 2,1 A × liczba pakietów.</text>
 
   <rect class="note" x="560" y="540" width="376" height="112"/>
-  <text class="nh" x="576" y="562">Domena A jest w tym wariancie pusta</text>
-  <text class="nt" x="576" y="583">Nie ma jeszcze Nano, HM-10 ani RXB6, więc na postoju</text>
-  <text class="nt" x="576" y="600">z banku pobiera prąd wyłącznie sam XH-M609.</text>
-  <text class="nt" x="576" y="621">Przy 40 mA i pięciu pakietach to ~13 dni do 50 % DoD,</text>
-  <text class="nt" x="576" y="638">przy 125 mA już tylko ~4 dni. Zmierz go — §7.3.</text>
+  <text class="nh" x="576" y="562">Pobór postojowy — S3 to nie zero</text>
+  <text class="nt" x="576" y="583">M910q w S3 1,5–3 W + straty XL6019 1–1,5 W + XH-M609</text>
+  <text class="nt" x="576" y="600">0,25–1,5 W  =  razem 240–480 mA z banku.</text>
+  <text class="nt" x="576" y="621">5 pakietów → 1,1–2,2 dnia · 8 pakietów → 1,8–3,5 dnia</text>
+  <text class="nt" x="576" y="638">Na dłuższy postój: wyłącznik główny. ZMIERZ ten pobór.</text>
 
   <rect class="note" x="560" y="668" width="376" height="230"/>
   <text class="nh" x="576" y="690">Bezpieczniki i przekroje</text>
@@ -132,7 +133,7 @@
   <text class="nt" x="576" y="790">wejście XH-M609</text><text class="nt" x="800" y="790">15 A</text><text class="nt" x="866" y="790">2,5 mm²</text>
   <text class="nt" x="576" y="812">odgałęzienie do XL6019</text><text class="nt" x="800" y="812">7,5 A</text><text class="nt" x="866" y="812">1,5 mm²</text>
   <text class="nt" x="576" y="834">panel 7" (przez USB)</text><text class="nt" x="800" y="834">—</text><text class="nt" x="866" y="834">—</text>
-  <text class="nt" x="576" y="856">cewka przekaźnika (ACC)</text><text class="nt" x="800" y="856">—</text><text class="nt" x="866" y="856">0,75 mm²</text>
+  <text class="nt" x="576" y="856">podświetlenie (LM2596)</text><text class="nt" x="800" y="856">2 A</text><text class="nt" x="866" y="856">1,5 mm²</text>
   <line x1="576" y1="868" x2="920" y2="868" stroke="#c8d2da"/>
   <text class="foot" x="576" y="886">2,5 mm² zamiast 6 mm² — bo ładowarka daje 8 A, nie 25 A.</text>
 

--- a/schematics/schematic_test_build.svg
+++ b/schematics/schematic_test_build.svg
@@ -1,0 +1,319 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1440" height="820" viewBox="0 0 1440 820" font-family="DejaVu Sans, Verdana, sans-serif">
+  <title>BCM v8.5 — schemat elektryczny wariantu testowo-rozwojowego (M910q)</title>
+  <style>
+    .bg   { fill: #ffffff; }
+    .w    { stroke: #1b2b36; stroke-width: 2; fill: none; stroke-linecap: round; }
+    .wp   { stroke: #c0392b; stroke-width: 2.4; fill: none; stroke-linecap: round; }
+    .wg   { stroke: #46586a; stroke-width: 2; fill: none; stroke-linecap: round; }
+    .wd   { stroke: #7a8b99; stroke-width: 1.6; fill: none; stroke-dasharray: 5 4; }
+    .sym  { stroke: #1b2b36; stroke-width: 2; fill: none; }
+    .symf { stroke: #1b2b36; stroke-width: 2; fill: #1b2b36; }
+    .blk  { fill: #f7f9fb; stroke: #2b3a45; stroke-width: 2; rx: 4; }
+    .blkg { fill: #eef7ee; stroke: #2d6a2d; stroke-width: 2; rx: 4; }
+    .blko { fill: #fdf3e6; stroke: #9a6b12; stroke-width: 2; rx: 4; }
+    .note { fill: #fbfcfd; stroke: #c8d2da; stroke-width: 1.5; rx: 5; }
+    .ttl  { font-size: 19px; font-weight: bold; fill: #10202b; }
+    .sub  { font-size: 12px; fill: #5a6b78; }
+    .sec  { font-size: 13px; font-weight: bold; fill: #2d6a2d; letter-spacing: 0.5px; }
+    .secb { font-size: 13px; font-weight: bold; fill: #2b4a8a; letter-spacing: 0.5px; }
+    .ref  { font-size: 11.5px; font-weight: bold; fill: #a8321a; }
+    .lbl  { font-size: 11px; fill: #33424e; }
+    .lbc  { font-size: 11px; fill: #33424e; text-anchor: middle; }
+    .lbb  { font-size: 11.5px; font-weight: bold; fill: #10202b; text-anchor: middle; }
+    .nh   { font-size: 12.5px; font-weight: bold; fill: #10202b; }
+    .nt   { font-size: 11px; fill: #4a5a66; }
+  </style>
+
+  <defs>
+    <!-- fuse: horizontal, origin at left lead -->
+    <g id="fuse">
+      <line class="sym" x1="0" y1="0" x2="8" y2="0"/>
+      <rect class="sym" x="8" y="-8" width="34" height="16" fill="#ffffff"/>
+      <line class="sym" x1="8" y1="0" x2="42" y2="0"/>
+      <line class="sym" x1="42" y1="0" x2="50" y2="0"/>
+    </g>
+    <!-- fuse: vertical, origin top -->
+    <g id="fuseV">
+      <line class="sym" x1="0" y1="0" x2="0" y2="8"/>
+      <rect class="sym" x="-8" y="8" width="16" height="34" fill="#ffffff"/>
+      <line class="sym" x1="0" y1="8" x2="0" y2="42"/>
+      <line class="sym" x1="0" y1="42" x2="0" y2="50"/>
+    </g>
+    <!-- ground -->
+    <g id="gnd">
+      <line class="wg" x1="0" y1="0" x2="0" y2="8"/>
+      <line class="wg" x1="-13" y1="8" x2="13" y2="8"/>
+      <line class="wg" x1="-8" y1="13" x2="8" y2="13"/>
+      <line class="wg" x1="-3" y1="18" x2="3" y2="18"/>
+    </g>
+    <!-- diode pointing right, origin at left lead -->
+    <g id="diode">
+      <line class="sym" x1="0" y1="0" x2="12" y2="0"/>
+      <path class="symf" d="M12 -10 L12 10 L30 0 Z"/>
+      <line class="sym" x1="30" y1="-10" x2="30" y2="10"/>
+      <path class="sym" d="M30 -10 L24 -10 M30 10 L36 10"/>
+      <line class="sym" x1="30" y1="0" x2="42" y2="0"/>
+    </g>
+    <!-- TVS bidirectional, vertical, origin top -->
+    <g id="tvs">
+      <line class="sym" x1="0" y1="0" x2="0" y2="8"/>
+      <path class="symf" d="M-10 8 L10 8 L0 24 Z"/>
+      <path class="symf" d="M-10 40 L10 40 L0 24 Z"/>
+      <line class="sym" x1="0" y1="40" x2="0" y2="48"/>
+    </g>
+    <!-- capacitor vertical, origin top -->
+    <g id="cap">
+      <line class="sym" x1="0" y1="0" x2="0" y2="14"/>
+      <line class="sym" x1="-11" y1="14" x2="11" y2="14"/>
+      <line class="sym" x1="-11" y1="21" x2="11" y2="21"/>
+      <line class="sym" x1="0" y1="21" x2="0" y2="35"/>
+    </g>
+    <!-- SPST switch, origin at left terminal -->
+    <g id="sw">
+      <circle class="symf" cx="0" cy="0" r="3"/>
+      <line class="sym" x1="0" y1="0" x2="34" y2="-16"/>
+      <circle class="symf" cx="42" cy="0" r="3"/>
+    </g>
+  </defs>
+
+  <rect class="bg" x="0" y="0" width="1440" height="820"/>
+  <text class="ttl" x="24" y="32">Schemat elektryczny — wariant testowo-rozwojowy</text>
+  <text class="sub" x="24" y="54">Ładowanie przez przekaźnik zapłonu i MBR2545CT · bank 5 × CSB HR1221W · LVD XH-M609 · M910q zasilany stale. Wykrywanie zapłonu: ignition_sense.svg</text>
+  <line x1="24" y1="66" x2="1416" y2="66" stroke="#c8d2da" stroke-width="1.5"/>
+
+  <!-- ================= A. CHARGING ================= -->
+  <text class="sec" x="24" y="94">A · TOR ŁADOWANIA</text>
+
+  <!-- car battery -->
+  <text class="lbb" x="72" y="140">Akumulator</text>
+  <text class="lbb" x="72" y="154">rozruchowy</text>
+  <line class="sym" x1="52" y1="176" x2="52" y2="212"/>
+  <line class="sym" x1="66" y1="186" x2="66" y2="202"/>
+  <line class="sym" x1="80" y1="176" x2="80" y2="212"/>
+  <line class="sym" x1="94" y1="186" x2="94" y2="202"/>
+  <text class="lbc" x="52" y="234">+</text>
+  <line class="wp" x1="52" y1="176" x2="52" y2="168"/>
+  <line class="wp" x1="52" y1="168" x2="118" y2="168"/>
+  <line class="wg" x1="94" y1="212" x2="94" y2="252"/>
+  <use xlink:href="#gnd" x="94" y="252"/>
+
+  <!-- F1 -->
+  <use xlink:href="#fuse" x="118" y="168"/>
+  <text class="ref" x="126" y="152">F1 · 15 A</text>
+  <line class="wp" x1="168" y1="168" x2="228" y2="168"/>
+
+  <!-- TVS + C -->
+  <circle class="symf" cx="228" cy="168" r="3"/>
+  <use xlink:href="#tvs" x="228" y="168"/>
+  <text class="lbl" x="212" y="200" text-anchor="end">TVS</text>
+  <text class="lbl" x="212" y="214" text-anchor="end">1.5KE33CA</text>
+  <line class="wg" x1="228" y1="216" x2="228" y2="252"/>
+  <use xlink:href="#gnd" x="228" y="252"/>
+
+  <line class="wp" x1="228" y1="168" x2="300" y2="168"/>
+  <circle class="symf" cx="300" cy="168" r="3"/>
+  <use xlink:href="#cap" x="300" y="168"/>
+  <text class="lbl" x="314" y="188">C1</text>
+  <text class="lbl" x="314" y="202">470 µF/35 V</text>
+  <line class="wg" x1="300" y1="203" x2="300" y2="252"/>
+  <use xlink:href="#gnd" x="300" y="252"/>
+
+  <!-- K1 relay -->
+  <line class="wp" x1="300" y1="168" x2="404" y2="168"/>
+  <circle class="symf" cx="404" cy="168" r="3"/>
+  <text class="lbl" x="384" y="160">30</text>
+  <line class="sym" x1="404" y1="168" x2="452" y2="146"/>
+  <circle class="symf" cx="458" cy="168" r="3"/>
+  <text class="lbl" x="452" y="160">87</text>
+  <rect class="sym" x="402" y="212" width="58" height="30" fill="#ffffff"/>
+  <text class="lbc" x="431" y="232">K1</text>
+  <line class="wg" x1="404" y1="171" x2="404" y2="212"/>
+  <line class="wg" x1="431" y1="242" x2="431" y2="266"/>
+  <use xlink:href="#gnd" x="431" y="266"/>
+  <path class="wd" d="M402 235 L380 235 L380 306 L232 306"/>
+  <text class="lbl" x="226" y="310" text-anchor="end">cewka: zapłon (albo D+ alternatora)</text>
+  <text class="lbl" x="470" y="222">K1 · przekaźnik 30 A SPDT</text>
+  <text class="lbl" x="470" y="236">dioda 1N4007 na cewce</text>
+
+  <!-- D1 MBR2545CT: two diodes in parallel -->
+  <line class="wp" x1="458" y1="168" x2="516" y2="168"/>
+  <circle class="symf" cx="516" cy="168" r="3"/>
+  <line class="wp" x1="516" y1="140" x2="516" y2="196"/>
+  <use xlink:href="#diode" x="516" y="140"/>
+  <use xlink:href="#diode" x="516" y="196"/>
+  <line class="wp" x1="558" y1="140" x2="558" y2="196"/>
+  <circle class="symf" cx="558" cy="168" r="3"/>
+  <text class="lbb" x="537" y="118">D1 · MBR2545CT</text>
+  <text class="lbc" x="566" y="258">obie połówki równolegle</text>
+  <text class="lbc" x="566" y="272">katoda = blaszka — izoluj</text>
+
+  <!-- boost -->
+  <line class="wp" x1="558" y1="168" x2="620" y2="168"/>
+  <rect class="blkg" x="620" y="132" width="176" height="72"/>
+  <text class="lbb" x="708" y="154">Moduł CC-CV boost</text>
+  <text class="lbc" x="708" y="172">CV 14,40 V</text>
+  <text class="lbc" x="708" y="190">CC 8,0 A (5 pakietów)</text>
+  <line class="wg" x1="708" y1="204" x2="708" y2="252"/>
+  <use xlink:href="#gnd" x="708" y="252"/>
+
+  <!-- overvoltage cutoff -->
+  <line class="wp" x1="796" y1="168" x2="852" y2="168"/>
+  <rect class="blko" x="852" y="132" width="172" height="72"/>
+  <text class="lbb" x="938" y="154">Rozłącznik nadnap.</text>
+  <text class="lbc" x="938" y="172">rozwiera przy 15,30 V</text>
+  <text class="lbc" x="938" y="190">powrót 14,00 V</text>
+  <line class="wg" x1="938" y1="204" x2="938" y2="252"/>
+  <use xlink:href="#gnd" x="938" y="252"/>
+
+  <!-- bank -->
+  <line class="wp" x1="1024" y1="168" x2="1084" y2="168"/>
+  <line class="wp" x1="1084" y1="168" x2="1372" y2="168"/>
+  <text class="lbb" x="1228" y="118">BANK · 5 × CSB HR1221W F2 (25,5 Ah)</text>
+  <text class="ref" x="1150" y="136">F2…F6 · 10 A na każdy pakiet</text>
+
+  <g>
+    <circle class="symf" cx="1104" cy="168" r="3"/>
+    <use xlink:href="#fuseV" x="1104" y="168"/>
+    <line class="sym" x1="1092" y1="222" x2="1116" y2="222"/>
+    <line class="sym" x1="1098" y1="230" x2="1110" y2="230"/>
+    <line class="sym" x1="1092" y1="238" x2="1116" y2="238"/>
+    <line class="sym" x1="1098" y1="246" x2="1110" y2="246"/>
+    <line class="sym" x1="1104" y1="218" x2="1104" y2="222"/>
+    <line class="wg" x1="1104" y1="246" x2="1104" y2="284"/>
+  </g>
+  <g>
+    <circle class="symf" cx="1194" cy="168" r="3"/>
+    <use xlink:href="#fuseV" x="1194" y="168"/>
+    <line class="sym" x1="1182" y1="222" x2="1206" y2="222"/>
+    <line class="sym" x1="1188" y1="230" x2="1200" y2="230"/>
+    <line class="sym" x1="1182" y1="238" x2="1206" y2="238"/>
+    <line class="sym" x1="1188" y1="246" x2="1200" y2="246"/>
+    <line class="sym" x1="1194" y1="218" x2="1194" y2="222"/>
+    <line class="wg" x1="1194" y1="246" x2="1194" y2="284"/>
+  </g>
+  <text class="lbc" x="1284" y="236">· · ·</text>
+  <g>
+    <circle class="symf" cx="1372" cy="168" r="3"/>
+    <use xlink:href="#fuseV" x="1372" y="168"/>
+    <line class="sym" x1="1360" y1="222" x2="1384" y2="222"/>
+    <line class="sym" x1="1366" y1="230" x2="1378" y2="230"/>
+    <line class="sym" x1="1360" y1="238" x2="1384" y2="238"/>
+    <line class="sym" x1="1366" y1="246" x2="1378" y2="246"/>
+    <line class="sym" x1="1372" y1="218" x2="1372" y2="222"/>
+    <line class="wg" x1="1372" y1="246" x2="1372" y2="284"/>
+  </g>
+
+  <!-- ground bus -->
+  <line class="wg" x1="1084" y1="284" x2="1392" y2="284"/>
+  <use xlink:href="#gnd" x="1238" y="284"/>
+  <text class="lbl" x="1258" y="300">masa: punkt gwiazdowy</text>
+
+  <!-- node A -->
+  <circle cx="1408" cy="168" r="11" fill="#ffffff" stroke="#c0392b" stroke-width="2"/>
+  <text class="lbc" x="1408" y="172" font-size="11" font-weight="bold" fill="#c0392b">A</text>
+  <line class="wp" x1="1372" y1="168" x2="1397" y2="168"/>
+
+  <line x1="24" y1="326" x2="1416" y2="326" stroke="#e2e8ed" stroke-width="1.5"/>
+
+  <!-- ================= B. LOADS ================= -->
+  <text class="secb" x="24" y="356">B · TOR ODBIORNIKÓW — ZASILANY STALE</text>
+
+  <circle cx="60" cy="424" r="11" fill="#ffffff" stroke="#c0392b" stroke-width="2"/>
+  <text class="lbc" x="60" y="428" font-size="11" font-weight="bold" fill="#c0392b">A</text>
+  <text class="lbl" x="42" y="452">szyna „+” banku</text>
+  <line class="wp" x1="71" y1="424" x2="124" y2="424"/>
+
+  <use xlink:href="#fuse" x="124" y="424"/>
+  <text class="ref" x="126" y="408">F7 · 15 A</text>
+  <line class="wp" x1="174" y1="424" x2="222" y2="424"/>
+
+  <rect class="blko" x="222" y="388" width="180" height="72"/>
+  <text class="lbb" x="312" y="410">XH-M609 · LVD</text>
+  <text class="lbc" x="312" y="428">odcięcie 11,00 V</text>
+  <text class="lbc" x="312" y="446">powrót 12,60 V</text>
+  <line class="wg" x1="312" y1="460" x2="312" y2="504"/>
+  <use xlink:href="#gnd" x="312" y="504"/>
+
+  <line class="wp" x1="402" y1="424" x2="440" y2="424"/>
+  <use xlink:href="#sw" x="440" y="424"/>
+  <text class="lbc" x="461" y="392">S1 · wyłącznik główny</text>
+  <line class="wp" x1="482" y1="424" x2="540" y2="424"/>
+  <circle class="symf" cx="540" cy="424" r="3"/>
+  <line class="wp" x1="540" y1="380" x2="540" y2="480"/>
+
+  <!-- branch 1: XL6019 -->
+  <line class="wp" x1="540" y1="380" x2="586" y2="380"/>
+  <use xlink:href="#fuse" x="586" y="380"/>
+  <text class="ref" x="580" y="364">F8 · 7,5 A</text>
+  <line class="wp" x1="636" y1="380" x2="684" y2="380"/>
+  <rect class="blk" x="684" y="350" width="164" height="60"/>
+  <text class="lbb" x="766" y="372">XL6019</text>
+  <text class="lbc" x="766" y="390">12 → 19,5 V · ok. 45 W</text>
+  <line class="wp" x1="848" y1="380" x2="900" y2="380"/>
+  <rect class="blk" x="900" y="342" width="230" height="76"/>
+  <text class="lbb" x="1015" y="364">M910q · 19,5 V</text>
+  <text class="lbc" x="1015" y="382">limit CPU 28 W (RAPL)</text>
+  <text class="lbc" x="1015" y="400">USB: panel + dotyk, Pro Micro, LTE</text>
+
+  <!-- branch 2: LM2596 -->
+  <line class="wp" x1="540" y1="480" x2="586" y2="480"/>
+  <use xlink:href="#fuse" x="586" y="480"/>
+  <text class="ref" x="586" y="464">F9 · 2 A</text>
+  <line class="wp" x1="636" y1="480" x2="684" y2="480"/>
+  <rect class="blk" x="684" y="450" width="164" height="60"/>
+  <text class="lbb" x="766" y="472">LM2596</text>
+  <text class="lbc" x="766" y="490">12 → 5 V</text>
+  <line class="wp" x1="848" y1="480" x2="900" y2="480"/>
+  <rect class="blk" x="900" y="450" width="230" height="60"/>
+  <text class="lbb" x="1015" y="472">Podświetlenie panelu 7"</text>
+  <text class="lbc" x="1015" y="490">złącze PWM + GND</text>
+
+  <line class="wg" x1="766" y1="410" x2="766" y2="434"/>
+  <line class="wg" x1="766" y1="434" x2="766" y2="450"/>
+  <line class="wg" x1="1015" y1="418" x2="1015" y2="434"/>
+  <line class="wg" x1="1015" y1="510" x2="1015" y2="540"/>
+  <line class="wg" x1="766" y1="510" x2="766" y2="540"/>
+  <line class="wg" x1="312" y1="540" x2="1015" y2="540"/>
+  <line class="wg" x1="312" y1="522" x2="312" y2="540"/>
+  <use xlink:href="#gnd" x="664" y="540"/>
+  <line class="wg" x1="664" y1="540" x2="664" y2="540"/>
+
+  <!-- ignition signal pointer -->
+  <line class="wd" x1="1015" y1="342" x2="1015" y2="320"/>
+  <line class="wd" x1="1015" y1="320" x2="1230" y2="320"/>
+  <text class="lbl" x="1240" y="324">sygnał zapłonu → S3 / wybudzenie</text>
+  <text class="lbl" x="1240" y="340">patrz ignition_sense.svg</text>
+
+  <!-- ================= LEGEND / NOTES ================= -->
+  <rect class="note" x="1160" y="376" width="256" height="180"/>
+  <text class="nh" x="1176" y="398">Oznaczenia bezpieczników</text>
+  <text class="nt" x="1176" y="420">F1  15 A — zasilanie ładowarki</text>
+  <text class="nt" x="1176" y="440">F2…F6  10 A — po jednym na pakiet</text>
+  <text class="nt" x="1176" y="460">F7  15 A — wejście XH-M609</text>
+  <text class="nt" x="1176" y="480">F8  7,5 A — odgałęzienie XL6019</text>
+  <text class="nt" x="1176" y="500">F9  2 A — odgałęzienie LM2596</text>
+  <text class="nt" x="1176" y="524">Przekroje: F1–F7 2,5 mm²,</text>
+  <text class="nt" x="1176" y="542">F8–F9 1,5 mm², cewka K1 0,75 mm²</text>
+
+  <rect class="note" x="24" y="580" width="676" height="212"/>
+  <text class="nh" x="40" y="602">Czego na tym schemacie celowo nie ma</text>
+  <text class="nt" x="40" y="624">• Przekaźnika odcinającego odbiorniki. M910q jest zasilany stale — zapłon</text>
+  <text class="nt" x="40" y="642">   jedynie usypia go do S3 i wybudza (ignition_sense.svg).</text>
+  <text class="nt" x="40" y="664">• Domeny A: Nano #1, Nano #2, HM-10, RXB6 i modułu przekaźników.</text>
+  <text class="nt" x="40" y="686">• Wzmacniacza — idzie osobną gałęzią wprost z akumulatora rozruchowego,</text>
+  <text class="nt" x="40" y="704">   z własnym bezpiecznikiem i własną masą; przez bank nie płynie prąd mocy.</text>
+  <text class="nt" x="40" y="726">• Kompensacji temperaturowej ładowania — CV 14,40 V jest stałe. Powód</text>
+  <text class="nt" x="40" y="744">   i konsekwencje: docs/ZASILANIE_BUFOROWANE.md §5.3b.</text>
+  <text class="nt" x="40" y="770">Wersja docelowa (z domeną A i przekaźnikiem zapłonu): power_domains_m910q.svg</text>
+
+  <rect class="note" x="724" y="580" width="692" height="212"/>
+  <text class="nh" x="740" y="602">Trzy rzeczy, które trzeba zrobić dobrze przy montażu</text>
+  <text class="nt" x="740" y="624">1.  D1 na radiatorze. Przy 9 A rozprasza ok. 4,5 W. Blaszka TO-220 jest</text>
+  <text class="nt" x="740" y="642">     połączona z katodą — izoluj ją podkładką mikową albo daj radiator,</text>
+  <text class="nt" x="740" y="660">     który nie dotyka nadwozia.</text>
+  <text class="nt" x="740" y="682">2.  Masa w jednym punkcie. Wszystkie „−” z tego rysunku schodzą do punktu</text>
+  <text class="nt" x="740" y="700">     gwiazdowego, nie do przypadkowych śrub karoserii.</text>
+  <text class="nt" x="740" y="722">3.  Nastawy przed podłączeniem banku. XL6019 19,5 V, boost 14,40 V / 8 A,</text>
+  <text class="nt" x="740" y="740">     rozłącznik 15,30 V, LVD 11,00 / 12,60 V — wszystko na zasilaczu lab.</text>
+  <text class="nt" x="740" y="770">Zaciski po kolei i kolejność montażu: wiring_test_build.svg</text>
+</svg>

--- a/schematics/vehicle_layout_m910q.svg
+++ b/schematics/vehicle_layout_m910q.svg
@@ -88,7 +88,7 @@
 
   <!-- ============ FRONT CABIN — PASSENGER SIDE ============ -->
   <rect class="zoneS" x="276" y="344" width="104" height="32"/>
-  <text class="zt" x="328" y="364">VSR</text>
+  <text class="zt" x="328" y="364">przekaźnik</text>
   <circle class="pin" cx="276" cy="344" r="11"/><text class="pinT" x="276" y="348">3</text>
 
   <rect class="zoneB" x="276" y="392" width="190" height="56"/>
@@ -146,7 +146,7 @@
   <circle class="pin" cx="1172" cy="372" r="11"/><text class="pinT" x="1172" y="376">20</text>
 
   <!-- ============ ROUTES ============ -->
-  <!-- main power: battery -> firewall -> VSR -> M910q bay -> bank -->
+  <!-- main power: battery -> firewall -> charge relay -> M910q bay -> bank -->
   <path class="route" d="M177 290 L177 404 L255 404"/>
   <path class="route" d="M255 404 L255 360 L276 360"/>
   <path class="route" d="M328 376 L328 392"/>
@@ -166,7 +166,7 @@
   <rect x="60" y="576" width="560" height="230" fill="#fbfcfd" stroke="#c8d2da" stroke-width="1.5" rx="6"/>
   <text class="tl" x="78" y="598">1 · akumulator rozruchowy + bezpieczniki 30 A i 20 A</text>
   <text class="tl" x="78" y="618">2 · fabryczna przelotka w przegrodzie</text>
-  <text class="tl" x="78" y="638">3 · VSR — rozdział ładowania</text>
+  <text class="tl" x="78" y="638">3 · Przekaźnik ładowania + dioda</text>
   <text class="tl" x="78" y="658">4 · M910q, hub USB, step-up, przekaźnik zapłonu, listwa</text>
   <text class="tl" x="78" y="678">5 · bank 5 × HR1221W, ładowarka CC-CV, LVD, rozłącznik masy</text>
   <text class="tl" x="78" y="698">6 · wyświetlacz główny 10,1" 1280×800 — miejsce radia</text>

--- a/schematics/vehicle_layout_m910q.svg
+++ b/schematics/vehicle_layout_m910q.svg
@@ -208,7 +208,7 @@
 
   <text class="tb" x="78" y="1068">Step-up w tej samej strefie, ale z wentylatorem</text>
   <text class="note" x="78" y="1086">Rozprasza ~9 W. Nie kładź jej na wykładzinie ani tapicerce — radiator na</text>
-  <text class="note" x="78" y="1102">blasze lub profilu aluminiowym, wentylator 40 mm z domeny B.</text>
+  <text class="note" x="78" y="1102">blasze lub profilu aluminiowym, wentylator 40 mm z szyny buforowanej.</text>
 
   <text class="warn" x="78" y="1128">Rozłącznik masy banku musi być dostępny bez demontażu fotela.</text>
   <text class="note" x="78" y="1144">Będzie potrzebny przy każdym serwisie i przy dłuższym postoju auta.</text>

--- a/schematics/wiring_power_modules.svg
+++ b/schematics/wiring_power_modules.svg
@@ -308,7 +308,7 @@
   <text class="ms" x="340" y="1414">Gotowy wzmacniacz samochodowy — prosto z klemy „+”, NIE z szyny buforowanej</text>
   <text class="wn" x="80" y="1438">• bezpiecznik wg karty wzmacniacza przy klemie, przewód 6 mm²</text>
   <text class="wn" x="80" y="1458">• zaciski „+12V” i „GND” — masa lokalna, do 1 m, ten sam przekrój</text>
-  <text class="wn" x="80" y="1478">• REM ← zacisk 87 przekaźnika zapłonu (domena B)</text>
+  <text class="wn" x="80" y="1478">• REM ← wprost z linii zapłonu (nie z komputera)</text>
   <text class="note" x="80" y="1498">Wspólna masa z komputerem daje pętlę masy i przydźwięk alternatora.</text>
 
   <!-- ================= LEGEND ================= -->

--- a/schematics/wiring_power_modules.svg
+++ b/schematics/wiring_power_modules.svg
@@ -55,9 +55,9 @@
   <path class="plus" d="M101 242 L101 278"/>
   <text class="wl" x="108" y="264">6 mm²</text>
 
-  <!-- ================= 3. VSR ================= -->
+  <!-- ============ 3. CHARGE RELAY + DIODE ============ -->
   <rect class="mod" x="60" y="278" width="300" height="72"/>
-  <text class="mt" x="210" y="300">VSR — rozdział ładowania</text>
+  <text class="mt" x="210" y="300">Przekaźnik + MBR2545CT</text>
   <text class="ms" x="210" y="318">12 V / 140 A · zał. 13,3 V · wył. 12,8 V</text>
   <text class="ms" x="110" y="336">od auta</text>
   <text class="ms" x="222" y="336">do bufora</text>

--- a/schematics/wiring_test_build.svg
+++ b/schematics/wiring_test_build.svg
@@ -1,0 +1,308 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1280" height="1180" viewBox="0 0 1280 1180" font-family="DejaVu Sans, Verdana, sans-serif">
+  <title>BCM v8.5 — schemat połączeniowy wariantu testowo-rozwojowego, zacisk po zacisku (M910q)</title>
+  <style>
+    .bg   { fill: #ffffff; }
+    .wp   { stroke: #c0392b; stroke-width: 2.6; fill: none; stroke-linecap: round; }
+    .wg   { stroke: #46586a; stroke-width: 2.2; fill: none; stroke-linecap: round; }
+    .wd   { stroke: #7a8b99; stroke-width: 1.6; fill: none; stroke-dasharray: 5 4; }
+    .sym  { stroke: #1b2b36; stroke-width: 2; fill: none; }
+    .blk  { fill: #f7f9fb; stroke: #2b3a45; stroke-width: 2; rx: 5; }
+    .blkg { fill: #eef7ee; stroke: #2d6a2d; stroke-width: 2; rx: 5; }
+    .blko { fill: #fdf3e6; stroke: #9a6b12; stroke-width: 2; rx: 5; }
+    .blkb { fill: #eef2fa; stroke: #2b4a8a; stroke-width: 2; rx: 5; }
+    .fbox { fill: #ffffff; stroke: #a8321a; stroke-width: 2; rx: 3; }
+    .note { fill: #fbfcfd; stroke: #c8d2da; stroke-width: 1.5; rx: 5; }
+    .ttl  { font-size: 19px; font-weight: bold; fill: #10202b; }
+    .sub  { font-size: 12px; fill: #5a6b78; }
+    .sec  { font-size: 12.5px; font-weight: bold; fill: #2d6a2d; letter-spacing: 0.5px; }
+    .secb { font-size: 12.5px; font-weight: bold; fill: #2b4a8a; letter-spacing: 0.5px; }
+    .mh   { font-size: 12.5px; font-weight: bold; fill: #10202b; text-anchor: middle; }
+    .ms   { font-size: 10.5px; fill: #5a6b78; text-anchor: middle; }
+    .tm   { font-size: 10px; font-weight: bold; fill: #10202b; }
+    .fz   { font-size: 10.5px; font-weight: bold; fill: #a8321a; text-anchor: middle; }
+    .wn   { font-size: 10px; font-weight: bold; fill: #ffffff; text-anchor: middle; }
+    .nh   { font-size: 12.5px; font-weight: bold; fill: #10202b; }
+    .nt   { font-size: 11px; fill: #4a5a66; }
+    .lbl  { font-size: 10.5px; fill: #33424e; }
+  </style>
+
+  <defs>
+    <g id="gnd">
+      <line class="wg" x1="0" y1="0" x2="0" y2="7"/>
+      <line class="wg" x1="-11" y1="7" x2="11" y2="7"/>
+      <line class="wg" x1="-7" y1="11" x2="7" y2="11"/>
+      <line class="wg" x1="-3" y1="15" x2="3" y2="15"/>
+    </g>
+  </defs>
+
+  <rect class="bg" x="0" y="0" width="1280" height="1180"/>
+  <text class="ttl" x="24" y="32">Schemat połączeniowy — wariant testowo-rozwojowy</text>
+  <text class="sub" x="24" y="54">Każdy zacisk podpisany, każdy przewód ponumerowany. Tabela „skąd → dokąd”: docs/SCHEMATY_POLACZEN.md § 10 · schemat ideowy: schematic_test_build.svg</text>
+  <line x1="24" y1="66" x2="1256" y2="66" stroke="#c8d2da" stroke-width="1.5"/>
+
+  <!-- ================== ROW 1 — CHARGING INPUT ================== -->
+  <text class="sec" x="24" y="94">1 · WEJŚCIE ŁADOWANIA</text>
+
+  <rect class="blk" x="24" y="108" width="164" height="86"/>
+  <text class="mh" x="106" y="132">Akumulator rozruchowy</text>
+  <text class="ms" x="106" y="150">12 V, fabryczny</text>
+  <circle cx="188" cy="164" r="4" fill="#c0392b"/><text class="tm" x="166" y="168">+</text>
+  <circle cx="188" cy="182" r="4" fill="#46586a"/><text class="tm" x="166" y="186">−</text>
+
+  <rect class="fbox" x="228" y="150" width="72" height="28"/>
+  <text class="fz" x="264" y="169">F1 · 15 A</text>
+  <line class="wp" x1="188" y1="164" x2="228" y2="164"/>
+  <line class="wp" x1="300" y1="164" x2="348" y2="164"/>
+  <circle cx="208" cy="150" r="9" fill="#c0392b"/><text class="wn" x="208" y="154">1</text>
+  <circle cx="324" cy="150" r="9" fill="#c0392b"/><text class="wn" x="324" y="154">2</text>
+
+  <rect class="blk" x="348" y="108" width="164" height="86"/>
+  <text class="mh" x="430" y="132">TVS + C1</text>
+  <text class="ms" x="430" y="150">1.5KE33CA · 470 µF/35 V</text>
+  <text class="ms" x="430" y="166">równolegle do masy</text>
+  <circle cx="348" cy="164" r="4" fill="#c0392b"/>
+  <circle cx="512" cy="164" r="4" fill="#c0392b"/>
+  <line class="wg" x1="430" y1="194" x2="430" y2="216"/>
+  <use xlink:href="#gnd" x="430" y="216"/>
+
+  <rect class="blk" x="552" y="108" width="180" height="110"/>
+  <text class="mh" x="642" y="132">K1 · przekaźnik 30 A</text>
+  <text class="ms" x="642" y="150">Bosch SPDT + podstawka</text>
+  <circle cx="552" cy="176" r="4" fill="#c0392b"/><text class="tm" x="560" y="180">30</text>
+  <circle cx="732" cy="176" r="4" fill="#c0392b"/><text class="tm" x="704" y="180">87</text>
+  <circle cx="600" cy="218" r="4" fill="#46586a"/><text class="tm" x="590" y="238">85</text>
+  <circle cx="684" cy="218" r="4" fill="#46586a"/><text class="tm" x="674" y="238">86</text>
+  <line class="wp" x1="512" y1="164" x2="532" y2="164"/>
+  <line class="wp" x1="532" y1="164" x2="532" y2="176"/>
+  <line class="wp" x1="532" y1="176" x2="552" y2="176"/>
+  <circle cx="534" cy="146" r="9" fill="#c0392b"/><text class="wn" x="534" y="150">3</text>
+
+  <line class="wg" x1="600" y1="218" x2="600" y2="258"/>
+  <use xlink:href="#gnd" x="600" y="258"/>
+  <line class="wd" x1="684" y1="218" x2="684" y2="252"/>
+  <line class="wd" x1="684" y1="252" x2="792" y2="252"/>
+  <text class="lbl" x="798" y="256">zapłon / ACC (albo D+)</text>
+  <circle cx="740" cy="252" r="9" fill="#7a8b99"/><text class="wn" x="740" y="256">4</text>
+  <text class="ms" x="642" y="284">dioda 1N4007 równolegle do 85–86, katodą do „+”</text>
+
+  <rect class="blk" x="800" y="108" width="180" height="110"/>
+  <text class="mh" x="890" y="132">D1 · MBR2545CT</text>
+  <text class="ms" x="890" y="150">TO-220AB, na radiatorze</text>
+  <text class="ms" x="890" y="200">anody 1+3 zwarte razem</text>
+  <circle cx="800" cy="176" r="4" fill="#c0392b"/><text class="tm" x="808" y="180">A (1+3)</text>
+  <circle cx="980" cy="176" r="4" fill="#c0392b"/><text class="tm" x="932" y="180">K (2)</text>
+  <line class="wp" x1="732" y1="176" x2="800" y2="176"/>
+  <circle cx="766" cy="158" r="9" fill="#c0392b"/><text class="wn" x="766" y="162">5</text>
+
+  <rect class="blkg" x="1020" y="108" width="212" height="110"/>
+  <text class="mh" x="1126" y="132">Moduł CC-CV boost</text>
+  <text class="ms" x="1126" y="150">CV 14,40 V · CC 8,0 A</text>
+  <circle cx="1020" cy="176" r="4" fill="#c0392b"/><text class="tm" x="1028" y="180">IN+</text>
+  <circle cx="1020" cy="196" r="4" fill="#46586a"/><text class="tm" x="1028" y="200">IN−</text>
+  <circle cx="1232" cy="176" r="11" fill="#ffffff" stroke="#c0392b" stroke-width="2"/><text class="tm" x="1228" y="180">B</text><text class="tm" x="1180" y="180">OUT+</text>
+  <circle cx="1232" cy="200" r="4" fill="#46586a"/><text class="tm" x="1180" y="204">OUT−</text>
+  <text class="ms" x="1126" y="236">OUT− → szyna „−” banku (punkt gwiazdowy)</text>
+  <line class="wp" x1="980" y1="176" x2="1020" y2="176"/>
+  <circle cx="1000" cy="158" r="9" fill="#c0392b"/><text class="wn" x="1000" y="162">6</text>
+  <line class="wg" x1="1020" y1="196" x2="1000" y2="196"/>
+  <line class="wg" x1="1000" y1="196" x2="1000" y2="236"/>
+  <use xlink:href="#gnd" x="1000" y="236"/>
+
+  <line x1="24" y1="316" x2="1256" y2="316" stroke="#e2e8ed" stroke-width="1.5"/>
+
+  <!-- ================== ROW 2 — CUTOFF + BANK ================== -->
+  <text class="sec" x="24" y="344">2 · BLOKADA PRZEŁADOWANIA I BANK</text>
+
+  <circle cx="46" cy="418" r="12" fill="#ffffff" stroke="#c0392b" stroke-width="2"/><text class="tm" x="42" y="422">B</text>
+  <text class="ms" x="46" y="448">z OUT+ boostu</text>
+  <line class="wp" x1="58" y1="418" x2="72" y2="418"/>
+
+  <rect class="blko" x="72" y="358" width="228" height="120"/>
+  <text class="mh" x="186" y="382">Rozłącznik nadnapięciowy</text>
+  <text class="ms" x="186" y="400">próg 15,30 V · powrót 14,00 V</text>
+  <text class="ms" x="186" y="464">styk NC — rozwiera przy progu</text>
+  <circle cx="72" cy="418" r="4" fill="#c0392b"/><text class="tm" x="80" y="412">+ zas.</text>
+  <circle cx="72" cy="440" r="4" fill="#46586a"/><text class="tm" x="80" y="436">− zas.</text>
+  <circle cx="300" cy="418" r="4" fill="#c0392b"/><text class="tm" x="262" y="412">COM</text>
+  <circle cx="300" cy="440" r="4" fill="#c0392b"/><text class="tm" x="272" y="436">NC</text>
+  <line class="wg" x1="72" y1="440" x2="56" y2="440"/>
+  <line class="wg" x1="56" y1="440" x2="56" y2="496"/>
+  <use xlink:href="#gnd" x="56" y="496"/>
+
+  <rect class="blk" x="312" y="358" width="380" height="146"/>
+  <text class="mh" x="502" y="382">BANK · 5 × CSB HR1221W F2</text>
+  <text class="ms" x="502" y="400">25,5 Ah · nasuwki F2 6,35 mm · łączenie równoległe wg §4.3</text>
+  <circle cx="312" cy="428" r="4" fill="#c0392b"/><text class="tm" x="320" y="432">szyna „+”</text>
+  <circle cx="312" cy="452" r="4" fill="#46586a"/><text class="tm" x="320" y="456">szyna „−”</text>
+  <circle cx="692" cy="428" r="4" fill="#c0392b"/>
+  <circle cx="692" cy="452" r="4" fill="#46586a"/>
+
+  <rect class="fbox" x="372" y="470" width="52" height="22"/><text class="fz" x="398" y="486">10 A</text>
+  <rect class="fbox" x="440" y="470" width="52" height="22"/><text class="fz" x="466" y="486">10 A</text>
+  <rect class="fbox" x="508" y="470" width="52" height="22"/><text class="fz" x="534" y="486">10 A</text>
+  <rect class="fbox" x="576" y="470" width="52" height="22"/><text class="fz" x="602" y="486">10 A</text>
+  <rect class="fbox" x="644" y="470" width="52" height="22"/><text class="fz" x="670" y="486">10 A</text>
+  <text class="ms" x="502" y="518">F2…F6 — po jednym na „+” każdego pakietu, osobno</text>
+
+  <line class="wp" x1="300" y1="440" x2="306" y2="440"/>
+  <line class="wp" x1="306" y1="440" x2="306" y2="428"/>
+  <line class="wp" x1="306" y1="428" x2="312" y2="428"/>
+  <circle cx="306" cy="464" r="9" fill="#c0392b"/><text class="wn" x="306" y="468">7</text>
+  <line class="wg" x1="312" y1="452" x2="288" y2="452"/>
+  <line class="wg" x1="288" y1="452" x2="288" y2="496"/>
+  <use xlink:href="#gnd" x="288" y="496"/>
+
+  <rect class="blko" x="752" y="358" width="228" height="120"/>
+  <text class="mh" x="866" y="382">XH-M609 · LVD</text>
+  <text class="ms" x="866" y="400">odcięcie 11,00 V · powrót 12,60 V</text>
+  <circle cx="752" cy="418" r="4" fill="#c0392b"/><text class="tm" x="760" y="422">VIN+</text>
+  <circle cx="752" cy="440" r="4" fill="#46586a"/><text class="tm" x="760" y="444">VIN−</text>
+  <circle cx="980" cy="418" r="4" fill="#c0392b"/><text class="tm" x="936" y="422">VOUT+</text>
+  <circle cx="980" cy="440" r="4" fill="#46586a"/><text class="tm" x="936" y="444">VOUT−</text>
+
+  <rect class="fbox" x="700" y="404" width="46" height="26"/>
+  <text class="fz" x="723" y="422">F7</text>
+  <text class="fz" x="723" y="396">15 A</text>
+  <line class="wp" x1="692" y1="428" x2="700" y2="428"/>
+  <line class="wp" x1="700" y1="428" x2="700" y2="418"/>
+  <line class="wp" x1="746" y1="418" x2="752" y2="418"/>
+  <circle cx="723" cy="378" r="9" fill="#c0392b"/><text class="wn" x="723" y="382">8</text>
+  <line class="wg" x1="692" y1="452" x2="752" y2="452"/>
+  <line class="wg" x1="752" y1="452" x2="752" y2="440"/>
+  <circle cx="722" cy="470" r="9" fill="#46586a"/><text class="wn" x="722" y="474">9</text>
+
+  <rect class="blk" x="1040" y="386" width="192" height="64"/>
+  <text class="mh" x="1136" y="410">S1 · wyłącznik główny</text>
+  <text class="ms" x="1136" y="428">20 A, dwustanowy</text>
+  <circle cx="1040" cy="418" r="4" fill="#c0392b"/><text class="tm" x="1048" y="436">1</text>
+  <circle cx="1232" cy="418" r="4" fill="#c0392b"/><text class="tm" x="1216" y="436">2</text>
+  <line class="wp" x1="980" y1="418" x2="1040" y2="418"/>
+  <circle cx="1010" cy="400" r="9" fill="#c0392b"/><text class="wn" x="1010" y="404">10</text>
+  <text class="ms" x="1136" y="470">jedyne realne „zero” poboru na postoju</text>
+
+  <line x1="24" y1="556" x2="1256" y2="556" stroke="#e2e8ed" stroke-width="1.5"/>
+
+  <!-- ================== ROW 3 — LOADS ================== -->
+  <text class="secb" x="24" y="584">3 · ODBIORNIKI</text>
+
+  <circle cx="60" cy="640" r="12" fill="#ffffff" stroke="#c0392b" stroke-width="2"/>
+  <text class="tm" x="55" y="644">S1</text>
+  <line class="wp" x1="72" y1="640" x2="120" y2="640"/>
+  <circle cx="120" cy="640" r="4" fill="#c0392b"/>
+  <line class="wp" x1="120" y1="600" x2="120" y2="760"/>
+  <text class="lbl" x="24" y="672">szyna odbiorników (z S1 zacisk 2)</text>
+  <text class="lbl" x="24" y="690">zasilana stale — bez przekaźnika</text>
+
+  <rect class="fbox" x="172" y="586" width="72" height="28"/>
+  <text class="fz" x="208" y="605">F8 · 7,5 A</text>
+  <line class="wp" x1="120" y1="600" x2="172" y2="600"/>
+  <line class="wp" x1="244" y1="600" x2="292" y2="600"/>
+  <circle cx="146" cy="620" r="9" fill="#c0392b"/><text class="wn" x="146" y="624">11</text>
+
+  <rect class="blk" x="292" y="566" width="196" height="102"/>
+  <text class="mh" x="390" y="590">XL6019</text>
+  <text class="ms" x="390" y="608">12 → 19,5 V · ok. 45 W</text>
+  <text class="ms" x="390" y="656">C 470 µF/35 V na wyjściu</text>
+  <circle cx="292" cy="600" r="4" fill="#c0392b"/><text class="tm" x="300" y="592">IN+</text>
+  <circle cx="292" cy="626" r="4" fill="#46586a"/><text class="tm" x="300" y="638">IN−</text>
+  <circle cx="488" cy="600" r="4" fill="#c0392b"/><text class="tm" x="450" y="592">OUT+</text>
+  <circle cx="488" cy="626" r="4" fill="#46586a"/><text class="tm" x="450" y="638">OUT−</text>
+  <line class="wg" x1="292" y1="626" x2="272" y2="626"/>
+  <line class="wg" x1="272" y1="626" x2="272" y2="700"/>
+  <use xlink:href="#gnd" x="272" y="700"/>
+
+  <rect class="blkb" x="548" y="566" width="252" height="102"/>
+  <text class="mh" x="674" y="590">M910q · wtyk 19,5 V</text>
+  <text class="ms" x="674" y="608">środek = „+”, ekran = „−”</text>
+  <text class="ms" x="674" y="632">USB: panel + dotyk, Pro Micro,</text>
+  <text class="ms" x="674" y="650">modem LTE, karta MT7921</text>
+  <circle cx="548" cy="600" r="4" fill="#c0392b"/><text class="tm" x="540" y="592" text-anchor="end">+</text>
+  <circle cx="548" cy="626" r="4" fill="#46586a"/><text class="tm" x="540" y="642" text-anchor="end">−</text>
+  <line class="wp" x1="488" y1="600" x2="548" y2="600"/>
+  <line class="wg" x1="488" y1="626" x2="548" y2="626"/>
+  <circle cx="518" cy="582" r="9" fill="#c0392b"/><text class="wn" x="518" y="586">12</text>
+
+  <rect class="fbox" x="172" y="746" width="72" height="28"/>
+  <text class="fz" x="208" y="765">F9 · 2 A</text>
+  <line class="wp" x1="120" y1="760" x2="172" y2="760"/>
+  <line class="wp" x1="244" y1="760" x2="292" y2="760"/>
+  <circle cx="146" cy="742" r="9" fill="#c0392b"/><text class="wn" x="146" y="746">13</text>
+
+  <rect class="blk" x="292" y="726" width="196" height="86"/>
+  <text class="mh" x="390" y="750">LM2596</text>
+  <text class="ms" x="390" y="768">12 → 5 V · nastaw przed montażem</text>
+  <circle cx="292" cy="760" r="4" fill="#c0392b"/><text class="tm" x="300" y="752">IN+</text>
+  <circle cx="292" cy="786" r="4" fill="#46586a"/><text class="tm" x="300" y="798">IN−</text>
+  <circle cx="488" cy="760" r="4" fill="#c0392b"/><text class="tm" x="450" y="752">OUT+</text>
+  <circle cx="488" cy="786" r="4" fill="#46586a"/><text class="tm" x="450" y="798">OUT−</text>
+  <line class="wg" x1="292" y1="786" x2="272" y2="786"/>
+  <line class="wg" x1="272" y1="786" x2="272" y2="836"/>
+  <use xlink:href="#gnd" x="272" y="836"/>
+
+  <rect class="blk" x="548" y="726" width="252" height="86"/>
+  <text class="mh" x="674" y="750">Panel 7" — podświetlenie</text>
+  <text class="ms" x="674" y="768">osobne złącze, nie USB</text>
+  <text class="ms" x="674" y="800">logika i dotyk zostają na USB M910q</text>
+  <circle cx="548" cy="760" r="4" fill="#c0392b"/><text class="tm" x="540" y="752" text-anchor="end">PWM+</text>
+  <circle cx="548" cy="786" r="4" fill="#46586a"/><text class="tm" x="540" y="802" text-anchor="end">GND</text>
+  <line class="wp" x1="488" y1="760" x2="548" y2="760"/>
+  <line class="wg" x1="488" y1="786" x2="548" y2="786"/>
+  <circle cx="518" cy="722" r="9" fill="#c0392b"/><text class="wn" x="518" y="726">14</text>
+
+  <!-- ignition sense summary -->
+  <rect class="blkb" x="860" y="566" width="372" height="246"/>
+  <text class="mh" x="1046" y="590">Wykrywanie zapłonu → S3</text>
+  <text class="ms" x="1046" y="610">pełny układ z wartościami: ignition_sense.svg</text>
+  <line x1="880" y1="624" x2="1212" y2="624" stroke="#c8d2da"/>
+  <text class="lbl" x="880" y="646">15 · ACC 12 V  →  R1 2,2 kΩ  →  U1 pin 1 (anoda LED)</text>
+  <text class="lbl" x="880" y="670">16 · U1 pin 2  →  masa instalacji auta</text>
+  <text class="lbl" x="880" y="694">17 · U1 pin 4  →  Pro Micro D0 (RXI)</text>
+  <text class="lbl" x="880" y="718">18 · U1 pin 3  →  Pro Micro GND</text>
+  <text class="lbl" x="880" y="742">19 · R2 10 kΩ  D0 → +5 V Pro Micro (opcjonalny)</text>
+  <text class="lbl" x="880" y="766">20 · C2 100 nF  D0 → GND</text>
+  <text class="ms" x="1046" y="796">PC817 rozdziela masę auta od masy USB — nie pomijaj tego</text>
+
+  <line x1="24" y1="860" x2="1256" y2="860" stroke="#e2e8ed" stroke-width="1.5"/>
+
+  <!-- ================== GROUND + NOTES ================== -->
+  <rect class="note" x="24" y="884" width="392" height="270"/>
+  <text class="nh" x="40" y="908">Punkt gwiazdowy masy — co na nim ląduje</text>
+  <text class="nt" x="40" y="932">• „−” akumulatora rozruchowego (przewód 2,5 mm²)</text>
+  <text class="nt" x="40" y="952">• „−” TVS / C1</text>
+  <text class="nt" x="40" y="972">• zacisk 85 przekaźnika K1</text>
+  <text class="nt" x="40" y="992">• IN− modułu CC-CV boost</text>
+  <text class="nt" x="40" y="1012">• „−” zasilania rozłącznika nadnapięciowego</text>
+  <text class="nt" x="40" y="1032">• szyna „−” banku</text>
+  <text class="nt" x="40" y="1052">• VIN− i VOUT− modułu XH-M609</text>
+  <text class="nt" x="40" y="1072">• IN− przetwornic XL6019 i LM2596</text>
+  <text class="nt" x="40" y="1100">Wyjątek: masa układu wykrywania zapłonu (U1 pin 2) idzie do</text>
+  <text class="nt" x="40" y="1118">masy instalacji auta, NIE do punktu gwiazdowego — o to właśnie</text>
+  <text class="nt" x="40" y="1136">chodzi w optoizolacji.</text>
+
+  <rect class="note" x="440" y="884" width="392" height="270"/>
+  <text class="nh" x="456" y="908">Kolejność podłączania</text>
+  <text class="nt" x="456" y="932">1.  S1 rozwarty, bank odłączony, F1 wyjęty z oprawki.</text>
+  <text class="nt" x="456" y="954">2.  Nastawy na zasilaczu laboratoryjnym: XL6019 19,5 V,</text>
+  <text class="nt" x="456" y="972">     LM2596 wg panelu, boost 14,40 V / 8 A, rozłącznik 15,30 V,</text>
+  <text class="nt" x="456" y="990">     XH-M609 11,00 / 12,60 V. Wszystkie pięć, bez wyjątku.</text>
+  <text class="nt" x="456" y="1012">3.  Masy: cały punkt gwiazdowy z listy obok.</text>
+  <text class="nt" x="456" y="1034">4.  Bank z bezpiecznikami F2…F6, pomiar napięcia na szynie.</text>
+  <text class="nt" x="456" y="1056">5.  Przewody 8, 9, 10 — bank przez F7 do LVD i S1.</text>
+  <text class="nt" x="456" y="1078">6.  Przewód 11 i 12: XL6019, pomiar 19,5 V BEZ M910q.</text>
+  <text class="nt" x="456" y="1100">7.  Dopiero teraz M910q; potem 13–14 (podświetlenie).</text>
+  <text class="nt" x="456" y="1122">8.  Na końcu 1–7: tor ładowania, przy zgaszonym silniku.</text>
+  <text class="nt" x="456" y="1144">9.  Rozruch silnika i pomiar prądu ładowania cęgami.</text>
+
+  <rect class="note" x="856" y="884" width="376" height="270"/>
+  <text class="nh" x="872" y="908">Przekroje i moment dokręcania</text>
+  <text class="nt" x="872" y="932">Przewody 1–10  ·  2,5 mm² FLRY</text>
+  <text class="nt" x="872" y="952">Przewody 11–14  ·  1,5 mm² FLRY</text>
+  <text class="nt" x="872" y="972">Przewód 4 (cewka K1)  ·  0,75 mm²</text>
+  <text class="nt" x="872" y="992">Przewody 15–20 (sygnał)  ·  0,5–0,75 mm²</text>
+  <text class="nt" x="872" y="1020">Wszystkie końcówki zaciskane zaciskarką zapadkową</text>
+  <text class="nt" x="872" y="1038">i zabezpieczone koszulką z klejem. Zacisk zrobiony</text>
+  <text class="nt" x="872" y="1056">kombinerkami to najczęstsza usterka instalacji.</text>
+  <text class="nt" x="872" y="1084">Nasuwki F2 6,35 mm na pakietach — izolowane,</text>
+  <text class="nt" x="872" y="1102">z pełnym zaciskiem na izolacji przewodu.</text>
+  <text class="nt" x="872" y="1130">D1 na radiatorze, blaszka izolowana od nadwozia.</text>
+</svg>

--- a/schematics/wiring_usb_av.svg
+++ b/schematics/wiring_usb_av.svg
@@ -49,7 +49,7 @@
   <text class="ms" x="225" y="144">1280×800 · dotyk USB</text>
   <text class="tl" x="78" y="168">wyjście główne M910q (sprawdź nazwę złącza)</text>
   <text class="tl" x="78" y="186">USB (dotyk) → hub USB</text>
-  <text class="tl" x="78" y="204">zasilanie 5 V ← buck MP1584 (domena B)</text>
+  <text class="tl" x="78" y="204">zasilanie 5 V ← buck MP1584 (szyna buforowana)</text>
   <text class="tl" x="78" y="222">M_PWM ← Nano #1 D9 · GND wspólna z Nano</text>
   <text class="ms" x="225" y="238">dashboard BCM, port 5002</text>
 
@@ -57,7 +57,7 @@
   <text class="mt" x="225" y="286">Wyświetlacz drugi 6,86" — opcjonalny</text>
   <text class="ms" x="225" y="304">1280×480 widescreen · bez dotyku · hotplug</text>
   <text class="tl" x="78" y="328">wyjście drugie M910q · small-display-watch.sh</text>
-  <text class="tl" x="78" y="346">zasilanie 5 V ← buck MP1584 (domena B)</text>
+  <text class="tl" x="78" y="346">zasilanie 5 V ← buck MP1584 (szyna buforowana)</text>
   <text class="tl" x="78" y="364">M_PWM ← Nano #1 D10 · GND wspólna z Nano</text>
   <text class="ms" x="225" y="380">karuzela statystyk + kamera cofania, port 5003</text>
 
@@ -74,7 +74,7 @@
   <!-- ============ USB HUB ============ -->
   <text class="sec" x="470" y="268">Hub USB (zasilany, 7 portów)</text>
   <rect class="modA" x="470" y="278" width="300" height="252"/>
-  <text class="ms" x="620" y="300">zasilany z domeny B — własny zasilacz 5 V</text>
+  <text class="ms" x="620" y="300">z szyny buforowanej — własny zasilacz 5 V</text>
   <text class="tl" x="488" y="324">• Arduino Pro Micro — /dev/ttyACM0</text>
   <text class="tl" x="488" y="344">• Arduino Nano #1 — /dev/ttyUSB0</text>
   <text class="tl" x="488" y="364">• Arduino Nano #2 — /dev/ttyUSB1</text>
@@ -160,7 +160,7 @@
 
   <path class="wpwr" d="M371 760 L371 774 L84 774"/>
   <text class="warn" x="84" y="792">Zasilanie 12 V wzmacniacza — osobna gałąź prosto z akumulatora, bezpiecznik wg karty modułu</text>
-  <text class="note" x="84" y="810">REM ← zacisk 87 przekaźnika zapłonu (domena B). Masa wzmacniacza lokalnie, nie do punktu gwiazdowego.</text>
+  <text class="note" x="84" y="810">REM ← wprost z linii zapłonu. Masa wzmacniacza lokalnie, nie do punktu gwiazdowego.</text>
 
   <!-- ============ NOTES ============ -->
   <rect x="60" y="852" width="1120" height="164" fill="#fbfcfd" stroke="#c8d2da" stroke-width="1.5" rx="6"/>
@@ -176,7 +176,7 @@
   <text class="tb" x="640" y="900">Przydźwięk alternatora w głośnikach</text>
   <text class="note" x="640" y="918">Pętla masy — masa wzmacniacza musi być lokalna, a RCA po drugiej stronie auta.</text>
   <text class="tb" x="640" y="942">Trzask w głośnikach przy załączaniu</text>
-  <text class="note" x="640" y="960">REM podpięty nie z domeny B — wzmacniacz wstaje przed komputerem.</text>
+  <text class="note" x="640" y="960">REM podpięty nie z zapłonu — wzmacniacz gra, gdy komputer śpi.</text>
   <text class="tb" x="640" y="984">Graber gubi klatki</text>
   <text class="note" x="640" y="1002">Wpięty w hub zamiast bezpośrednio w port M910q.</text>
 

--- a/schematics/wiring_vehicle_arduino.svg
+++ b/schematics/wiring_vehicle_arduino.svg
@@ -159,7 +159,7 @@
   <!-- Pro Micro -->
   <rect class="modB" x="830" y="102" width="380" height="228"/>
   <text class="mt" x="1020" y="124">Pro Micro (ATmega32U4) — wejścia</text>
-  <text class="ms" x="1020" y="142">domena B · USB HID + szeregowy 115200 · /dev/ttyACM0</text>
+  <text class="ms" x="1020" y="142">USB HID + szeregowy 115200 · /dev/ttyACM0 · 5 V z MP1584</text>
   <text class="tl" x="846" y="166">D2, D3 ← enkoder CLK, DT (+10 kΩ do VCC)</text>
   <text class="tl" x="846" y="184">D1 ← przycisk enkodera</text>
   <text class="tl" x="846" y="202">D5–D9 ← HOME, BACK, MEDIA, VOL+, VOL−</text>

--- a/src/input/arduino_serial.py
+++ b/src/input/arduino_serial.py
@@ -8,6 +8,8 @@ but also sends plain-text serial data for sensors and vehicle status:
         DOOR:FL=1,FR=0,RL=0,RR=0,BONNET=0,TRUNK=0  — door/panel states
         HBRAKE:1           — handbrake engaged (1) or released (0)
         IGN:1              — ignition/ACC 12V detected
+        PWR:RUNNING        — M910q state as seen by sensor_hub
+        PWRACT:SHORT       — power-button pulse just sent
         RAIN:1             — rain sensor triggered
         TEMP:23.5          — DS18B20 external temperature
         PARK:FL=123,FR=45,RL=200,RR=180  — parking sensor distances (cm)
@@ -157,7 +159,12 @@ class ArduinoSerialListener:
             elif line.startswith("FUEL:"):
                 self._bus.publish("vehicle.fuel_raw", int(line[5:]))
 
-            elif line.startswith(("SWC:", "MUSIC:", "STALK:")):
+            elif line.startswith("PWR:"):
+                # Stan M910q raportowany przez sensor_hub (FEATURE_PWRBTN):
+                # RUNNING / SLEEP / OFF / UNKNOWN.
+                self._bus.publish("vehicle.power_state", line[4:])
+
+            elif line.startswith(("SWC:", "MUSIC:", "STALK:", "PWRACT:")):
                 log.debug("Arduino: %s", line)
 
             else:

--- a/tests/test_arduino_serial.py
+++ b/tests/test_arduino_serial.py
@@ -26,6 +26,7 @@ def listener(monkeypatch):
         "vehicle.immo_ok",
         "vehicle.airbag_ok",
         "vehicle.fuel_raw",
+        "vehicle.power_state",
     ):
         bus.subscribe(topic, lambda t, v, ts: events.append((t, v)))
     lst._events = events  # test-only attachment
@@ -78,6 +79,23 @@ class TestParseLine:
         topic, value = _only_event(listener)
         assert topic == "vehicle.ignition_raw"
         assert value is False
+
+    def test_power_state(self, listener):
+        listener._parse_line("PWR:RUNNING")
+        topic, value = _only_event(listener)
+        assert topic == "vehicle.power_state"
+        assert value == "RUNNING"
+
+    def test_power_state_sleep(self, listener):
+        listener._parse_line("PWR:SLEEP")
+        topic, value = _only_event(listener)
+        assert topic == "vehicle.power_state"
+        assert value == "SLEEP"
+
+    def test_power_action_is_informational(self, listener):
+        # PWRACT: to log diagnostyczny, nie zdarzenie na magistrali.
+        listener._parse_line("PWRACT:LONG")
+        assert listener._events == []
 
     def test_rain(self, listener):
         listener._parse_line("RAIN:1")


### PR DESCRIPTION
Three changes. One of them costs real parking time and is worth reading before building.

## 1. VSR is gone everywhere

Removed from all six documents and six schematics. Charging is split by a **30 A relay off the ignition** plus an **MBR2545CT** Schottky:

- the relay breaks the path so the boost cannot drain the starter battery with the engine off
- the diode is the second barrier if the contacts weld
- it also drops the boost input by ~0.5 V, which **widens** the margin over the 14.40 V CV setpoint rather than narrowing it

**One consequence, stated next to the design rather than buried:** triggering the coil from the ignition instead of the alternator D+ means that with the key on and the engine not running, the charger runs off the starter battery. Seconds during a normal start; minutes if you sit with the key on. The D+ alternative is documented right beside it — one wire, no cost.

MBR2545CT wiring is spelled out because two things about it bite: it is a **dual common-cathode** part (short both anodes to get 25 A and ~0.45 V at 9 A), and the **tab is the cathode**, so it needs an insulating pad or a heatsink clear of the body. ~4.5 W continuous means the heatsink is not optional.

## 2. The BCM hangs on the buffer permanently

Ignition is now only a **signal**: the Arduino sees it change, the machine drops to S3 and comes back. Wake is ~3 s instead of a cold boot, and nothing gets cut mid-write.

The bill is standby:

| | |
|---|---|
| M910q in S3 | 1.5–3 W |
| XL6019 losses at that load | 1–1.5 W |
| XH-M609 (measure it) | 0.25–1.5 W |
| **Total** | **~3–6 W = 240–480 mA** |

Parking endurance falls from **~13 days to ~1.5–2.5 days** on five packs. So five packs is now the minimum, eight is worth using, and the main switch stops being a convenience — it is the only real zero. The full table is in `WDROZENIE_TESTOWE.md` §3.1a.

`ZASILANIE_BUFOROWANE.md` §2 now records that the test variant deliberately inverts the domain-B decision, and what would have to change for the target build to follow.

### The software for this does not exist yet

Said plainly in the doc rather than implied:

| Missing | Where |
|---------|-------|
| Ignition input on the Pro Micro | **D0 (RXI)** is the only free pin left — everything else is encoder, 5 buttons, 2 SWC pods, music panel, LDR, stalk button. 12 V must go through an optocoupler or divider |
| Host reaction | `PowerManager` on `hal.ignition = false` goes to STANDBY, which fades the backlight — **no `systemctl suspend`**. Suspend lives in `bcm-power-toggle.sh` via acpid, outside BCM |
| A publisher for `hal.ignition` on x86 | on the OPi this was `bcm-ignition-watcher` over GPIO |

Wake needs **no code** — any HID keypress with Wake on USB enabled. The prerequisite nobody would think to check: **whether USB stays powered in S3**. If it doesn't, the Arduino dies with the host and cannot wake it. That's now an acceptance item.

## 3. Backlight on its own LM2596

Touch and panel logic stay on USB (same cable, so USB has to stay); only the backlight moves to an LM2596 on the panel's PWM+GND header. That frees a few watts on the XL6019 rail (**29–42 W** now against a ~45 W ceiling) and eases the USB budget to a single port.

Flagged: the LM2596 is permanently powered, so **the backlight must actually go dark in S3** or it adds 2–4 W to the standby figure above. Most panels blank on HDMI signal loss — measure yours; if not, a small relay or MOSFET on the LM2596 output.

## On the brightness question

The observation that the UI has no brightness control is **correct**, and the reason is worse than "it's sensor-only":

- the web UI has no control at all; `POST /api/config` accepts `brightness`, writes `display.dashboard.brightness` and publishes `config.changed` — **nothing consumes it**
- the LDR on Pro Micro **A1** does get read and sent as `LIGHT:<0-1023>`, and the stalk/SWC "Brightness" action does send F9 → `input.brightness_cycle`
- but **`BrightnessController` is never constructed** — `start_power()` builds `PowerManager`, `BacklightController` and `ShutdownHandler` and nothing else. So both inputs go nowhere.
- even wired up, the PWM output reaches hardware via `central_lock.py` → **Nano #1**, which this build doesn't have

So the chain is broken in two places at once. **Left alone as instructed** — the panel has physical switches. Written up in §3.1c so the decision is recorded rather than rediscovered.

## Note on scope

The domain A/B split and the ignition relay still stand in the **target** deployment docs, where domain A (remote listener, BLE) has to survive long parking anyway. If you want the permanent-power + S3 model to become the architecture everywhere rather than just the test build, say so and I'll carry it through `power_domains_m910q.svg`, `SCHEMATY_POLACZEN.md` and the rest.

Verified: 419 tests pass, ruff clean, markdown links + anchors resolve, every SVG parses and the edited ones render without text collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cXmt2HyZ8iv3aQHpkNA4c

---
_Generated by [Claude Code](https://claude.ai/code/session_017cXmt2HyZ8iv3aQHpkNA4c)_