### PR TITLE
Name a real overvoltage cutoff module and fix where it draws power from

### DIFF
--- a/docs/LISTA_ZAKUPOWA.md
+++ b/docs/LISTA_ZAKUPOWA.md
@@ -4,7 +4,7 @@ Jedna lista do wariantu z [`WDROZENIE_TESTOWE.md`](WDROZENIE_TESTOWE.md):
 instalacja jeżdżąca z pełnym torem zasilania, Android Auto wireless, dźwiękiem
 przez mini-jack i przyciskami SWC.
 
-Ceny orientacyjne, rynek PL, 2025/2026. **Razem: ~479–923 PLN.**
+Ceny orientacyjne, rynek PL, 2025/2026. **Razem: ~494–948 PLN.**
 
 ---
 
@@ -40,7 +40,8 @@ Ceny orientacyjne, rynek PL, 2025/2026. **Razem: ~479–923 PLN.**
 | 2 | **Dioda MBR2545CT** | 25 A / 45 V, TO-220AB | blokada wsteczna; **obie anody zwarte** | 5–12 |
 | 3 | Radiator do TO-220 + podkładka mikowa | ok. 4,5 W strat | blaszka diody to katoda — musi być izolowana | 7–15 |
 | 4 | **Moduł CC-CV boost** | „900 W 15 A" z wyświetlaczem albo **SZBK07** | ładowarka: CV 14,40 V, CC 8 A | 50–140 |
-| 5 | Rozłącznik nadnapięciowy | przekaźnik napięciowy programowalny (XY-WJ01 lub odp.) | blokada przeładowania, próg 15,30 V | 40–80 |
+| 5 | **Rozłącznik nadnapięciowy** | **XH-M603** (albo XH-M604) — ta sama rodzina co XH-M609 | blokada przeładowania: 15,30 V / powrót 14,00 V | 40–80 |
+| 5a | Przekaźnik 30 A SPDT + podstawka (drugi) | Bosch 12 V | moduł steruje cewką zamiast przenosić 8 A — §6.3 ZASILANIE | 15–25 |
 | 6 | Dioda TVS | 1.5KE33CA albo SMCJ26CA | ochrona wejścia przed load dumpem | 5–10 |
 | 7 | Kondensator 470 µF / 35 V low-ESR × 2 | 105 °C | wejście ładowarki + wyjście XL6019 | 7–14 |
 | 8 | Dioda 1N4007 × 5 | | gaszenie cewek przekaźników | 2–5 |
@@ -64,7 +65,7 @@ Ceny orientacyjne, rynek PL, 2025/2026. **Razem: ~479–923 PLN.**
 | 26 | Skrzynka / wspornik na bank + pasy | na 5–8 pakietów | mocowanie do nadwozia | 60–120 |
 | 27 | Peszel + przelotki gumowe | 5 m + komplet | przejścia przez blachę | 25–40 |
 | 28 | Kabel USB z **przeciętą żyłą VBUS** | albo przetnij czerwoną w zwykłym | Nano ma własne 5 V — dwa źródła nie mogą się bić | 0–20 |
-| | | | **Razem** | **479–923** |
+| | | | **Razem** | **494–948** |
 
 ---
 

--- a/docs/SCHEMATY_POLACZEN.md
+++ b/docs/SCHEMATY_POLACZEN.md
@@ -530,8 +530,22 @@ obowiązują**.
 | 4 | Zapłon / ACC (albo **D+** alternatora) | **K1** zacisk **86** | 0,75 mm² | — |
 | 5 | **K1** zacisk **87** | **D1 MBR2545CT**, anody **1 + 3** zwarte | 2,5 mm² | — |
 | 6 | **D1** katoda **2** (blaszka) | Moduł CC-CV boost **IN+** | 2,5 mm² | — |
