### PR TITLE
Resize the bank to four packs and add a from-scratch Arduino guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ pip install -r requirements.txt -r requirements-x86.txt
   plus `bluetooth.enabled`, `wifi.enabled`, `fuel_sender.enabled`).
 - Arduino firmware (3 boards): `make -C arduino` compiles all sketches,
   `make -C arduino <sketch>-upload PORT=/dev/ttyXXX` flashes one —
-  see `docs/ARDUINO_SETUP_GUIDE.md`.
+  see `docs/ARDUINO_SETUP_GUIDE.md`. Never touched an Arduino before?
+  Start with `docs/ARDUINO_OD_ZERA.md` (PL) — cable, USB driver, IDE,
+  first upload and a bench test, step by step.
 - After changing Tailwind classes in the web UI run
   `config/scripts/build-frontend.sh` (CSS is precompiled — there is no
   runtime Tailwind engine).

--- a/docs/ARDUINO_OD_ZERA.md
+++ b/docs/ARDUINO_OD_ZERA.md
@@ -1,0 +1,414 @@
+# Arduino od zera — pierwsze wgranie firmware
+
+Przewodnik dla kogoś, kto **nigdy nie miał do czynienia z Arduino**. Zero
+założeń. Od „czym to w ogóle podłączyć" do działającego sterownika zasilania
+na biurku.
+
+Efekt końcowy: Arduino Nano, które wykrywa zapłon i „naciska" przycisk
+zasilania M910q — sprawdzone bez auta, na samym kablu USB.
+
+> **Cały ten przewodnik robisz przy biurku.** Nic tu nie wymaga auta,
+> akumulatorów ani 12 V. Arduino zasila się z USB komputera.
+
+---
+
+## Spis treści
+
+1. [Co to w ogóle jest](#1-co-to-w-ogóle-jest)
+2. [Czego potrzebujesz](#2-czego-potrzebujesz)
+3. [Instalacja Arduino IDE](#3-instalacja-arduino-ide)
+4. [Sterownik USB — najczęstsza przeszkoda](#4-sterownik-usb--najczęstsza-przeszkoda)
+5. [Pierwsze podłączenie płytki](#5-pierwsze-podłączenie-płytki)
+6. [Test „czy w ogóle działa" — miganie diodą](#6-test-czy-w-ogóle-działa--miganie-diodą)
+7. [Otwarcie firmware BCM](#7-otwarcie-firmware-bcm)
+8. [Konfiguracja minimalna na pierwszy raz](#8-konfiguracja-minimalna-na-pierwszy-raz)
+9. [Wgranie i sprawdzenie](#9-wgranie-i-sprawdzenie)
+10. [Test działania na biurku](#10-test-działania-na-biurku)
+11. [Kiedy coś nie działa](#11-kiedy-coś-nie-działa)
+12. [Druga płytka — Pro Micro](#12-druga-płytka--pro-micro)
+13. [Co dalej](#13-co-dalej)
+
+---
+
+## 1. Co to w ogóle jest
+
+Arduino Nano to mały komputerek wielkości gumy do żucia. Nie ma systemu
+operacyjnego — wgrywasz w niego **jeden program**, który startuje po
+podaniu zasilania i chodzi w kółko do odcięcia prądu.
+
+Trzy rzeczy, które warto wiedzieć od razu:
+
+| | |
+|---|---|
+| **Program nazywa się „sketch"** | to zwykły plik tekstowy `.ino` |
+| **Wgrywanie idzie po USB** | ten sam kabel służy do zasilania, wgrywania i podglądu tego, co płytka „mówi" |
+| **Wgranie nadpisuje poprzedni program** | nie da się mieć dwóch naraz, nie ma czego zepsuć na stałe |
+
+**Niczego nie zniszczysz przez złe wgranie.** Płytkę można zepsuć podając
+na nią 12 V albo zwierając zasilanie — ale nie programem. Wgrywaj śmiało.
+
+---
+
+## 2. Czego potrzebujesz
+
+### Kabel
+
+To pierwsza pułapka. Arduino Nano ma zwykle gniazdo **mini-USB** (starsze,
+trapez) albo **micro-USB** (nowsze, płaskie) — sprawdź, które masz na
+płytce, i dobierz kabel.
+
+> **Kabel musi być „do danych", nie sam do ładowania.** Tanie kable od
+> ładowarek mają często tylko żyły zasilania i **nie da się nimi nic
+> wgrać** — komputer w ogóle nie zobaczy płytki. Jeśli podłączasz i nic
+> się nie dzieje, to jest podejrzany numer jeden.
+
+### Komputer
+
+Windows, Linux albo macOS — wszystko jedno. Może to być ten sam M910q,
+na którym pracuje BCM.
+
+### Nic więcej
+
+Na tym etapie **nie podłączaj nic do pinów płytki**. Żadnych przewodów,
+żadnego 12 V, żadnego przekaźnika. Sam kabel USB.
+
+---
+
+## 3. Instalacja Arduino IDE
+
+Arduino IDE to program na komputer, w którym edytujesz sketch i wysyłasz
+go do płytki.
+
+1. Wejdź na **https://www.arduino.cc/en/software**
+2. Pobierz **Arduino IDE 2.x** dla swojego systemu
+3. Zainstaluj standardowo (Windows: `.exe`, macOS: przeciągnij do
+   Applications, Linux: AppImage — nadaj mu prawo wykonywania)
+
+Po pierwszym uruchomieniu IDE może chwilę pobierać komponenty. Poczekaj.
+
+### Dodanie obsługi płytki
+
+IDE domyślnie zna płytki Arduino, ale upewnijmy się:
+
+1. **Tools → Board → Boards Manager…** (albo ikona płytki na lewym pasku)
+2. Wpisz `Arduino AVR`
+3. Znajdź **„Arduino AVR Boards"** i kliknij **Install**, jeśli nie ma
+   przy nim wersji
+
+---
+
+## 4. Sterownik USB — najczęstsza przeszkoda
+
+Oryginalne Arduino Nano ma układ FTDI. **Klony — a Twój Nano V3 prawie
+na pewno jest klonem — mają układ CH340.** To zmienia jedną rzecz:
+komputer musi mieć sterownik CH340.
+
+| System | Co zrobić |
+|--------|-----------|
+| **Linux** | nic — sterownik `ch341` jest w jądrze od lat. Płytka pojawi się jako `/dev/ttyUSB0` |
+| **Windows 10/11** | zwykle instaluje się sam przez Windows Update. Jeśli nie: pobierz „CH340 driver" ze strony producenta (wch.cn) i zainstaluj |
+| **macOS** | nowsze wersje mają sterownik wbudowany; jeśli nie widać portu, poszukaj „CH34x macOS driver" |
+
+**Jak sprawdzić, czy zadziałało:** podłącz płytkę i zobacz, czy pojawia się
+nowy port (§5). Jeśli tak — sterownik jest w porządku.
+
+> **Na Linuksie może brakować uprawnień do portu.** Objaw: port widać, ale
+> IDE pisze „Permission denied". Naprawa:
+> ```bash
+> sudo usermod -aG dialout $USER
+> ```
+> i **wyloguj się i zaloguj ponownie** (albo zrestartuj komputer).
+
+---
+
+## 5. Pierwsze podłączenie płytki
+
+1. Podłącz Nano kablem USB do komputera
+2. Na płytce powinna zapalić się mała dioda zasilania (zwykle czerwona lub
+   zielona), a druga może zamigać kilka razy
+3. W Arduino IDE: **Tools → Port**
+
+Powinieneś zobaczyć nowy port:
+
+| System | Jak wygląda |
+|--------|-------------|
+| Windows | `COM3`, `COM4`, `COM7`… (numer dowolny) |
+| Linux | `/dev/ttyUSB0` |
+| macOS | `/dev/cu.wchusbserial…` |
+
+**Sztuczka na rozpoznanie, który to port:** otwórz listę portów, zapamiętaj,
+odłącz Arduino, otwórz listę ponownie — port, który zniknął, to Twój.
+
+### Wybór płytki
+
+**Tools → Board → Arduino AVR Boards → Arduino Nano**
+
+Potem **Tools → Processor**. Tu są dwie opcje i to bywa problem:
+
+- `ATmega328P`
+- `ATmega328P (Old Bootloader)`
+
+**Klony prawie zawsze potrzebują „Old Bootloader".** Jeśli wgrywanie
+kończy się błędem o timeoutach — wróć tu i przełącz na drugą opcję.
+
+---
+
+## 6. Test „czy w ogóle działa" — miganie diodą
+
+Zanim ruszymy firmware BCM, wgraj gotowy przykład. To zajmuje minutę
+i oddziela „coś nie działa w moim układzie" od „coś nie działa w ogóle".
+
+1. **File → Examples → 01.Basics → Blink**
+2. Kliknij strzałkę **→** (Upload) na górnym pasku
+3. Poczekaj — na dole zobaczysz pasek postępu, potem `Done uploading`
+
+**Efekt:** dioda `L` na płytce miga raz na sekundę.
+
+Jeśli to zadziałało, masz potwierdzone: kabel jest dobry, sterownik jest,
+port jest właściwy, płytka żyje. **Reszta to już tylko właściwy program.**
+
+Jeśli nie zadziałało — [§11](#11-kiedy-coś-nie-działa).
+
+---
+
+## 7. Otwarcie firmware BCM
+
+Firmware leży w repozytorium, w katalogu `arduino/sensor_hub/`.
+
+1. **File → Open…**
+2. Wskaż plik **`arduino/sensor_hub/sensor_hub.ino`**
+3. IDE otworzy go w nowym oknie
+
+> **Katalog musi się nazywać tak samo jak plik.** Arduino IDE tego wymaga
+> — i tak właśnie jest w repo (`sensor_hub/sensor_hub.ino`), więc nic nie
+> przenoś ani nie zmieniaj nazw.
+
+---
+
+## 8. Konfiguracja minimalna na pierwszy raz
+
+Sketch obsługuje dużo rzeczy: drzwi, ręczny, deszcz, temperaturę, czujniki
+parkowania. **Na pierwszy raz włączamy tylko to, co potrzebne do sterowania
+zasilaniem** — mniej rzeczy, mniej powodów do porażki, zero dodatkowych
+bibliotek do instalowania.
+
+Na początku pliku znajdź blok `#define FEATURE_…` i ustaw go tak:
+
+```cpp
+// #define FEATURE_DOORS      // ← zakomentowane
+// #define FEATURE_HBRAKE     // ← zakomentowane
+#define FEATURE_IGN           // ← ZOSTAJE
+// #define FEATURE_RAIN       // ← zakomentowane
+// #define FEATURE_TEMP       // ← zakomentowane (to ono wymaga bibliotek)
+#define FEATURE_PWRBTN        // ← ZOSTAJE
+// #define FEATURE_PWRLED     // ← na razie zakomentowane, patrz niżej
+```
+
+**Zakomentować = dopisać `//` na początku linii.** Odkomentować = usunąć te
+dwa znaki. To wszystko.
+
+### Dlaczego akurat tak
+
+| Wyłączamy | Powód |
+|-----------|-------|
+| `FEATURE_TEMP` | wymaga doinstalowania bibliotek OneWire i DallasTemperature — niepotrzebna komplikacja na start |
+| `FEATURE_DOORS`, `HBRAKE`, `RAIN` | nie masz jeszcze podłączonych czujników; bez nich sketch wysyłałby same zera |
+| `FEATURE_PWRLED` | wymaga podłączenia do diody panelu M910q, czego jeszcze nie zrobiłeś. **Na biurku wręcz przeszkadza** — patrz ostrzeżenie w §10 |
+
+`FEATURE_IGN` i `FEATURE_PWRBTN` zostają, bo to właśnie one są przedmiotem
+testu.
+
+---
+
+## 9. Wgranie i sprawdzenie
+
+1. Upewnij się, że **Board = Arduino Nano** i **Port** wskazuje Twoją płytkę
+2. Kliknij **✓** (Verify) — to tylko kompilacja, bez wysyłania.
+   Powinno skończyć się `Done compiling`
+3. Kliknij **→** (Upload)
+4. Czekaj na `Done uploading`
+
+### Podgląd tego, co płytka mówi
+
+1. **Tools → Serial Monitor** (albo ikona lupy/monitora w prawym górnym rogu)
+2. W prawym dolnym rogu monitora ustaw prędkość na **115200 baud**
+
+Powinieneś zobaczyć:
+
+```
+BCM v8.5 Sensor Hub ready
+IGN:0
+PWR:UNKNOWN
+IGN:0
+PWR:UNKNOWN
+```
+
+…i tak co dwie sekundy. **To jest sukces.** Płytka żyje, czyta zapłon
+(na razie „wyłączony") i raportuje stan komputera jako „nieznany".
+
+> **Otwarcie Serial Monitora resetuje płytkę.** To normalne — zobaczysz
+> wtedy ponownie „ready". Nie jest to objaw usterki.
+
+---
+
+## 10. Test działania na biurku
+
+Teraz sprawdzimy, czy logika naprawdę działa — **bez auta i bez 12 V**.
+
+Wejście zapłonu (pin **D9**) jest skonfigurowane jako `INPUT_PULLUP`:
+w spoczynku ma stan wysoki, a **zwarcie do masy oznacza „zapłon włączony"**.
+Docelowo robi to transoptor; na biurku wystarczy kawałek drutu.
+
+### Potrzebny sprzęt
+
+Jeden przewód połączeniowy (albo spinacz, albo kawałek drutu). Serio, tyle.
+
+### Przebieg
+
+| Krok | Co robisz | Co powinieneś zobaczyć w Serial Monitor |
+|------|-----------|------------------------------------------|
+| 1 | Nic — poczekaj 5 s po starcie | `IGN:0`, `PWR:UNKNOWN` |
+| 2 | Zewrzyj **D9** z **GND** (dowolny pin GND) | po ~2 s: `IGN:1`, potem `PWRACT:SHORT` i `PWR:RUNNING` |
+| 3 | Odczekaj 20 s | nic nowego — to cisza po impulsie |
+| 4 | Rozewrzyj D9 od GND | po ~2 s: `IGN:0`, potem `PWRACT:SHORT` i `PWR:SLEEP` |
+
+**`PWRACT:SHORT` to moment, w którym płytka „naciska" przycisk.** Gdyby był
+podłączony moduł przekaźnika, usłyszałbyś teraz kliknięcie.
+
+Jeśli te cztery kroki przechodzą — **firmware działa poprawnie i możesz
+przejść do montażu**.
+
+> **Dlaczego `FEATURE_PWRLED` przeszkadza na biurku.** Z włączonym odczytem
+> diody panelu płytka patrzy na pin A1. Nic tam nie jest podłączone, więc
+> odczyta „dioda zgaszona" = „komputer wyłączony". W kroku 4 nie wyśle
+> wtedy impulsu — i słusznie, bo nie usypia się czegoś, co jest wyłączone.
+> Wygląda to jak usterka, a jest poprawnym zachowaniem. Dlatego na testy
+> biurkowe zostaw tę funkcję zakomentowaną.
+
+### Podłączenie przekaźnika (opcjonalnie, żeby usłyszeć kliknięcie)
+
+Jeżeli masz już moduł przekaźnika 1-kanałowego i chcesz sprawdzić całość:
+
+| Moduł przekaźnika | Arduino Nano |
+|-------------------|--------------|
+| `VCC` | `5V` |
+| `GND` | `GND` |
+| `IN` | `A0` |
+
+Styków (`COM`, `NO`) na razie **nie podłączaj do niczego** — chodzi tylko
+o usłyszenie kliknięcia w krokach 2 i 4.
+
+---
+
+## 11. Kiedy coś nie działa
+
+| Objaw | Najczęstsza przyczyna | Co zrobić |
+|-------|----------------------|-----------|
+| **Brak portu w Tools → Port** | kabel tylko do ładowania, bez żył danych | weź inny kabel — to statystycznie numer jeden |
+| j.w. | brak sterownika CH340 | §4 |
+| j.w. | uszkodzone gniazdo USB na płytce | delikatnie poruszaj wtyczką — jeśli port miga i znika, gniazdo jest wyrwane |
+| **`avrdude: stk500_recv(): programmer is not responding`** | zły wybór „Processor" | Tools → Processor → **ATmega328P (Old Bootloader)** |
+| j.w. | zły port | sprawdź metodą odłącz–podłącz z §5 |
+| j.w. | Serial Monitor trzyma port | zamknij Serial Monitor i spróbuj ponownie |
+| **`Permission denied` (Linux)** | brak grupy `dialout` | `sudo usermod -aG dialout $USER`, wyloguj się i zaloguj |
+| **`Expected signature for ATmega328P`** | masz **328PB**, nie 328P | patrz niżej |
+| **W Serial Monitor same krzaki** | zła prędkość | ustaw **115200** w prawym dolnym rogu |
+| **Kompilacja: `OneWire.h: No such file`** | włączone `FEATURE_TEMP` | zakomentuj je (§8) albo doinstaluj biblioteki |
+| **Nic się nie dzieje po zwarciu D9** | zwarcie do złego pinu | GND jest kilka — użyj tego obok pinu `5V` |
+
+### Jeśli avrdude narzeka na sygnaturę (ATmega328PB)
+
+Twój Nano V3 może mieć układ **ATmega328PB** — to nie to samo co 328P
+i standardowy rdzeń Arduino go nie zna. Objaw jest jednoznaczny:
+
+```
+avrdude: Expected signature for ATmega328P is 1E 95 0F
+         Double check chip, or use -F to override this check.
+```
+
+Najprostsze rozwiązanie — **MiniCore**:
+
+1. **File → Preferences → Additional boards manager URLs**
+2. Wklej:
+   ```
+   https://mcudude.github.io/MiniCore/package_MCUdude_MiniCore_index.json
+   ```
+3. **Tools → Board → Boards Manager…** → wpisz `MiniCore` → **Install**
+4. **Tools → Board → MiniCore → ATmega328**
+5. Ustaw: **Variant → 328PB**, **Clock → 16 MHz external**,
+   **Bootloader → Yes (UART0)**
+6. Port jak wcześniej, i wgrywaj
+
+Sam firmware kompiluje się na obu układach bez zmian — używa wyłącznie
+peryferiów, które mają jedno i drugie.
+
+---
+
+## 12. Druga płytka — Pro Micro
+
+Pro Micro (ATmega32U4) obsługuje przyciski na kierownicy i udaje klawiaturę
+USB. Wgrywa się prawie tak samo, z dwiema różnicami.
+
+**Wybór płytki:** Tools → Board → Arduino AVR Boards → **Arduino Leonardo**
+(Pro Micro to jego odpowiednik; niektóre paczki mają wprost „SparkFun Pro
+Micro").
+
+**Reset przed wgraniem.** Pro Micro potrafi „zgubić" port po wgraniu
+programu, który go zajmuje. Jeśli wgrywanie się nie udaje:
+
+1. Kliknij **Upload**
+2. Gdy w konsoli pojawi się `Uploading…`, **szybko dwa razy zewrzyj pin
+   `RST` z `GND`** (albo dwa razy naciśnij przycisk reset, jeśli płytka
+   go ma)
+3. Płytka wejdzie na ~8 s w tryb bootloadera i wgrywanie ruszy
+
+Plik: **`arduino/rotary_encoder/rotary_encoder.ino`**.
+
+> **Pro Micro nie jest potrzebne do sterowania zasilaniem.** Tym zajmuje
+> się Nano. Pro Micro dochodzi wtedy, gdy podłączasz pody SWC.
+
+---
+
+## 13. Co dalej
+
+Firmware działa na biurku. Kolejność montażu:
+
+1. **Zbuduj układ wejściowy zapłonu** — transoptor PC817 i rezystory,
+   wartości i schemat: [`../schematics/ignition_sense.svg`](../schematics/ignition_sense.svg)
+2. **Podłącz moduł przekaźnika** równolegle do przycisku zasilania M910q —
+   zaciski i numery przewodów w [`SCHEMATY_POLACZEN.md`](SCHEMATY_POLACZEN.md) §10.5
+3. **Zasil Nano z MP1584**, nie z USB M910q — i **przetnij żyłę VBUS**
+   w kablu USB. Powód: M910q odcina zasilanie portów w S3, więc płytka
+   zasilana z USB zgasłaby razem z nim i nie miałaby czym nacisnąć przycisku
+4. **Włącz `FEATURE_PWRLED`** dopiero po podłączeniu odczytu diody panelu
+
+Szerszy kontekst — po co to wszystko i jak działa całość:
+[`WDROZENIE_TESTOWE.md`](WDROZENIE_TESTOWE.md) §3.1a.
+
+### Ponowne wgranie po zmianach
+
+Kolejne wgrania to już tylko: podłącz USB → sprawdź Port → **Upload**.
+Zmiana `#define`, zmiana progu, poprawka — za każdym razem ta sama droga.
+
+### Dla wygodnych: bez klikania
+
+Repozytorium ma też Makefile, jeśli wolisz terminal:
+
+```bash
+make -C arduino sensor_hub                       # sama kompilacja
+make -C arduino sensor_hub-upload PORT=/dev/ttyUSB0
+```
+
+Wymaga zainstalowanego `arduino-cli`. **Na początek zostań przy IDE** —
+Makefile jest wygodny, gdy już wiesz, co robisz.
+
+---
+
+## Powiązane dokumenty
+
+| Dokument | Zakres |
+|----------|--------|
+| [`ARDUINO_SETUP_GUIDE.md`](ARDUINO_SETUP_GUIDE.md) | pełne tabele pinów wszystkich trzech płytek, kalibracja SWC |
+| [`WDROZENIE_TESTOWE.md`](WDROZENIE_TESTOWE.md) | po co to sterowanie zasilaniem i ile kosztuje |
+| [`SCHEMATY_POLACZEN.md`](SCHEMATY_POLACZEN.md) | zaciski i numery przewodów (§10.4 i §10.5) |
+| [`../schematics/ignition_sense.svg`](../schematics/ignition_sense.svg) | schemat układu wejściowego z wartościami elementów |

--- a/docs/ARDUINO_SETUP_GUIDE.md
+++ b/docs/ARDUINO_SETUP_GUIDE.md
@@ -4,6 +4,13 @@ This guide walks you through flashing the two Arduino boards used by the
 BCM headunit on the x86 (Lenovo M910q) platform, from a completely fresh
 start. **No prior Arduino experience required.**
 
+> **Absolute beginner — never plugged an Arduino in at all?** Read
+> [`ARDUINO_OD_ZERA.md`](ARDUINO_OD_ZERA.md) (PL) first. It covers the
+> layer below this guide: which cable, the CH340 driver, installing the
+> IDE, finding the serial port, a Blink smoke test, and a minimal
+> first-upload config for `sensor_hub` that needs no external libraries.
+> Come back here for the full pin tables and SWC calibration.
+
 You will end up with:
 
 | Board | Role | Sketch | USB device |

--- a/docs/LISTA_ZAKUPOWA.md
+++ b/docs/LISTA_ZAKUPOWA.md
@@ -4,7 +4,7 @@ Jedna lista do wariantu z [`WDROZENIE_TESTOWE.md`](WDROZENIE_TESTOWE.md):
 instalacja jeżdżąca z pełnym torem zasilania, Android Auto wireless, dźwiękiem
 przez mini-jack i przyciskami SWC.
 
-Ceny orientacyjne, rynek PL, 2025/2026. **Razem: ~494–948 PLN.**
+Ceny orientacyjne, rynek PL, 2025/2026. **Razem: ~483–928 PLN.**
 
 ---
 
@@ -17,7 +17,7 @@ Ceny orientacyjne, rynek PL, 2025/2026. **Razem: ~494–948 PLN.**
 | Karta WiFi MediaTek MT7921 | P2P-GO dla Android Auto wireless |
 | Pody SWC + dekoder rezystorowy | przyciski na kierownicy |
 | Modem LTE Huawei E3372 (HiLink) | internet |
-| CSB HR1221W F2 × 8 (12 V / 5,1 Ah AGM) | bank buforowy — użyj 5, lepiej 8 |
+| CSB HR1221W F2 × 8 (12 V / 5,1 Ah AGM) | bank buforowy — **użyj 4 (20,4 Ah)**, tyle się mieści |
 | **XL6019** | step-up 12 → 19,5 V dla M910q |
 | **XH-M609** | LVD, ochrona banku |
 | **Arduino Pro Micro** (ATmega32U4) | SWC, enkoder, przyciski — USB HID |
@@ -51,7 +51,7 @@ Ceny orientacyjne, rynek PL, 2025/2026. **Razem: ~494–948 PLN.**
 | 12 | Rezystory 1/4 W | 2,2 kΩ × 2, 10 kΩ × 2, 1 kΩ × 2 | do transoptorów i pull-upów | 5–10 |
 | 13 | Kondensator 100 nF × 2 | ceramiczny | filtr na wejściach zapłonu i diody | 2–4 |
 | 14 | Bezpiecznik **15 A** + oprawka | przy klemie „+" | zasilanie ładowarki | 15–25 |
-| 15 | Bezpieczniki inline **10 A × 5** + oprawki | | po jednym na pakiet banku | 25–40 |
+| 15 | Bezpieczniki inline **10 A × 4** + oprawki | | po jednym na pakiet banku | 20–32 |
 | 16 | Bezpiecznik inline **15 A** + oprawka | | wejście XH-M609 | 8–12 |
 | 17 | Bezpiecznik **7,5 A** + oprawka | | odgałęzienie XL6019 | 8–12 |
 | 18 | Bezpiecznik **3 A** + oprawka × 2 | | LM2596 (podświetlenie) i MP1584 (Nano) | 12–20 |
@@ -62,10 +62,10 @@ Ceny orientacyjne, rynek PL, 2025/2026. **Razem: ~494–948 PLN.**
 | 23 | Nasuwki **F2 6,35 mm** izolowane | komplet | zaciski akumulatorów HR1221W | 15–25 |
 | 24 | Konektory oczkowe, tulejki, koszulki | zestaw, koszulki z klejem | | 30–50 |
 | 25 | **Rozłącznik masy 100 A** | kluczykowy albo pokrętło | jedyne realne zero poboru na postoju | 40–70 |
-| 26 | Skrzynka / wspornik na bank + pasy | na 5–8 pakietów | mocowanie do nadwozia | 60–120 |
+| 26 | Skrzynka / wspornik na bank + pasy | na 4 pakiety (7,2 kg) | mocowanie do nadwozia | 50–100 |
 | 27 | Peszel + przelotki gumowe | 5 m + komplet | przejścia przez blachę | 25–40 |
 | 28 | Kabel USB z **przeciętą żyłą VBUS** | albo przetnij czerwoną w zwykłym | Nano ma własne 5 V — dwa źródła nie mogą się bić | 0–20 |
-| | | | **Razem** | **494–948** |
+| | | | **Razem** | **483–928** |
 
 ---
 
@@ -88,7 +88,7 @@ Ceny orientacyjne, rynek PL, 2025/2026. **Razem: ~494–948 PLN.**
 |---------|----------|
 | VSR / separator akumulatorów | zastąpiony przekaźnikiem z zapłonu i diodą — §5.3c [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) |
 | Ładowarka B2B (Victron / Redarc) | wariant z przekaźnikiem i boostem robi to samo za ~1/5 ceny |
-| Moduł buck-boost LTC3780 | utrzyma 13,8 V, ale tylko 80 W ciągle — za mało przy pięciu pakietach |
+| Moduł buck-boost LTC3780 | utrzyma 13,8 V, ale tylko 80 W ciągle — za mało nawet przy czterech pakietach |
 | Czujnik NTC | tanie moduły CC-CV nie mają wejścia kompensacji |
 | Przewód 6 mm², bezpiecznik główny 30 A | wymiarowane pod ładowarkę B2B, nie pod 8 A |
 | Buck 12 → 5 V dla panelu | logika i dotyk idą po USB z M910q |
@@ -105,6 +105,7 @@ Ceny orientacyjne, rynek PL, 2025/2026. **Razem: ~494–948 PLN.**
 | Dokument | Zakres |
 |----------|--------|
 | [`WDROZENIE_TESTOWE.md`](WDROZENIE_TESTOWE.md) | co z tym zrobić — krok po kroku |
+| [`ARDUINO_OD_ZERA.md`](ARDUINO_OD_ZERA.md) | wgranie firmware na Nano — od kabla po test na biurku |
 | [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) | nastawy, uzasadnienia, lista dla wersji docelowej (§10) |
 | [`SCHEMATY_POLACZEN.md`](SCHEMATY_POLACZEN.md) | tabele „skąd → dokąd" (§10 — wariant testowy) |
 | [`../schematics/schematic_test_build.svg`](../schematics/schematic_test_build.svg) | schemat ideowy |

--- a/docs/PODSUMOWANIE_KONSOLIDACJI.md
+++ b/docs/PODSUMOWANIE_KONSOLIDACJI.md
@@ -146,7 +146,7 @@ i limit prądu **15–20 A**.
 |----------|--------------|------------------------------|---------|
 | Absorpcja @ 25 °C | 14,4 V | 14,4–15,0 V (cykl) | ✅ prawidłowo |
 | Float @ 25 °C | 13,8 V | 13,5–13,8 V (bufor) | ✅ prawidłowo |
-| Maks. prąd ładowania | 15–20 A | **2,1 A/pakiet → 10,5 A na 5** | ❌ za wysoko |
+| Maks. prąd ładowania | 15–20 A | **2,1 A/pakiet → 8,4 A na 4** | ❌ za wysoko |
 | Kompensacja temperaturowa | brak | **−18 mV/°C** float, **−30 mV/°C** cykl | ❌ brak |
 
 **Dlaczego prąd ma znaczenie.** Ładowanie powyżej katalogowego limitu grzeje
@@ -212,10 +212,15 @@ Przy faktycznej pojemności 25,5 Ah i ograniczeniu do 50 % DoD wychodzi
 
 | Pakiety | Pojemność | Do 30 % DoD | Do 50 % DoD | Do progu LVD |
 |---------|-----------|-------------|-------------|--------------|
-| 4 | 20,4 Ah | ~4,3 dnia | ~7,1 dnia | ~10,6 dnia |
-| **5** | **25,5 Ah** | **~5,3 dnia** | **~8,9 dnia** | **~13,3 dnia** |
+| **4** | **20,4 Ah** | **~4,3 dnia** | **~7,1 dnia** | **~10,6 dnia** |
+| 5 | 25,5 Ah | ~5,3 dnia | ~8,9 dnia | ~13,3 dnia |
 | 6 | 30,6 Ah | ~6,4 dnia | ~10,6 dnia | ~15,9 dnia |
 | 8 | 40,8 Ah | ~8,5 dnia | ~14,2 dnia | ~21,3 dnia |
+
+> Wiersz 5 był pierwotnie przyjęty jako optimum energetyczne. Ostatecznie
+> bank ma **cztery pakiety** — ograniczenie jest fizyczne (nie ma gdzie
+> schować więcej), nie energetyczne. Aktualne liczby: §4.2
+> [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md).
 
 Kolumna 30 % DoD doszła dlatego, że HR to seria buforowa (UPS), a nie
 trakcyjna — płytsze rozładowanie wyraźnie wydłuża jej życie.
@@ -364,6 +369,7 @@ docs/
 ├── URUCHOMIENIE.md             ← symulacja, przełączniki modułów
 ├── X86_PLATFORM_SETUP.md       ← referencja krok-po-kroku (EN)
 ├── ARDUINO_SETUP_GUIDE.md      ← okablowanie trzech płytek
+├── ARDUINO_OD_ZERA.md          ← pierwsze wgranie firmware (NOWY)
 ├── KLINE_SNIFFING.md           ← podsłuch K-Line, PID-y ECU
 └── x86-production/             ← 12 rozdziałów HTML z ilustracjami
 

--- a/docs/SCHEMATY_POLACZEN.md
+++ b/docs/SCHEMATY_POLACZEN.md
@@ -558,7 +558,7 @@ zasilania rozłącznika) idą do punktu gwiazdowego — §10.4.
 
 | # | Skąd | Dokąd | Przewód | Zabezpieczenie |
 |---|------|-------|---------|----------------|
-| — | „+” każdego pakietu HR1221W | Szyna **„+”** banku | 2,5 mm² | **F2…F6** 10 A, osobno na pakiet |
+| — | „+” każdego pakietu HR1221W | Szyna **„+”** banku | 2,5 mm² | **F2…F5** 10 A, osobno na pakiet |
 | — | „−” każdego pakietu | Szyna **„−”** banku | 2,5 mm² | — |
 | 8 | Szyna **„+”** banku | **XH-M609 VIN+** | 2,5 mm² | **F7** 15 A |
 | 9 | Szyna **„−”** banku | **XH-M609 VIN−** | 2,5 mm² | — |
@@ -651,7 +651,7 @@ idzie do masy instalacji auta.
    XL6019 19,5 V · LM2596 wg panelu · boost 14,40 V / 8 A
    rozłącznik 15,30 V · XH-M609 11,00 / 12,60 V
 3. Punkt gwiazdowy masy — komplet z §10.5.
-4. Bank z bezpiecznikami F2…F6, pomiar napięcia na szynie.
+4. Bank (4 pakiety) z bezpiecznikami F2…F5, pomiar napięcia na szynie.
 5. Przewody 8, 9, 10 — bank przez F7 do LVD i S1.
 6. Przewody 11 i 12 — XL6019. POMIAR 19,5 V BEZ podłączonego M910q.
 7. Dopiero teraz M910q, potem 13–14 (podświetlenie).

--- a/docs/URUCHOMIENIE.md
+++ b/docs/URUCHOMIENIE.md
@@ -212,6 +212,10 @@ Okablowanie pin-po-pinie: **[docs/ARDUINO_SETUP_GUIDE.md](ARDUINO_SETUP_GUIDE.md
 — §7 (Nano always-on) i **§7b (sensor hub)**. Szybki test sensor huba:
 `picocom -b 115200 /dev/ttyUSB1` → linie `DOOR:...`, `IGN:0`, `TEMP:21.4`.
 
+Jeśli `arduino-cli` i `make` to dla Ciebie za dużo naraz — to samo przez
+klikanie w Arduino IDE, od instalacji sterownika po pierwsze wgranie:
+**[docs/ARDUINO_OD_ZERA.md](ARDUINO_OD_ZERA.md)**.
+
 ---
 
 ## 5. Przełączniki modułów (wszystkie)

--- a/docs/WDROZENIE_M910Q.md
+++ b/docs/WDROZENIE_M910Q.md
@@ -53,6 +53,7 @@ sprzęt → zasilanie → BIOS → OS → BCM → usługi → kiosk → peryferi
 | Szczegóły zasilania buforowanego | [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) |
 | Tabele połączeń, przekroje, kolejność montażu | [`SCHEMATY_POLACZEN.md`](SCHEMATY_POLACZEN.md) |
 | Rozmieszczenie podzespołów w aucie | [`../schematics/vehicle_layout_m910q.svg`](../schematics/vehicle_layout_m910q.svg) |
+| Pierwsze wgranie firmware na Arduino (od zera) | [`ARDUINO_OD_ZERA.md`](ARDUINO_OD_ZERA.md) |
 | Okablowanie Arduino pin-po-pinie | [`ARDUINO_SETUP_GUIDE.md`](ARDUINO_SETUP_GUIDE.md) |
 | Podsłuch K-Line, poznawanie PID-ów | [`KLINE_SNIFFING.md`](KLINE_SNIFFING.md) |
 | Wersja ilustrowana (12 rozdziałów HTML) | [`x86-production/index.html`](x86-production/index.html) |
@@ -169,19 +170,20 @@ Tutaj tylko to, co trzeba wiedzieć, żeby zrozumieć resztę wdrożenia.
 odbiornika — jest sygnałem, który Arduino zamienia na impuls na styki
 **przycisku zasilania M910q**:
 
-| Stan | Pobór z banku | Postój (5 pakietów) |
-|------|---------------|---------------------|
+| Stan | Pobór z banku | Postój (4 pakiety, 20,4 Ah) |
+|------|---------------|------------------------------|
 | Praca | 10–55 W | — |
-| **S3** (kluczyk OFF) | 400–550 mA | ~1,2 dnia |
-| **Wyłączony** (impuls 5 s po 2 h) | 100–200 mA | ~3,5–5,3 dnia |
+| **S3** (kluczyk OFF) | 200–460 mA | ~0,9–2,1 dnia |
+| **Wyłączony** (impuls 5 s po 2 h) | 50–150 mA | ~2,8–8,5 dnia |
 
 Jedyny przekaźnik w torze mocy siedzi w **ładowaniu**, nie w odbiornikach.
 Uzasadnienie i porównanie z porzuconym modelem „domena B":
 [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) §2.2.
 
-Między akumulatorem auta a head unitem stoi **bank 5 × CSB HR1221W F2**
-(12 V / 5,1 Ah AGM, razem 25,5 Ah), ładowany przez ładowarkę CC-CV z profilem
-**AGM** (14,40 V absorpcji / 13,65 V float, maks. 10,5 A wg karty katalogowej),
+Między akumulatorem auta a head unitem stoi **bank 4 × CSB HR1221W F2**
+(12 V / 5,1 Ah AGM, razem 20,4 Ah — więcej fizycznie się nie mieści),
+ładowany przez ładowarkę CC-CV z profilem **AGM** (14,40 V absorpcji /
+13,65 V float, maks. 8,4 A wg karty katalogowej),
 chroniony rozłącznikiem nadnapięciowym (15,3 V) i modułem **XH-M609** jako
 LVD (11,0 / 12,60 V). M910q zasila **przetwornica step-up XL6019**
 (12 → 19,5 V) za przekaźnikiem zapłonu.
@@ -989,7 +991,7 @@ Wnioski:
 
 **Napięcia są prawidłowe** — HR1221W to AGM, a karta katalogowa CSB dopuszcza
 14,4–15,0 V cyklicznie i 13,5–13,8 V buforowo. **Limit prądu nie jest**:
-katalog podaje 2,1 A na pakiet, czyli 10,5 A dla banku pięciu. Brakuje też
+katalog podaje 2,1 A na pakiet, czyli 8,4 A dla banku czterech. Brakuje też
 kompensacji temperaturowej (−18 mV/°C float, −30 mV/°C cykl).
 
 Obowiązujące nastawy: [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) §4.4–§4.5 i §5.
@@ -1055,6 +1057,7 @@ mimo neutralnej nazwy. Został zarchiwizowany jako
 | [`URUCHOMIENIE.md`](URUCHOMIENIE.md) | symulacja na laptopie, przełączniki modułów, Arduino w skrócie |
 | [`X86_PLATFORM_SETUP.md`](X86_PLATFORM_SETUP.md) | referencja krok-po-kroku (EN) — pamiętaj o §19 |
 | [`x86-production/index.html`](x86-production/index.html) | 12 rozdziałów z ilustracjami |
+| [`ARDUINO_OD_ZERA.md`](ARDUINO_OD_ZERA.md) | pierwsze wgranie firmware — dla zupełnie początkujących |
 | [`ARDUINO_SETUP_GUIDE.md`](ARDUINO_SETUP_GUIDE.md) | okablowanie trzech płytek Arduino |
 | [`KLINE_SNIFFING.md`](KLINE_SNIFFING.md) | podsłuch K-Line, poznawanie PID-ów ECU |
 | [`../schematics/README.md`](../schematics/README.md) | indeks schematów elektrycznych |

--- a/docs/WDROZENIE_TESTOWE.md
+++ b/docs/WDROZENIE_TESTOWE.md
@@ -122,7 +122,7 @@ moduł CC-CV boost  (CV 14,40 V, CC wg §3.3)
 rozłącznik nadnapięciowy (próg 15,30 V)   ← warstwa 2
    │
    ▼
-BANK AGM 5 × HR1221W ── bezpiecznik 10 A na „+" każdego pakietu
+BANK AGM 4 × HR1221W ── bezpiecznik 10 A na „+" każdego pakietu
    │
    ▼
 XH-M609 (LVD)  ── bezpiecznik 15 A przed VIN+
@@ -166,25 +166,28 @@ Cena też jest realna — i to jest najważniejsza liczba w tej zmianie:
 
 | Stan na postoju | Pobór z banku |
 |-----------------|---------------|
-| M910q w S3 | 1,5–3 W |
-| straty XL6019 przy tak małym obciążeniu | 1–1,5 W |
-| XH-M609 (zmierz!) | 0,25–1,5 W |
-| **Razem** | **~3–6 W, czyli 240–480 mA** |
+| M910q w S3 (przez XL6019) | 160–320 mA |
+| Arduino Nano przez MP1584 | ~15 mA |
+| XH-M609 — **zmierz**, to jedyna niewiadoma | 20–125 mA |
+| **Razem** | **200–460 mA** |
 
-| Pakiety | 240 mA | 350 mA | 480 mA |
-|---------|--------|--------|--------|
-| 5 (25,5 Ah) | ~2,2 dnia | ~1,5 dnia | ~1,1 dnia |
-| 8 (40,8 Ah) | ~3,5 dnia | ~2,4 dnia | ~1,8 dnia |
+> **Wyświetlacz nie występuje w tej tabeli i to jest sprawdzone.** M910q
+> **odcina zasilanie portów USB w S3**, więc panel gaśnie razem
+> z komputerem i nie pobiera nic. Z tego samego powodu „Wake on USB" jest
+> tu bezużyteczne, a Arduino **musi** mieć własne 5 V z MP1584 — inaczej
+> zgaśnie razem z portem i nie będzie czym nacisnąć przycisku.
 
-Po **twardym wyłączeniu** (a nie S3) zostaje sam pobór przetwornic i LVD,
-czyli ~80–120 mA — wtedy 5 pakietów daje **4,4–5,3 dnia**, a 8 pakietów
-**7,1–8,5 dnia**. Dlatego eskalacja z S3 do pełnego wyłączenia po kilku
-godzinach jest tu naprawdę warta zachodu — a przy sterowaniu przyciskiem
-zasilania kosztuje tyle, co dłuższy impuls.
+| Stan | Pobór | 4 pakiety (20,4 Ah, do 50 % DoD) |
+|------|-------|----------------------------------|
+| **S3** | 200–460 mA | **0,9–2,1 dnia** |
+| **Wyłączony** (impuls 5 s) | 50–150 mA | **2,8–8,5 dnia** |
 
-Wszystko do 50 % DoD. Dla porównania: przy twardym odcięciu domeny B
-wychodziło **~13 dni**. Utrata jest sześciokrotna i wynika wprost z tego,
-że S3 to nie jest zero.
+Dlatego eskalacja z S3 do pełnego wyłączenia po dwóch godzinach jest tu
+naprawdę warta zachodu — a przy sterowaniu przyciskiem zasilania kosztuje
+tyle, co dłuższy impuls.
+
+Rozrzut w obu wierszach bierze się prawie w całości z XH-M609. Zmierz go
+raz, a obie liczby zrobią się konkretne.
 
 Co z tym zrobić:
 
@@ -410,30 +413,31 @@ CC = obciążenie (≈3,5 A) + docelowy prąd ładowania
 
 | Pakiety | Sufit katalogowy | Zalecane CC | Netto do banku |
 |---------|------------------|-------------|----------------|
+| **4** | **8,4 A** | **7,5 A** | **4,0 A** |
 | 3 | 6,3 A | 6,0 A | 2,5 A |
-| **5** | **10,5 A** | **8,0 A** | **4,5 A** |
-| 8 | 16,8 A | 10,0 A (limit modułu) | 6,5 A |
 
-Przy 8 A ciągłego prądu tani moduł „300 W / 10 A" **wymaga radiatora
-i przewiewu** — traktuj katalogowe 10 A jako wartość szczytową, nie roboczą.
+Bank ma cztery pakiety, więc sufit katalogowy to **8,4 A** — nastawa 7,5 A
+zostawia pod nim ~11 % zapasu i daje 4,0 A netto do banku. Przy takim
+prądzie tani moduł **wymaga radiatora i przewiewu**; katalogowe 10 A na
+puszce traktuj jako wartość szczytową, nie roboczą.
 
 ### 3.4 Ile pakietów
 
-**Pięć (25,5 Ah) to minimum, osiem jest wyraźnie lepsze.** Stałe zasilanie
-i S3 podniosły pobór postojowy z kilkudziesięciu miliamperów do kilkuset
-(§3.1a), więc pojemność zaczęła realnie decydować o tym, ile dni auto może
-postać. Trzy pakiety odpadają.
+**Cztery (20,4 Ah)** — i nie jest to wybór energetyczny, tylko fizyczny:
+więcej po prostu nie ma gdzie schować. Pozostałe cztery z ośmiu zostają
+jako zapas.
 
-| Pakiety | Pojemność | Praca przy zgaszonym silniku (3,5 A) | Postój w S3 (350 mA) | Doładowanie z 50 % |
+| Pakiety | Pojemność | Praca przy zgaszonym silniku (3,5 A) | Postój w S3 (300 mA) | Doładowanie z 50 % |
 |---------|-----------|--------------------------------------|----------------------|--------------------|
-| 3 | 15,3 Ah | ~2,2 h | ~0,9 dnia | ~3,1 h jazdy |
-| **5** | **25,5 Ah** | **~3,6 h** | **~1,5 dnia** | **~2,8 h jazdy** |
-| 8 | 40,8 Ah | ~5,8 h | ~2,4 dnia | ~3,1 h jazdy |
+| **4** | **20,4 Ah** | **~2,9 h** | **~1,4 dnia** | **~2,6 h jazdy** |
+| 5 | 25,5 Ah | ~3,6 h | ~1,8 dnia | ~2,8 h jazdy |
 
-Wszystko liczone do 50 % DoD. Kolumna „postój" zakłada środek widełek
-z §3.1a — pełny rozrzut (240–480 mA) jest tam w osobnej tabeli. Skoro
-i tak masz osiem pakietów, **na czas testów wstaw wszystkie osiem**:
-kosztuje to tylko miejsce i trzy dodatkowe bezpieczniki, a podwaja zapas.
+Wszystko do 50 % DoD; pełny rozrzut poboru w S3 (200–460 mA) jest w §3.1a.
+
+Co kosztuje zejście z pięciu na cztery: 20 % pojemności, czyli ok. pół doby
+postoju w S3 i godzinę pracy przy zgaszonym silniku. Prąd ładowania schodzi
+z 8,0 na 7,5 A, żeby zmieścić się pod katalogowym sufitem 8,4 A. Nic poza
+tym się nie zmienia — układ zasilania zostaje bez zmian.
 
 > Krótkie przejazdy po mieście nie doładują banku po dłuższym postoju.
 > Kolumna „doładowanie" zakłada ciągłą jazdę z pracującym alternatorem.
@@ -487,13 +491,14 @@ w osobnym dokumencie: **[`LISTA_ZAKUPOWA.md`](LISTA_ZAKUPOWA.md)**.
 
 | | |
 |---|---|
-| **Razem do kupienia** | **~494–948 PLN** |
+| **Razem do kupienia** | **~483–928 PLN** |
 | Największe pozycje | moduł CC-CV boost (50–140), rozłącznik nadnapięciowy (40–80), skrzynka na bank (60–120), rozłącznik masy (40–70) |
 | Czego **nie** kupujesz | VSR, ładowarka B2B, DAC USB, karta WiFi, buck dla panelu — pełna lista z powodami tamże |
 | Warto dołożyć | multimetr z pomiarem prądu DC 10 A — bez niego nie odbierzesz instalacji |
 
-Masz już: M910q, ekran 7", MT7921, pody SWC, modem LTE, 8 × HR1221W,
-XL6019, XH-M609, Pro Micro, Nano V3, LM2596 i MP1584.
+Masz już: M910q, ekran 7", MT7921, pody SWC, modem LTE, 8 × HR1221W
+(**do banku idą 4** — §3.4), XL6019, XH-M609, Pro Micro, Nano V3,
+LM2596 i MP1584.
 
 ---
 
@@ -551,6 +556,11 @@ i naciskaj kolejne przyciski wg podpowiedzi na porcie szeregowym. Progi
 zapisują się w EEPROM.
 
 Szczegóły: [`ARDUINO_SETUP_GUIDE.md`](ARDUINO_SETUP_GUIDE.md).
+
+> **Pierwszy raz z Arduino?** Zanim dojdziesz do kalibracji SWC, wgraj
+> firmware wg [`ARDUINO_OD_ZERA.md`](ARDUINO_OD_ZERA.md) — od kabla
+> i sterownika USB, przez IDE, po test na biurku. Ten dokument zakłada,
+> że nie miałeś wcześniej płytki w ręku.
 
 ### 5.6 Android Auto wireless (P2P-GO)
 
@@ -751,5 +761,6 @@ przejdź na `bcm_config.yaml`, gdy większość będzie już podłączona.
 | [`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md) | wdrożenie docelowe, pełne |
 | [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) | warianty ładowania, nastawy modułów, sprawdzenia przed załączeniem |
 | [`SCHEMATY_POLACZEN.md`](SCHEMATY_POLACZEN.md) | tabele połączeń dla wersji docelowej |
+| [`ARDUINO_OD_ZERA.md`](ARDUINO_OD_ZERA.md) | **pierwsze wgranie firmware — dla zupełnie początkujących** |
 | [`ARDUINO_SETUP_GUIDE.md`](ARDUINO_SETUP_GUIDE.md) | Pro Micro, kalibracja SWC |
 | [`URUCHOMIENIE.md`](URUCHOMIENIE.md) | symulacja bez sprzętu, przełączniki modułów |

--- a/docs/ZASILANIE_BUFOROWANE.md
+++ b/docs/ZASILANIE_BUFOROWANE.md
@@ -40,7 +40,7 @@ Trzy niezależne powody — każdy sam w sobie wystarczyłby:
 |---------|-----------|-----------|
 | **Rozruch silnika** | Instalacja 12 V zapada na 6–8 V przez 200–600 ms. M910q gubi zasilanie i twardo się resetuje przy każdym przekręceniu kluczyka. | Bank trzyma szynę powyżej 12 V przez cały rozruch — komputer nawet nie mrugnie. |
 | **Funkcje na postoju** | Pilot szyb 433 MHz i bramkowany BLE przycisk bagażnika muszą żyć non stop. Wpięte w akumulator rozruchowy rozładują go w kilka dni. | Domena A żyje z banku. Akumulator rozruchowy jest odizolowany i zawsze gotowy do rozruchu. |
-| **Jakość napięcia** | Instalacja auta to śmietnik EMI: przepięcia od cewek, load dump z alternatora, tętnienia. | Bank o pojemności 25,5 Ah to gigantyczny kondensator — wygładza wszystko, co jest za nim. |
+| **Jakość napięcia** | Instalacja auta to śmietnik EMI: przepięcia od cewek, load dump z alternatora, tętnienia. | Bank o pojemności 20,4 Ah to gigantyczny kondensator — wygładza wszystko, co jest za nim. |
 
 Kluczowa konsekwencja architektury: **akumulator rozruchowy nigdy nie zasila
 head unitu na postoju**. Rozdziela je przekaźnik ładowania z diodą, więc auto
@@ -65,11 +65,24 @@ M910q.
 
 ### 2.1 Trzy stany i trzy poziomy poboru
 
-| Stan | Co pobiera | Pobór z banku | 5 pakietów | 8 pakietów |
-|------|-----------|---------------|-----------|-----------|
-| **Praca** | wszystko | 10–55 W | — | — |
-| **S3** | logika + M910q w S3 + straty przetwornic | **400–550 mA** | ~1,2 dnia | ~1,9 dnia |
-| **Wyłączony** (impuls 5 s) | logika + straty przetwornic | **100–200 mA** | ~3,5–5,3 dnia | ~5,7–8,5 dnia |
+Bank ma **4 pakiety (20,4 Ah)** — tyle się fizycznie mieści. Do 50 % DoD
+zostaje 10,2 Ah użytecznych.
+
+| Stan | Co pobiera | Pobór z banku | 4 pakiety (20,4 Ah) |
+|------|-----------|---------------|---------------------|
+| **Praca** | wszystko | 10–55 W | ~2,9 h przy zgaszonym silniku |
+| **S3** | M910q w S3 + Arduino + LVD | **200–460 mA** | **0,9–2,1 dnia** |
+| **Wyłączony** (impuls 5 s) | przetwornice + Arduino + LVD | **50–150 mA** | **2,8–8,5 dnia** |
+
+> **Pobór w S3 jest zmierzony, nie oszacowany.** Wyświetlacz gaśnie razem
+> z komputerem, bo M910q **odcina zasilanie portów USB w S3** — z szyny
+> ciągną wtedy tylko sam komputer i Arduino. To także przesądza dwie rzeczy:
+> „Wake on USB" jest tu bezużyteczne (port jest martwy), a Arduino **musi**
+> mieć własne 5 V z MP1584, inaczej nie ma czym nacisnąć przycisku.
+
+Rozrzut w obu wierszach bierze się prawie w całości z **własnego poboru
+XH-M609** (20–125 mA wg wersji płytki). To jedyna liczba warta zmierzenia
+multimetrem — reszta jest przewidywalna.
 
 Wszystko do 50 % DoD. Wniosek jest praktyczny: **S3 do krótkich postojów,
 twarde wyłączenie do długich**. Arduino przełącza między nimi samo — po
@@ -84,7 +97,7 @@ dlaczego:
 
 | | Przekaźnik odcinający | Stałe zasilanie + S3 |
 |---|---|---|
-| Postój (5 pakietów) | ~6,6 dnia | ~1,2 dnia w S3, ~3,5–5,3 po wyłączeniu |
+| Postój (4 pakiety) | ~5,3 dnia | ~0,9–2,1 dnia w S3, ~2,8–8,5 po wyłączeniu |
 | Wybudzenie | zimny start ~40 s | **~3 s** z S3 |
 | Ryzyko ucięcia zapisu na dysk | **przy każdym przekręceniu kluczyka** | brak — maszyna schodzi do S3 sama |
 | Elementy w torze mocy | przekaźnik 30 A + okablowanie | **brak** |
@@ -355,14 +368,19 @@ Pakiety łączone **równolegle** — napięcie zostaje 12 V, sumuje się pojemn
 
 | Liczba pakietów | Pojemność | Masa | Maks. prąd ładowania | Uwagi |
 |-----------------|-----------|------|---------------------|-------|
-| 4 | 20,4 Ah | 7,2 kg | 8,4 A | minimum sensowne |
-| **5** | **25,5 Ah** | **9,0 kg** | **10,5 A** | **optimum — zalecane** |
-| 6 | 30,6 Ah | 10,8 kg | 12,6 A | jeśli jest miejsce |
-| 8 | 40,8 Ah | 14,4 kg | 16,8 A | przemyśl, czy 14 kg w aucie jest warte 5 dni więcej |
+| **4** | **20,4 Ah** | **7,2 kg** | **8,4 A** | **przyjęte — tyle się mieści** |
+| 5 | 25,5 Ah | 9,0 kg | 10,5 A | teoretyczne optimum, brak miejsca |
+| 6 | 30,6 Ah | 10,8 kg | 12,6 A | — |
+| 8 | 40,8 Ah | 14,4 kg | 16,8 A | — |
 
-Notatki w repozytorium mówią o **ośmiu posiadanych pakietach**. Użycie pięciu
-daje optimum, a trzy zostają jako zapas — pakiety starzeją się też leżąc, więc
-rotacja jest korzystna.
+**Bank ma cztery pakiety** — to ograniczenie fizyczne, nie wybór
+energetyczny: więcej po prostu nie ma gdzie schować. Pozostałe cztery
+z ośmiu posiadanych zostają jako zapas; pakiety starzeją się także leżąc,
+więc rotacja co rok–dwa jest korzystna.
+
+Co to kosztuje wobec pięciu: 20 % pojemności, czyli mniej więcej pół doby
+postoju w S3 i godzinę pracy przy zgaszonym silniku. Prąd ładowania trzeba
+zejść z 8,0 na **7,5 A**, żeby zmieścić się pod katalogowym sufitem 8,4 A.
 
 Pięć pakietów obok siebie zajmuje ok. **350 × 90 × 101 mm** (bokiem, szerokość
 70 mm każdy) plus miejsce na przewody i pasy.
@@ -403,14 +421,14 @@ Ponieważ HR1221W to AGM, obowiązują wartości z karty katalogowej CSB:
 |----------|------------------|---------------------|----------|
 | Absorpcja (cykl) | 14,4–15,0 V | **14,40 V** | dolny kraniec — najłagodniejszy dla żywotności |
 | Podtrzymanie (float) | 13,5–13,8 V | **13,65 V** | środek zakresu |
-| Prąd ładowania | maks. 2,1 A/pakiet | **6,0 A** dla 5 pakietów | 57 % katalogowego limitu 10,5 A |
+| Prąd ładowania | maks. 2,1 A/pakiet | **7,5 A** dla 4 pakietów | 89 % katalogowego limitu 8,4 A |
 
 > **Korekta wcześniejszej wersji tego dokumentu.** Wcześniejsze wydanie
 > zakładało akumulatory żelowe i podawało 14,20 V / 13,70 V oraz ostrzeżenie,
 > że 14,4 V jest za dużo. **Dla HR1221W jest inaczej: 14,4 V mieści się
 > w katalogowym zakresie cyklicznym**, a wartości 15–20 A z oryginalnych
 > notatek repo są za wysokie nie dlatego, że to żel, tylko dlatego, że limit
-> katalogowy wynosi 2,1 A na pakiet (10,5 A na bank pięciu).
+> katalogowy wynosi 2,1 A na pakiet (8,4 A na bank czterech).
 
 **Seria HR to akumulator buforowy, nie trakcyjny.** Konstrukcja z cienkimi
 płytami jest zoptymalizowana pod krótkie rozładowania dużym prądem (UPS) —
@@ -514,12 +532,12 @@ z presetem **AGM**, kompensację temperaturową i detekcję pracy alternatora.
 | Model | Prąd | Orientacyjna cena | Uwagi |
 |-------|------|------------------|-------|
 | Victron Orion-Tr Smart 12/12-18 | 18 A | ~800–1000 PLN | konfiguracja przez Bluetooth, preset AGM, izolowana |
-| Victron Orion XS 12/12-50 | 50 A | ~1200–1500 PLN | mocno przewymiarowana dla 25,5 Ah |
+| Victron Orion XS 12/12-50 | 50 A | ~1200–1500 PLN | mocno przewymiarowana dla 20,4 Ah |
 | Redarc BCDC1225D | 25 A | ~1300–1600 PLN | bardzo odporna, popularna w off-roadzie |
 | Sterling BB1230 | 30 A | ~900–1200 PLN | |
 
-Prąd nastaw i tak na **6 A** (katalogowy sufit dla pięciu HR1221W to 10,5 A)
-— większy model to tylko zapas i mniejsze grzanie. Dla banku 25,5 Ah
+Prąd nastaw i tak na **7,5 A** (katalogowy sufit dla czterech HR1221W to 8,4 A)
+— większy model to tylko zapas i mniejsze grzanie. Dla banku 20,4 Ah
 **najmniejsza dostępna wersja w zupełności wystarcza**.
 
 **Co odpada przy wariancie A:** przekaźnik ładowania (ładowarka sama wykrywa
@@ -697,7 +715,7 @@ To pytanie decyduje o doborze modułu, więc najpierw ono. Rozłącznik siedzi
 **między wyjściem boostu a bankiem**, czyli w torze ładowania — nie w torze
 odbiorników. Płynie przez niego wyłącznie **prąd ładowania, ograniczony
 nastawą CC boostu** (§3.3 [`WDROZENIE_TESTOWE.md`](WDROZENIE_TESTOWE.md)),
-czyli maksymalnie **8 A** przy pięciu pakietach.
+czyli maksymalnie **7,5 A** przy czterech pakietach.
 
 Nie myl tego z XH-M609: ten stoi po stronie odbiorników i przenosi prąd
 komputera z panelem (do ~4,6 A), a ma przekaźnik 20 A — tam zapas jest duży.
@@ -981,7 +999,7 @@ Czas zależy od tego, ile pobiera XH-M609 — dlatego tabela jest rozpisana
 wg **sumarycznego poboru**. Logika i przekaźniki to stałe 60 mA; reszta to
 moduł LVD.
 
-**Bank 5 pakietów — 25,5 Ah:**
+**Bank 4 pakiety — 20,4 Ah:**
 
 | Pobór całkowity | XH-M609 | Do 30 % DoD | Do 50 % DoD | Do progu LVD |
 |-----------------|---------|-------------|-------------|--------------|
@@ -990,7 +1008,8 @@ moduł LVD.
 | 130 mA | 70 mA | ~2,5 dnia | ~4,1 dnia | ~6,1 dnia |
 | 185 mA | 125 mA (spec max) | ~1,7 dnia | ~2,9 dnia | ~4,3 dnia |
 
-**Bank 8 pakietów — 40,8 Ah** (masz osiem, więc to realna opcja):
+**Bank 8 pakietów — 40,8 Ah** (odniesienie — pakiety masz, ale miejsca na
+nie nie ma; tabela pokazuje wyłącznie, ile kosztuje to ograniczenie):
 
 | Pobór całkowity | Do 30 % DoD | Do 50 % DoD | Do progu LVD |
 |-----------------|-------------|-------------|--------------|
@@ -1003,25 +1022,26 @@ Kolumna 30 % DoD jest tu dlatego, że HR1221W to seria buforowa (UPS), a nie
 trakcyjna — płytsze rozładowanie wyraźnie wydłuża jej życie. Przy okazjonalnym
 dłuższym postoju 50 % DoD jest w porządku; jako **rutyna** lepiej trzymać 30 %.
 
-> **Jeżeli pomiar z §7.3 wypadnie powyżej ~40 mA**, najprostszą reakcją jest
-> użycie **wszystkich ośmiu pakietów zamiast pięciu**. Masz je, a 40,8 Ah
-> cofa czas postoju mniej więcej tam, gdzie był przy 25,5 Ah i niskim poborze
-> LVD. Kosztem jest 14,4 kg zamiast 9,0 kg i więcej miejsca pod fotelem.
+> **Dołożenie pakietów odpada — nie ma gdzie.** Bank jest ograniczony do
+> czterech miejscem, nie budżetem, więc jeżeli pomiar z §7.3 wypadnie
+> powyżej ~40 mA, jedyne realne kierunki to:
 >
-> Drugi kierunek to wymiana LVD na moduł bez wyświetlacza (prosty komparator
-> z przekaźnikiem pobiera 5–10 mA), ale skoro XH-M609 już jest — najpierw
-> zmierz, a decyduj potem.
+> - **wymiana LVD** na moduł bez wyświetlacza (prosty komparator
+>   z przekaźnikiem pobiera 5–10 mA zamiast 20–125 mA),
+> - **skrócenie progu eskalacji** z 2 h do np. 30 min, żeby maszyna szybciej
+>   schodziła z S3 (200–460 mA) do wyłączenia (50–150 mA),
+> - **wyłącznik główny** przy dłuższym postoju — jedyne prawdziwe zero.
 
 > **Korekta wobec starszych notatek.** `docs/X86_PLATFORM_SETUP.md` § 2.3
 > i `10-power-suspend.html` podają dla banku 25 Ah „~17 dni" z adnotacją
 > „ograniczone do 50 % DoD". Te dwie rzeczy się wykluczają: 25 Ah / 0,060 A
-> = 417 h = 17,4 dnia to **pełne rozładowanie do zera**. Przy realnym
-> ograniczeniu do 50 % DoD i faktycznej pojemności 25,5 Ah wychodzi
-> 12,75 Ah / 0,060 A = 212 h = **8,9 dnia**. Tabela powyżej rozdziela
-> wszystkie trzy przypadki.
+> = 417 h = 17,4 dnia to **pełne rozładowanie do zera**. Do tego bank ma
+> dziś **cztery pakiety, nie pięć**, a komputer nie jest już odcinany — więc
+> liczba z tamtych notatek nie ma żadnego przełożenia na obecny układ.
+> Obowiązuje tabela z §2.1.
 
 Samorozładowanie HR1221W (> 75 % pojemności po 6 miesiącach @ 25 °C, czyli
-≤ 4 %/miesiąc) odpowiada ok. **1,4 mA** przy banku 25,5 Ah — wobec 60 mA
+≤ 4 %/miesiąc) odpowiada ok. **1,1 mA** przy banku 20,4 Ah — wobec 60 mA
 logiki jest pomijalne. W upale rośnie kilkukrotnie, ale nadal nie zmienia
 obrazu.
 
@@ -1037,10 +1057,11 @@ postoju wyłącz je z UI.
 
 ### 9.4 Ładowanie po postoju
 
-Bank rozładowany do 50 % (12,75 Ah do uzupełnienia) przy prądzie ładowania
-6 A potrzebuje ~2,2 h w fazie CC plus ~2 h absorpcji — czyli **około
-4–5 godzin jazdy**. Podniesienie prądu do katalogowego sufitu 10,5 A skraca
-fazę CC do ~1,3 h, ale absorpcja i tak trwa swoje. Krótkie przejazdy po mieście nie doładują banku po
+Bank rozładowany do 50 % (10,2 Ah do uzupełnienia) przy nastawie CC 7,5 A
+i obciążeniu ~3,5 A ładuje się netto prądem ~4,0 A, czyli **około 2,6 h
+w fazie CC** plus absorpcja. Realnie licz **3–4 godziny jazdy** do pełna.
+Katalogowy sufit to 8,4 A — więcej się nie da, więc tego czasu nie skrócisz
+inaczej niż zmniejszając obciążenie. Krótkie przejazdy po mieście nie doładują banku po
 dłuższym postoju; jeśli tak wygląda Twój profil użytkowania, rozważ
 ładowarkę sieciową na czas parkowania w garażu.
 
@@ -1057,7 +1078,7 @@ dłuższym postoju; jeśli tak wygląda Twój profil użytkowania, rozważ
 |---------|--------------|-------|
 | **XL6019** — moduł step-up | 12 V → 19,5 V dla M910q | ok. **45 W ciągle**, nie 65 W — wymaga ograniczenia poboru CPU, §3.2 i §3.5a |
 | **XH-M609** — moduł ochrony | **LVD** (warstwa 3), 11,00 / 12,60 V | przekaźnik 20 A wystarcza; zmierz pobór własny, §7.3 |
-| **CSB HR1221W F2** × 8 (12 V / 5,1 Ah AGM) | bank buforowy | użyj 5 (25,5 Ah) albo 8 (40,8 Ah) — decyzja po pomiarze z §7.3 |
+| **CSB HR1221W F2** × 8 (12 V / 5,1 Ah AGM) | bank buforowy | **użyj 4 (20,4 Ah)** — tyle się mieści; reszta jako zapas |
 | Lenovo ThinkCentre M910q Tiny | komputer | |
 
 ### 10.2 Do dokupienia — obowiązkowe
@@ -1086,7 +1107,7 @@ dłuższym postoju; jeśli tak wygląda Twój profil użytkowania, rozważ
 | 19 | **Konektory oczkowe M6/M8** | do 6 mm², zaciskane | 10 | 15–25 |
 | 20 | **Konektory / tulejki / koszulki** | zestaw, koszulki z klejem | kpl. | 30–50 |
 | 21 | **Peszel / oplot + przelotki gumowe** | 5 m peszla + komplet przelotek | kpl. | 25–40 |
-| 22 | **Skrzynka / wspornik na bank + pasy** | na 5 pakietów, mocowanie do nadwozia | 1 | 60–120 |
+| 22 | **Skrzynka / wspornik na bank + pasy** | na 4 pakiety, mocowanie do nadwozia | 1 | 60–120 |
 | 23 | **Rozłącznik masy** | 100 A, kluczykowy lub pokrętło | 1 | 40–70 |
 | 24 | **Radiator + wentylator 40 mm** | do XL6019 — przy 45 W obowiązkowe | kpl. | 20–35 |
 | 24a | **Kondensator wyjściowy** | 470 µF / 35 V low-ESR na wyjście XL6019 | 1 | 3–6 |
@@ -1144,12 +1165,13 @@ XH-M609 (LVD)
 [ ] Moduł pracuje stabilnie przy 11,0 V — bez drgania styku (§7.3 pkt 1)
 [ ] Omomierzem sprawdzone, że przełącza PLUS, nie masę (§7.3 pkt 2)
 [ ] Zmierzony pobór własny przy 12 V, wpisany do budżetu §9
-[ ] Decyzja: 5 czy 8 pakietów w banku — na podstawie powyższego pomiaru
+[ ] Jeśli pobór wyszedł przy górnej granicy (125 mA) — rozważ wymianę
+    modułu; dołożenie pakietów odpada, bank jest ograniczony do czterech
 [ ] Bezpiecznik 15 A przed zaciskiem VIN+
 
 Pozostałe
 [ ] Ładowarka: CV 14,40 V (lub 13,80 V w wariancie B bez kompensacji)
-[ ] Ładowarka: limit prądu CC 6,0 A (sufit katalogowy 10,5 A dla 5 pakietów)
+[ ] Ładowarka: limit prądu CC 7,5 A (sufit katalogowy 8,4 A dla 4 pakietów)
 [ ] Rozłącznik nadnapięciowy: rozwarcie 15,30 V, powrót 14,00 V (§6.4)
 [ ] Buck logiki: wyjście 5,0 V
 [ ] Buck wyświetlaczy: wyjście 5,0 V
@@ -1224,7 +1246,9 @@ Pozostałe
 ```
 [ ] Auto zaparkowane na 48 h bez uruchamiania
 [ ] Pomiar napięcia banku przed i po
-[ ] Spadek zgodny z ~60 mA (dla 25,5 Ah: ok. 2,9 Ah = ~0,2–0,3 V)
+[ ] Spadek zgodny z pomiarem z §2.1 (w S3 przy 300 mA: ok. 14 Ah przez 48 h
+    — bank zejdzie poniżej 50 % DoD, więc na tę próbę użyj wyłącznika
+    głównego albo skróć ją do 12 h)
 [ ] Akumulator rozruchowy bez zmian — auto odpala normalnie
 ```
 
@@ -1265,7 +1289,7 @@ podają 14,4 V absorpcji, 13,8 V float i limit prądu **15–20 A**.
 - **Napięcia są prawidłowe** dla CSB HR1221W (AGM): katalog dopuszcza
   14,4–15,0 V cyklicznie i 13,5–13,8 V buforowo.
 - **Limit prądu jest za wysoki.** Karta katalogowa CSB podaje **2,1 A na
-  pakiet**, czyli 10,5 A dla banku pięciu — nie 15–20 A.
+  pakiet**, czyli 8,4 A dla banku czterech — nie 15–20 A.
 
 Brakuje tam też kompensacji temperaturowej, która dla tej serii ma **dwa różne
 współczynniki** (−18 mV/°C float, −30 mV/°C cykl) — patrz §4.5.

--- a/schematics/audio_system.svg
+++ b/schematics/audio_system.svg
@@ -134,7 +134,7 @@
   <text class="sec" x="60" y="548">Dlaczego osobno</text>
   <rect x="60" y="558" width="560" height="182" fill="#fbfcfd" stroke="#c8d2da" stroke-width="1.5" rx="6"/>
   <text class="tb" x="78" y="582">Prąd</text>
-  <text class="note" x="78" y="600">Wzmacniacz 4 × 50 W RMS pobiera w szczytach 20–30 A. Bank 25,5 Ah</text>
+  <text class="note" x="78" y="600">Wzmacniacz 4 × 50 W RMS pobiera w szczytach 20–30 A. Bank 20,4 Ah</text>
   <text class="note" x="78" y="616">rozłożyłby się przy takim prądzie w kilkanaście minut, a przekaźnik</text>
   <text class="note" x="78" y="632">XH-M609 (20 A) zostałby przekroczony.</text>
   <text class="tb" x="78" y="658">Zakłócenia</text>

--- a/schematics/charging_lvd.svg
+++ b/schematics/charging_lvd.svg
@@ -45,7 +45,7 @@
   <rect class="box" x="508" y="90" width="216" height="92"/>
   <text class="h" x="616" y="112">WARSTWA 1 — ładowarka</text>
   <text class="t" x="616" y="132">CC-CV buck-boost, profil AGM</text>
-  <text class="t" x="616" y="150">6 A / 14,40 V / 13,65 V</text>
+  <text class="t" x="616" y="150">7,5 A / 14,40 V / 13,65 V</text>
   <text class="t" x="616" y="168">kompensacja temperaturowa</text>
 
   <path class="wire" d="M724 136 L774 136"/>
@@ -59,9 +59,9 @@
   <path class="wire" d="M882 182 L882 214 L616 214 L616 246"/>
 
   <rect class="boxA" x="420" y="246" width="392" height="102"/>
-  <text class="h" x="616" y="268">Bank CSB HR1221W — 5 × 12 V / 5,1 Ah = 25,5 Ah</text>
+  <text class="h" x="616" y="268">Bank CSB HR1221W — 4 × 12 V / 5,1 Ah = 20,4 Ah</text>
   <text class="t" x="616" y="288">VRLA AGM, seria High Rate (praca buforowa)</text>
-  <text class="t" x="616" y="306">limit ładowania 2,1 A na pakiet → 10,5 A na bank</text>
+  <text class="t" x="616" y="306">limit ładowania 2,1 A na pakiet → 8,4 A na bank</text>
   <text class="t" x="616" y="324">bezpiecznik 10 A na każdym pakiecie</text>
   <text class="t" x="616" y="342">czujnik NTC przyklejony do środkowego pakietu</text>
 
@@ -83,7 +83,7 @@
 
   <!-- ===== SETPOINT TABLE ===== -->
   <rect x="30" y="516" width="540" height="366" fill="#fbfcfd" stroke="#c8d2da" stroke-width="1.5" rx="6"/>
-  <text class="h" x="300" y="540">Nastawy — CSB HR1221W (AGM), bank 5 × 5,1 Ah</text>
+  <text class="h" x="300" y="540">Nastawy — CSB HR1221W (AGM), bank 4 × 5,1 Ah</text>
 
   <line x1="46" y1="552" x2="554" y2="552" stroke="#c8d2da"/>
   <text class="tb" x="52" y="572">Parametr</text>
@@ -96,7 +96,7 @@
   <text class="tl" x="490" y="600">1</text>
 
   <text class="tl" x="52" y="620">Limit katalogowy prądu</text>
-  <text class="tl" x="322" y="620">2,1 A × 5 = 10,5 A</text>
+  <text class="tl" x="322" y="620">2,1 A × 4 = 8,4 A</text>
   <text class="tl" x="490" y="620">—</text>
 
   <text class="tl" x="52" y="640">Napięcie absorpcji (CV)</text>

--- a/schematics/power_buffered_m910q.svg
+++ b/schematics/power_buffered_m910q.svg
@@ -52,7 +52,7 @@
   <!-- 4. CC-CV CHARGER -->
   <rect class="box" x="40" y="404" width="270" height="112"/>
   <text class="h" x="175" y="426">Ładowarka CC-CV (buck-boost)</text>
-  <text class="t" x="175" y="444">CC: 6 A  (limit katalogowy 10,5 A)</text>
+  <text class="t" x="175" y="444">CC: 7,5 A  (limit katalogowy 8,4 A)</text>
   <text class="t" x="175" y="460">CV absorpcja: 14,40 V @ 25 °C</text>
   <text class="t" x="175" y="476">float: 13,65 V @ 25 °C</text>
   <text class="t" x="175" y="494">komp. −30 mV/°C abs. / −18 mV/°C float</text>
@@ -72,8 +72,8 @@
   <!-- 6. BUFFER BUS + AGM BANK -->
   <rect class="boxA" x="40" y="678" width="270" height="150"/>
   <text class="h" x="175" y="700">Szyna bufora 12 V — bank AGM</text>
-  <text class="t" x="175" y="718">5 × CSB HR1221W F2 (12 V / 5,1 Ah) równolegle</text>
-  <text class="t" x="175" y="734">25,5 Ah, szyna 4 mm² lub mostek miedziany</text>
+  <text class="t" x="175" y="718">4 × CSB HR1221W F2 (12 V / 5,1 Ah) równolegle</text>
+  <text class="t" x="175" y="734">20,4 Ah, szyna 4 mm² lub mostek miedziany</text>
 
   <g>
     <rect class="batt" x="58" y="746" width="42" height="34"/><text class="t" x="79" y="767">5,1 Ah</text>

--- a/schematics/power_domains_m910q.svg
+++ b/schematics/power_domains_m910q.svg
@@ -27,7 +27,7 @@
   <!-- BUS -->
   <rect class="box" x="360" y="86" width="460" height="62"/>
   <text class="h" x="590" y="110">Szyna buforowana 12 V — za XH-M609 i wyłącznikiem głównym</text>
-  <text class="t" x="590" y="132">bank 5 × CSB HR1221W · 25,5 Ah · listwa dystrybucyjna z bezpiecznikami</text>
+  <text class="t" x="590" y="132">bank 4 × CSB HR1221W · 20,4 Ah · listwa dystrybucyjna z bezpiecznikami</text>
 
   <path class="wire" d="M590 148 L590 180"/>
   <path class="wire" d="M240 180 L940 180"/>
@@ -123,21 +123,22 @@
   <text class="note" x="80" y="676">Szczyty 20–30 A rozłożyłyby bank AGM w kilkanaście minut.</text>
 
   <!-- ============ BUDGET ============ -->
-  <rect x="700" y="536" width="420" height="216" fill="#fbfcfd" stroke="#c8d2da" stroke-width="1.5" rx="6"/>
+  <rect x="700" y="536" width="420" height="234" fill="#fbfcfd" stroke="#c8d2da" stroke-width="1.5" rx="6"/>
   <text class="h" x="910" y="560">Trzy stany maszyny — trzy poziomy poboru</text>
   <line x1="716" y1="570" x2="1104" y2="570" stroke="#c8d2da"/>
   <text class="tb" x="722" y="590">Stan</text>
   <text class="tb" x="852" y="590">Pobór</text>
-  <text class="tb" x="960" y="590">5 pak.</text>
-  <text class="tb" x="1036" y="590">8 pak.</text>
+  <text class="tb" x="972" y="590">4 pakiety</text>
+  
   <line x1="716" y1="598" x2="1104" y2="598" stroke="#c8d2da"/>
-  <text class="tl" x="722" y="618">Praca</text><text class="tl" x="852" y="618">10–55 W</text><text class="tl" x="960" y="618">—</text><text class="tl" x="1036" y="618">—</text>
-  <text class="tl" x="722" y="642">S3 (kluczyk OFF)</text><text class="tl" x="852" y="642">400–550 mA</text><text class="tl" x="960" y="642">~1,2 d</text><text class="tl" x="1036" y="642">~1,9 d</text>
-  <text class="tl" x="722" y="666">Wyłączony</text><text class="tl" x="852" y="666">100–200 mA</text><text class="tl" x="960" y="666">3,5–5,3 d</text><text class="tl" x="1036" y="666">5,7–8,5 d</text>
+  <text class="tl" x="722" y="618">Praca</text><text class="tl" x="852" y="618">10–55 W</text><text class="tl" x="972" y="618">~2,9 h bez silnika</text>
+  <text class="tl" x="722" y="642">S3 (kluczyk OFF)</text><text class="tl" x="852" y="642">200–460 mA</text><text class="tl" x="972" y="642">0,9–2,1 dnia</text>
+  <text class="tl" x="722" y="666">Wyłączony</text><text class="tl" x="852" y="666">50–150 mA</text><text class="tl" x="972" y="666">2,8–8,5 dnia</text>
   <line x1="716" y1="680" x2="1104" y2="680" stroke="#c8d2da"/>
   <text class="note" x="722" y="700">Czasy do 50 % DoD. Arduino przechodzi z S3 do pełnego wyłączenia po 2 h</text>
   <text class="note" x="722" y="716">zgaszonego zapłonu — dłuższy impuls na ten sam przycisk.</text>
-  <text class="note" x="722" y="740">Pobór własny XH-M609 (20–125 mA) jest w tych liczbach — ZMIERZ go.</text>
+  <text class="note" x="722" y="740">Wyświetlacz gaśnie z komputerem — USB w S3 jest martwe.</text>
+  <text class="note" x="722" y="756">Rozrzut w obu wierszach to własny pobór XH-M609 — ZMIERZ go.</text>
 
   <text class="note" x="24" y="778">Wyłącznik główny to jedyne realne zero poboru. Na postój dłuższy niż tydzień rozłączaj bank — inaczej LVD odetnie go przy 11,00 V.</text>
   <text class="note" x="24" y="800">Wszystkie bezpieczniki: wkładki nożowe ATO/ATC w listwie dystrybucyjnej z pokrywą, w miejscu dostępnym bez demontażu deski rozdzielczej.</text>

--- a/schematics/power_test_build.svg
+++ b/schematics/power_test_build.svg
@@ -49,7 +49,7 @@
 
   <rect class="boxC" x="90" y="378" width="420" height="76"/>
   <text class="h" x="300" y="401">Moduł CC-CV boost — „900 W 15 A” albo SZBK07</text>
-  <text class="t" x="300" y="420">CV 14,40 V · CC 8,0 A dla pięciu pakietów</text>
+  <text class="t" x="300" y="420">CV 14,40 V · CC 7,5 A dla czterech pakietów</text>
   <text class="t" x="300" y="438">radiator i przewiew — 8 A ciągłe to nie jest praca „na sucho”</text>
 
   <path class="wire" d="M300 454 L300 488"/>
@@ -63,10 +63,10 @@
   <text class="tb" x="90" y="576" fill="#9a6b12" font-size="13.5">BANK</text>
 
   <rect class="boxB" x="90" y="584" width="420" height="84"/>
-  <text class="h" x="300" y="607">BANK 5 × CSB HR1221W F2 — 25,5 Ah</text>
+  <text class="h" x="300" y="607">BANK 4 × CSB HR1221W F2 — 20,4 Ah</text>
   <text class="t" x="300" y="626">bezpiecznik 10 A na „+” każdego pakietu, osobno</text>
   <text class="t" x="300" y="644">nasuwki F2 6,35 mm · łączenie równoległe wg §4.3 ZASILANIE</text>
-  <text class="t" x="300" y="661">5 to minimum, 8 wyraźnie lepsze — patrz tabela obok</text>
+  <text class="t" x="300" y="661">cztery pakiety — więcej fizycznie się nie mieści</text>
 
   <path class="wire" d="M300 668 L300 702"/>
   <text class="fuse" x="312" y="690">bezp. 15 A przed VIN+</text>
@@ -111,15 +111,15 @@
   <text class="nt" x="576" y="437">Moduł limituje prąd WYJŚCIOWY — obciążenie plus</text>
   <text class="nt" x="576" y="454">ładowanie. Zestaw pobiera podczas jazdy ok. 3,5 A.</text>
   <text class="nt" x="576" y="475">CC 4 A  →  do banku 0,5 A  →  nigdy się nie doładuje</text>
-  <text class="nt" x="576" y="492">CC 8 A  →  do banku 4,5 A  →  z 50 % w ~2,8 h jazdy</text>
-  <text class="nt" x="576" y="513">Sufit katalogowy CSB: 2,1 A × liczba pakietów.</text>
+  <text class="nt" x="576" y="492">CC 7,5 A →  do banku 4,0 A  →  z 50 % w ~2,6 h jazdy</text>
+  <text class="nt" x="576" y="513">Sufit katalogowy CSB: 2,1 A × 4 = 8,4 A.</text>
 
   <rect class="note" x="560" y="540" width="376" height="112"/>
   <text class="nh" x="576" y="562">Pobór postojowy — S3 to nie zero</text>
-  <text class="nt" x="576" y="583">M910q w S3 1,5–3 W + straty XL6019 1–1,5 W + XH-M609</text>
-  <text class="nt" x="576" y="600">0,25–1,5 W  =  razem 240–480 mA z banku.</text>
-  <text class="nt" x="576" y="621">5 pakietów → 1,1–2,2 dnia · 8 pakietów → 1,8–3,5 dnia</text>
-  <text class="nt" x="576" y="638">Na dłuższy postój: wyłącznik główny. ZMIERZ ten pobór.</text>
+  <text class="nt" x="576" y="583">M910q w S3 160–320 mA + Arduino 15 mA + XH-M609</text>
+  <text class="nt" x="576" y="600">20–125 mA  =  razem 200–460 mA z banku.</text>
+  <text class="nt" x="576" y="621">4 pakiety (20,4 Ah) → 0,9–2,1 dnia w S3</text>
+  <text class="nt" x="576" y="638">Po wyłączeniu (impuls 5 s): 50–150 mA → 2,8–8,5 dnia.</text>
 
   <rect class="note" x="560" y="668" width="376" height="230"/>
   <text class="nh" x="576" y="690">Bezpieczniki i przekroje</text>

--- a/schematics/schematic_test_build.svg
+++ b/schematics/schematic_test_build.svg
@@ -78,7 +78,7 @@
 
   <rect class="bg" x="0" y="0" width="1440" height="820"/>
   <text class="ttl" x="24" y="32">Schemat elektryczny — wariant testowo-rozwojowy</text>
-  <text class="sub" x="24" y="54">Ładowanie przez przekaźnik zapłonu i MBR2545CT · bank 5 × CSB HR1221W · LVD XH-M609 · M910q zasilany stale. Wykrywanie zapłonu: ignition_sense.svg</text>
+  <text class="sub" x="24" y="54">Ładowanie przez przekaźnik zapłonu i MBR2545CT · bank 4 × CSB HR1221W · LVD XH-M609 · M910q zasilany stale. Wykrywanie zapłonu: ignition_sense.svg</text>
   <line x1="24" y1="66" x2="1416" y2="66" stroke="#c8d2da" stroke-width="1.5"/>
 
   <!-- ================= A. CHARGING ================= -->
@@ -152,7 +152,7 @@
   <rect class="blkg" x="620" y="132" width="176" height="72"/>
   <text class="lbb" x="708" y="154">Moduł CC-CV boost</text>
   <text class="lbc" x="708" y="172">CV 14,40 V</text>
-  <text class="lbc" x="708" y="190">CC 8,0 A (5 pakietów)</text>
+  <text class="lbc" x="708" y="190">CC 7,5 A (4 pakiety)</text>
   <line class="wg" x1="708" y1="204" x2="708" y2="252"/>
   <use xlink:href="#gnd" x="708" y="252"/>
 
@@ -168,8 +168,8 @@
   <!-- bank -->
   <line class="wp" x1="1024" y1="168" x2="1084" y2="168"/>
   <line class="wp" x1="1084" y1="168" x2="1372" y2="168"/>
-  <text class="lbb" x="1228" y="118">BANK · 5 × CSB HR1221W F2 (25,5 Ah)</text>
-  <text class="ref" x="1150" y="136">F2…F6 · 10 A na każdy pakiet</text>
+  <text class="lbb" x="1228" y="118">BANK · 4 × CSB HR1221W F2 (20,4 Ah)</text>
+  <text class="ref" x="1150" y="136">F2…F5 · 10 A na każdy pakiet</text>
 
   <g>
     <circle class="symf" cx="1104" cy="168" r="3"/>
@@ -288,7 +288,7 @@
   <rect class="note" x="1160" y="376" width="256" height="180"/>
   <text class="nh" x="1176" y="398">Oznaczenia bezpieczników</text>
   <text class="nt" x="1176" y="420">F1  15 A — zasilanie ładowarki</text>
-  <text class="nt" x="1176" y="440">F2…F6  10 A — po jednym na pakiet</text>
+  <text class="nt" x="1176" y="440">F2…F5  10 A — po jednym na pakiet</text>
   <text class="nt" x="1176" y="460">F7  15 A — wejście XH-M609</text>
   <text class="nt" x="1176" y="480">F8  7,5 A — odgałęzienie XL6019</text>
   <text class="nt" x="1176" y="500">F9  2 A — odgałęzienie LM2596</text>

--- a/schematics/vehicle_layout_m910q.svg
+++ b/schematics/vehicle_layout_m910q.svg
@@ -98,7 +98,7 @@
   <circle class="pin" cx="276" cy="392" r="11"/><text class="pinT" x="276" y="396">4</text>
 
   <rect class="zoneA" x="490" y="392" width="190" height="56"/>
-  <text class="zt" x="585" y="411">bank 5 × HR1221W</text>
+  <text class="zt" x="585" y="411">bank 4 × HR1221W</text>
   <text class="zt" x="585" y="427">ładowarka, LVD</text>
   <text class="zt" x="585" y="441">rozłącznik masy</text>
   <circle class="pin" cx="490" cy="392" r="11"/><text class="pinT" x="490" y="396">5</text>
@@ -168,7 +168,7 @@
   <text class="tl" x="78" y="618">2 · fabryczna przelotka w przegrodzie</text>
   <text class="tl" x="78" y="638">3 · Przekaźnik ładowania + dioda</text>
   <text class="tl" x="78" y="658">4 · M910q, hub USB, step-up, przekaźnik zapłonu, listwa</text>
-  <text class="tl" x="78" y="678">5 · bank 5 × HR1221W, ładowarka CC-CV, LVD, rozłącznik masy</text>
+  <text class="tl" x="78" y="678">5 · bank 4 × HR1221W, ładowarka CC-CV, LVD, rozłącznik masy</text>
   <text class="tl" x="78" y="698">6 · wyświetlacz główny 10,1" 1280×800 — miejsce radia</text>
   <text class="tl" x="78" y="718">7 · wyświetlacz drugi 6,86" 1280×480 (opcjonalny)</text>
   <text class="tl" x="78" y="738">8 · enkoder, przyciski, panel muzyczny</text>
@@ -226,11 +226,11 @@
 
   <text class="sec" x="650" y="1046">Masa i rozkład</text>
   <rect x="650" y="1056" width="560" height="96" fill="#fbfcfd" stroke="#c8d2da" stroke-width="1.5" rx="6"/>
-  <text class="tl" x="668" y="1078">bank 5 × HR1221W</text><text class="tl" x="1000" y="1078">9,0 kg</text>
+  <text class="tl" x="668" y="1078">bank 4 × HR1221W</text><text class="tl" x="1000" y="1078">7,2 kg</text>
   <text class="tl" x="668" y="1096">M910q, hub, przetwornice</text><text class="tl" x="1000" y="1096">ok. 2,5 kg</text>
   <text class="tl" x="668" y="1114">wzmacniacze + radiatory</text><text class="tl" x="1000" y="1114">ok. 2,0 kg</text>
   <text class="tl" x="668" y="1132">subwoofer z obudową</text><text class="tl" x="1000" y="1132">5–12 kg</text>
-  <text class="tb" x="1000" y="1150">razem 19–26 kg</text>
+  <text class="tb" x="1000" y="1150">razem 17–24 kg</text>
 
   <text class="warn" x="24" y="1186">Każdy element powyżej 1 kg przykręcony albo przypięty pasem do elementu konstrukcyjnego. Luźny akumulator 1,8 kg przy hamowaniu awaryjnym to pocisk.</text>
   <text class="note" x="24" y="1206">Rysunek pokazuje strefy montażu i trasy, nie wymiary nadwozia. Przed wierceniem sprawdź, co jest po drugiej stronie blachy — wiązki, przewody paliwowe, wzmocnienia.</text>

--- a/schematics/wiring_power_modules.svg
+++ b/schematics/wiring_power_modules.svg
@@ -130,8 +130,8 @@
 
   <!-- ================= 6. BANK ================= -->
   <rect class="modA" x="440" y="470" width="470" height="172"/>
-  <text class="mt" x="675" y="494">Bank buforowy — 5 × CSB HR1221W F2</text>
-  <text class="ms" x="675" y="512">12 V / 5,1 Ah AGM · razem 25,5 Ah · zaciski faston 6,35 mm</text>
+  <text class="mt" x="675" y="494">Bank buforowy — 4 × CSB HR1221W F2</text>
+  <text class="ms" x="675" y="512">12 V / 5,1 Ah AGM · razem 20,4 Ah · zaciski faston 6,35 mm</text>
   <g>
     <rect class="term" x="466" y="526" width="70" height="42"/>
     <text class="tp" x="501" y="543">HR1221W</text><text class="ms" x="501" y="559">+F2  −F2</text>

--- a/schematics/wiring_test_build.svg
+++ b/schematics/wiring_test_build.svg
@@ -130,8 +130,8 @@
   <use xlink:href="#gnd" x="56" y="496"/>
 
   <rect class="blk" x="312" y="358" width="380" height="146"/>
-  <text class="mh" x="502" y="382">BANK · 5 × CSB HR1221W F2</text>
-  <text class="ms" x="502" y="400">25,5 Ah · nasuwki F2 6,35 mm · łączenie równoległe wg §4.3</text>
+  <text class="mh" x="502" y="382">BANK · 4 × CSB HR1221W F2</text>
+  <text class="ms" x="502" y="400">20,4 Ah · nasuwki F2 6,35 mm · łączenie równoległe wg §4.3</text>
   <circle cx="312" cy="428" r="4" fill="#c0392b"/><text class="tm" x="320" y="432">szyna „+”</text>
   <circle cx="312" cy="452" r="4" fill="#46586a"/><text class="tm" x="320" y="456">szyna „−”</text>
   <circle cx="692" cy="428" r="4" fill="#c0392b"/>
@@ -141,8 +141,8 @@
   <rect class="fbox" x="440" y="470" width="52" height="22"/><text class="fz" x="466" y="486">10 A</text>
   <rect class="fbox" x="508" y="470" width="52" height="22"/><text class="fz" x="534" y="486">10 A</text>
   <rect class="fbox" x="576" y="470" width="52" height="22"/><text class="fz" x="602" y="486">10 A</text>
-  <rect class="fbox" x="644" y="470" width="52" height="22"/><text class="fz" x="670" y="486">10 A</text>
-  <text class="ms" x="502" y="518">F2…F6 — po jednym na „+” każdego pakietu, osobno</text>
+  
+  <text class="ms" x="502" y="518">F2…F5 — po jednym na „+” każdego pakietu, osobno</text>
 
   <line class="wp" x1="300" y1="440" x2="306" y2="440"/>
   <line class="wp" x1="306" y1="440" x2="306" y2="428"/>
@@ -286,7 +286,7 @@
   <text class="nt" x="456" y="972">     LM2596 wg panelu, boost 14,40 V / 8 A, rozłącznik 15,30 V,</text>
   <text class="nt" x="456" y="990">     XH-M609 11,00 / 12,60 V. Wszystkie pięć, bez wyjątku.</text>
   <text class="nt" x="456" y="1012">3.  Masy: cały punkt gwiazdowy z listy obok.</text>
-  <text class="nt" x="456" y="1034">4.  Bank z bezpiecznikami F2…F6, pomiar napięcia na szynie.</text>
+  <text class="nt" x="456" y="1034">4.  Bank z bezpiecznikami F2…F5, pomiar napięcia na szynie.</text>
   <text class="nt" x="456" y="1056">5.  Przewody 8, 9, 10 — bank przez F7 do LVD i S1.</text>
   <text class="nt" x="456" y="1078">6.  Przewód 11 i 12: XL6019, pomiar 19,5 V BEZ M910q.</text>
   <text class="nt" x="456" y="1100">7.  Dopiero teraz M910q; potem 13–14 (podświetlenie).</text>


### PR DESCRIPTION
## Four packs, because that's what fits

The bank was sized at five as an energy optimum. It's four now, and the reason is physical — there is nowhere else to hide them — so the sizing section says that instead of presenting five as the answer. The 5/6/8 rows stay in the comparison tables, relabelled as *what the space constraint costs* rather than as open options.

| | before | now |
|---|---|---|
| Capacity | 25,5 Ah | **20,4 Ah** (10,2 Ah to 50 % DoD) |
| Catalogue charge ceiling | 10,5 A | **8,4 A** |
| CC setting | 8,0 A | **7,5 A** (89 % of ceiling; net 4,0 A after the load) |
| Engine-off runtime | ~3,6 h | **~2,9 h** |
| Recharge | | **~2,6 h CC / 3–4 h driving** |
| Weight | 9,0 kg | **7,2 kg** (17–24 kg installed) |
| Pack fuses | F2…F6 | **F2…F5** |

The extra four packs stay as spares — they age on the shelf too, so rotating them every year or two is worth doing.

## S3 draw, corrected from measurement

The panel draws **nothing** in sleep: the M910q cuts USB port power in S3, and the panel's logic and touch both run off that port. So the standby budget is the computer plus the Arduino and nothing else.

| | |
|---|---|
| M910q in S3 (through XL6019) | 160–320 mA |
| Arduino Nano through MP1584 | ~15 mA |
| XH-M609 — **measure yours** | 20–125 mA |
| **Total** | **200–460 mA** → 0,9–2,1 days on four packs |
| After a hard off | 50–150 mA → 2,8–8,5 days |

Two consequences are now written where they belong:

- **"Wake on USB" cannot work here.** The port is dead in S3, so nothing on it can wake the machine. That is precisely why the relay across the power button exists rather than a USB HID wake.
- **The Arduino must keep its own MP1584 supply.** Powering it from an M910q USB port would kill it in sleep — which is when it has to be awake to watch the ignition.

## `docs/ARDUINO_OD_ZERA.md` — new

A first-upload guide written for someone who has never held a board, because that's the actual starting point here. 13 sections:

- which cable (the data-vs-charging trap), CH340 driver per OS, the `dialout` group on Linux
- identifying the port by unplugging and replugging it
- Blink first, as a smoke test that proves the toolchain before any real firmware
- a **minimal config** — only `FEATURE_IGN` + `FEATURE_PWRBTN`, everything else commented out. Verified against the sketch: the OneWire/DallasTemperature includes are guarded behind `FEATURE_TEMP`, so this config needs no library installs at all
- upload, Serial Monitor at 115200, and what a healthy boot looks like
- a **bench test with one piece of wire** — jumper D9 to GND to fake ignition, watch `IGN:1` → `PWRACT:SHORT` → `PWR:RUNNING`, then open it and watch the sleep path. No car, no 12 V
- why `FEATURE_PWRLED` must stay off for that bench test: with nothing on A1 the board correctly reads "machine is off" and correctly declines to sleep it. Looks like a fault, isn't one
- the ATmega328PB signature trap (`0x1E9516` vs `0x1E950F`) and the MiniCore fix, plus the Pro Micro double-reset trick

Linked from `README.md`, `ARDUINO_SETUP_GUIDE.md`, `URUCHOMIENIE.md`, `WDROZENIE_TESTOWE.md`, `WDROZENIE_M910Q.md` and `LISTA_ZAKUPOWA.md`.

## Also fixed

The shopping-list total **did not match the sum of its own rows**, and `WDROZENIE_TESTOWE.md` carried a third, different number. Recomputed from the table: **483–928 PLN**, now the same in both files.

## Files

- `docs/ZASILANIE_BUFOROWANE.md` — §4.2 sizing, §2.1 three-state budget, §9.2 standby tables, commissioning checklist
- `docs/WDROZENIE_TESTOWE.md` — §3.4 pack count, §3.3 CC calculation, §4 totals
- `docs/LISTA_ZAKUPOWA.md`, `docs/SCHEMATY_POLACZEN.md`, `docs/WDROZENIE_M910Q.md`, `docs/PODSUMOWANIE_KONSOLIDACJI.md`
- `docs/ARDUINO_OD_ZERA.md` (new, 414 lines)
- 9 schematics redrawn for four packs

Verified: 422 tests pass, ruff clean, 256 relative markdown links and anchors resolve, all 12 SVGs parse and render without text collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cXmt2HyZ8iv3aQHpkNA4c

---
_Generated by [Claude Code](https://claude.ai/code/session_017cXmt2HyZ8iv3aQHpkNA4c)_