-| **B** | Boost **OUT+** | Rozłącznik nadnapięciowy **+ zasilanie** | 2,5 mm² | — |
-| 7 | Rozłącznik **NC** | Szyna **„+”** banku | 2,5 mm² | — |
+| **B** | Boost **OUT+** | **K2** (przekaźnik mocy) zacisk **30** | 2,5 mm² | — |
+| 7 | **K2** zacisk **87** | Szyna **„+”** banku | 2,5 mm² | — |
+| 7a | **K1** zacisk **87** | **XH-M603** zasilanie „+" | 0,75 mm² | — |
+| 7b | **XH-M603** zasilanie „−" | Punkt gwiazdowy masy | 0,75 mm² | — |
+| 7c | **K1** zacisk **87** | **XH-M603** styk **COM** | 0,75 mm² | — |
+| 7d | **XH-M603** styk **NO** | **K2** zacisk **86** (cewka) | 0,75 mm² | — |
+| 7e | **K2** zacisk **85** | Punkt gwiazdowy masy | 0,75 mm² | — |
+
+> **XH-M603 i cewka K2 wiszą na zacisku 87 przekaźnika ładowania, nie na
+> banku.** Na banku dokładałyby ~160 mA przez całą dobę — tyle, ile
+> w stanie wyłączonym pobiera cała reszta instalacji. Uzasadnienie
+> i zachowanie po zadziałaniu: §6.3 [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md).
+
+> **Dioda 1N4007** równolegle do cewki K2 (zaciski 85–86), katodą do „+”.
+> Przy **CC ≤ 6 A** można pominąć K2 i puścić 8 A wprost przez styki
+> modułu — wtedy przewody 7c–7e odpadają, a 7 idzie z **NO** modułu.
 
 Masy tego toru (K1 zacisk 85, „−” TVS/C1, boost **IN−** i **OUT−**, „−”
 zasilania rozłącznika) idą do punktu gwiazdowego — §10.4.

--- a/docs/WDROZENIE_TESTOWE.md
+++ b/docs/WDROZENIE_TESTOWE.md
@@ -449,7 +449,7 @@ kosztuje to tylko miejsce i trzy dodatkowe bezpieczniki, a podwaja zapas.
 | **XH-M609** | odcięcie **11,00 V**, powrót **12,60 V** | sprawdź, czy pracuje stabilnie przy 11 V |
 | **Przekaźnik ładowania** | cewka z zapłonu (albo D+) | dioda 1N4007 równolegle, katodą do „+” |
 | **CC-CV boost** | CV **14,40 V**, CC wg §3.3 | ustaw CV **bez obciążenia**, CC na sztucznym obciążeniu; nigdy poniżej napięcia wejściowego — §3.2 |
-| **Rozłącznik nadnapięciowy** | próg **15,30 V**, powrót **14,00 V** | test zasilaczem laboratoryjnym, nie „na aucie" |
+| **Rozłącznik nadnapięciowy** (XH-M603) | próg **15,30 V**, powrót **14,00 V** | test zasilaczem laboratoryjnym, nie „na aucie"; steruje cewką przekaźnika mocy — §6.3 ZASILANIE |
 
 Obowiązkowe sprawdzenia XL6019 i XH-M609 przed pierwszym załączeniem:
 [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) §3.4 i §7.3.
@@ -487,7 +487,7 @@ w osobnym dokumencie: **[`LISTA_ZAKUPOWA.md`](LISTA_ZAKUPOWA.md)**.
 
 | | |
 |---|---|
-| **Razem do kupienia** | **~479–923 PLN** |
+| **Razem do kupienia** | **~494–948 PLN** |
 | Największe pozycje | moduł CC-CV boost (50–140), rozłącznik nadnapięciowy (40–80), skrzynka na bank (60–120), rozłącznik masy (40–70) |
 | Czego **nie** kupujesz | VSR, ładowarka B2B, DAC USB, karta WiFi, buck dla panelu — pełna lista z powodami tamże |
 | Warto dołożyć | multimetr z pomiarem prądu DC 10 A — bez niego nie odbierzesz instalacji |

--- a/docs/ZASILANIE_BUFOROWANE.md
+++ b/docs/ZASILANIE_BUFOROWANE.md
@@ -687,23 +687,105 @@ napięcie na banku i rozwiera obwód ładowania, gdy przekroczy próg.
 | Próg rozwarcia | **15,30 V** | powyżej katalogowego maksimum 15,0 V, poniżej napięcia, przy którym AGM intensywnie odgazowuje |
 | Próg powrotu | **14,00 V** | poniżej absorpcji — nie klapkuje w kółko |
 | Zwłoka zadziałania | 1–3 s | ignoruje krótkie piki, reaguje na realne przeładowanie |
-| Obciążalność styków | ≥ 10 A | musi przenieść prąd ładowania z zapasem |
+| Prąd przez styki | **≤ 8 A** | tylko prąd ładowania — patrz §6.3 |
 
 ### 6.3 Realizacja
 
-**Moduł programowalnego przekaźnika napięciowego** (na rynku jako „DC 6–30 V
-programmable voltage control relay", np. XY-WJ01 lub odpowiednik z wyświetlaczem):
-ustawiasz próg załączenia i wyłączenia, moduł steruje przekaźnikiem. Koszt
-40–80 PLN.
+#### Ile prądu tam naprawdę płynie
 
-> **Sprawdź kierunek działania.** Większość tanich modułów jest fabrycznie
-> skonfigurowana jako ochrona **podnapięciowa** (załącz powyżej progu).
-> Potrzebujesz trybu odwrotnego: **rozwarcie powyżej progu**. Część modułów
-> ma to jako tryb pracy (F-1/F-2), część wymaga użycia styku NC zamiast NO.
-> Zweryfikuj na stole zasilaczem laboratoryjnym, zanim wepniesz to w auto.
+To pytanie decyduje o doborze modułu, więc najpierw ono. Rozłącznik siedzi
+**między wyjściem boostu a bankiem**, czyli w torze ładowania — nie w torze
+odbiorników. Płynie przez niego wyłącznie **prąd ładowania, ograniczony
+nastawą CC boostu** (§3.3 [`WDROZENIE_TESTOWE.md`](WDROZENIE_TESTOWE.md)),
+czyli maksymalnie **8 A** przy pięciu pakietach.
 
-Jeżeli styki modułu nie wyrabiają prądowo — steruj nimi **przekaźnik
-mocy 30 A** (ten sam typ, co przekaźnik zapłonu).
+Nie myl tego z XH-M609: ten stoi po stronie odbiorników i przenosi prąd
+komputera z panelem (do ~4,6 A), a ma przekaźnik 20 A — tam zapas jest duży.
+
+#### Konkretne moduły
+
+Rodzina XH-M60x, ta sama co posiadany XH-M609 — identyczna obsługa,
+wyświetlacz, przyciski, nastawa co 0,1 V:
+
+| Model | Zakres | Nastawy | Uwaga |
+|-------|--------|---------|-------|
+| **XH-M603** | zasilanie 10–30 V | próg górny i dolny osobno, precyzja 0,1 V | **domyślny wybór** — fabrycznie 12,0 / 14,5 V, przestaw na 14,00 / 15,30 V |
+| **XH-M604** | zasilanie 6–60 V | j.w. | gdy chcesz zapas napięciowy albo masz go pod ręką |
+| **XH-M601** / **XH-M602** | 12 V / 24 V | prostsze, część wersji bez regulacji obu progów | tylko jeśli potwierdzisz, że da się ustawić OBA progi |
+
+Logika XH-M603 jest dokładnie tą, której potrzebujemy: **zwiera, gdy
+napięcie jest poniżej progu górnego, rozwiera po jego przekroczeniu**,
+a wraca dopiero przy progu dolnym. To jest sterownik ładowania, nie
+ochrona podnapięciowa — nie trzeba go odwracać.
+
+#### „30 A” na przekaźniku to nie 30 A na module
+
+Na tych płytkach siedzi zwykle przekaźnik z nadrukiem 30 A / 14 VDC, ale
+**ograniczeniem jest płytka, nie przekaźnik**: ścieżki i zaciski śrubowe
+wytrzymują realnie ok. 10 A. Przy naszych 8 A jesteś w spec, ale bez
+komfortowego zapasu — i to jest właśnie powód, dla którego warto zrobić
+o jeden krok więcej.
+
+#### Zalecane: moduł jako pilot, moc na osobnym przekaźniku
+
+```
+XH-M603 styk (COM/NO)  →  cewka przekaźnika Bosch 30 A  (~150 mA)
+przekaźnik Bosch 30/87 →  w torze ładowania (te 8 A)
+```
+
+Moduł przełącza wtedy 150 mA zamiast 8 A i pytanie o obciążalność znika.
+Koszt: +15–25 PLN za przekaźnik z podstawką.
+
+> **Zepnij to tak, żeby awaria oznaczała „nie ładuje".** Cewka przekaźnika
+> mocy ma być **zasilana, gdy moduł mówi OK**. Wtedy przepalona cewka,
+> uszkodzony moduł albo urwany przewód sterujący dają rozwarty tor
+> ładowania — najgorsze, co się stanie, to nienaładowany bank. Odwrotne
+> zepnięcie (przekaźnik zwarty w spoczynku) przy awarii modułu zostawia
+> ładowanie bez nadzoru.
+>
+> Zanim zalutujesz: sprawdź miernikiem, przy którym stanie modułu jego
+> styk COM–NO jest zwarty. Wersje płytek się różnią.
+
+#### Zasilaj to z przekaźnika ładowania, nie z banku
+
+Łatwo tu zepsuć cały budżet postojowy. Cewka przekaźnika mocy bierze
+~150 mA, moduł XH-M603 kilka do kilkunastu mA. Gdyby wisiały na banku,
+**dokładałyby ~160 mA przez całą dobę** — czyli mniej więcej tyle, ile
+w stanie wyłączonym pobiera wszystko pozostałe razem wzięte (§2.1).
+
+Zasilaj więc i moduł, i cewkę **z zacisku 87 przekaźnika ładowania K1**:
+
+```
+K1 (zapłon)  ──87──┬── moduł CC-CV boost
+                   ├── XH-M603 zasilanie
+                   └── styk XH-M603 → cewka K2 (przekaźnik mocy)
+```
+
+Przy zgaszonym silniku K1 jest rozwarty, więc cały ten węzeł jest martwy:
+zero poboru, K2 rozwarty, tor ładowania przerwany podwójnie.
+
+**Skutek uboczny, który akurat działa na naszą korzyść:** moduł mierzy
+wtedy napięcie po stronie boostu. Po zadziałaniu wyjście boostu bez
+obciążenia nie spadnie do progu powrotu 14,00 V, więc rozłącznik zostaje
+**zatrzaśnięty do końca jazdy** i wraca dopiero po przekręceniu kluczyka.
+Dla usterki to lepsze zachowanie niż klapkowanie w kółko.
+
+#### Kiedy można pominąć K2
+
+Przy nastawie **CC ≤ 6 A** styki XH-M603 wyrabiają bez K2. Wtedy tor
+wygląda tak: boost OUT+ → COM modułu → NO modułu → szyna „+” banku,
+a moduł zasilasz z zacisku 87 K1 jak wyżej. Oszczędzasz 20 PLN i jedno
+złącze, kosztem pracy styków na granicy komfortu.
+
+#### Czego ten rozłącznik NIE robi
+
+**Nie chroni przed load dumpem.** Moduł reaguje w dziesiątkach do setek
+milisekund, a szpilka z alternatora trwa mikrosekundy — od tego jest dioda
+TVS na wejściu (§5.4). To dwie różne warstwy, jedna nie zastępuje drugiej.
+
+**Nie musi chronić odbiorników.** Bank trzyma napięcie szyny, a XL6019
+i LM2596 przyjmują 15–16 V bez mrugnięcia. Odcięcie samego ładowania
+w zupełności wystarcza.
 
 **Wariant A i tak potrzebuje tej warstwy.** Ładowarka Victron/Redarc jest
 bardzo niezawodna, ale nie jest niezniszczalna — a komplet pięciu HR1221W
@@ -984,7 +1066,7 @@ dłuższym postoju; jeśli tak wygląda Twój profil użytkowania, rozważ
 |---|---------|--------------|------|-----------|
 | 1 | **Ładowarka DC-DC** *(wariant A)* | Victron Orion-Tr Smart 12/12-18 lub odpowiednik z presetem **AGM** | 1 | 800–1000 |
 | | *albo:* przekaźnik + dioda + moduł CC-CV boost *(wariant B)* | przekaźnik 30 A SPDT + **MBR2545CT** na radiatorze · boost: **„900 W 15 A" z wyświetlaczem** albo **SZBK07** — pełne zestawienie w §5.3a i §5.3c | 1+1+1 | 70–180 |
-| 2 | **Rozłącznik nadnapięciowy** | programowalny przekaźnik napięciowy, próg 15,3 V / powrót 14,0 V | 1 | 40–80 |
+| 2 | **Rozłącznik nadnapięciowy** | **XH-M603** (albo XH-M604), próg 15,30 V / powrót 14,00 V — §6.3 | 1 | 40–80 |
 | 3 | ~~Moduł LVD~~ | **posiadany — XH-M609** | — | 0 |
 | 4 | **Przekaźnik zapłonu** | Bosch 12 V / 30 A SPDT + podstawka | 1 | 15–25 |
 | 5 | **Przekaźnik mocy** (do poz. 2, jeśli styki modułu za słabe) | 12 V / 30 A + podstawka | 1 | 15–25 |


### PR DESCRIPTION
## The current there is smaller than it looks

The cutoff sits **between the boost and the bank**, so it carries only the charging current — capped by the boost's CC setting at **8 A**. It is not in the load path. That's the XH-M609, which passes the computer's ~4.6 A through a 20 A relay and has plenty of margin. Two different devices, two different jobs; worth separating before picking a part.

## XH-M603

Same family as the XH-M609 already on the bench — same buttons, same display, 0.1 V steps, separate upper and lower thresholds. Its logic is already the one needed: **closed below the upper threshold, opens above it, returns at the lower one**. It's a charge controller, so nothing has to be inverted. Set 15.30 V / 14.00 V.

| Model | Supply | Note |
|-------|--------|------|
| **XH-M603** | 10–30 V | default pick; factory 12.0 / 14.5 V, change to 14.00 / 15.30 V |
| **XH-M604** | 6–60 V | if you want voltage headroom |
| XH-M601 / M602 | 12 V / 24 V | only if you confirm both thresholds are settable |

**The 30 A printed on the relay can is not 30 A through the board.** Traces and screw terminals on these modules are good for roughly 10 A, so 8 A is inside spec without much comfort. Hence the recommended shape: the module drives a Bosch 30 A relay's coil (~150 mA) and that relay carries the charge current. Below CC 6 A the module can do it alone — that's written down too.

## Two things that decide whether this works

**Fail direction.** The power relay must be energised *while the module says OK*, so a dead module, a burnt coil or a broken control wire all leave the charging path open. The worst outcome is a bank that didn't charge, never a bank that cooked.

**Where it draws power.** Hanging the module and the coil off the bank would add **~160 mA around the clock** — about as much as everything else draws in the off state (§2.1). Both go on **terminal 87 of the charging relay** instead, so the whole node is dead with the ignition off.

A useful side effect of that: the module then measures the boost side, so after a trip the output doesn't fall back to the 14.00 V return threshold. The cutoff stays **latched until the next key cycle** rather than chattering — better behaviour for a fault.

## What it doesn't do

- **Not load-dump protection.** It reacts in tens to hundreds of milliseconds; a load dump is microseconds. That's the TVS's job (§5.4). Two layers, neither replaces the other.
- **Doesn't need to protect the loads.** The bank clamps the rail, and both XL6019 and LM2596 take 15–16 V without complaint. Cutting the charger is enough.

## Files

- `docs/ZASILANIE_BUFOROWANE.md` §6.2/§6.3 — rewritten: current analysis, concrete modules, pilot + power relay, fail direction, supply point, what it doesn't do, when K2 can be skipped
- `docs/SCHEMATY_POLACZEN.md` §10.1 — wiring rows 7a–7e for the pilot arrangement
- `docs/LISTA_ZAKUPOWA.md` — XH-M603 named, second Bosch relay added, total **494–948 PLN**
- `docs/WDROZENIE_TESTOWE.md` — setpoint table and total updated

`XY-WJ01` is gone from the lists — it's a delay-timer module and was never the right family. My earlier naming there was wrong.

Verified: 422 tests pass, ruff clean, markdown links + anchors resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cXmt2HyZ8iv3aQHpkNA4c

---
_Generated by [Claude Code](https://claude.ai/code/session_017cXmt2HyZ8iv3aQHpkNA4c)_