### PR TITLE
Move crowded labels off the drawing and point at them with leaders

### DIFF
--- a/schematics/gen_test_schematics.py
+++ b/schematics/gen_test_schematics.py
@@ -12,6 +12,8 @@ Uruchomienie (z katalogu głównego repo):
 popraw ten plik i wygeneruj SVG ponownie — nie edytuj SVG ręcznie.
 """
 
+import math
+
 STYLE = '''<style>
  .bg{fill:#ffffff}
  .w{stroke:#16242e;stroke-width:2.2;fill:none;stroke-linecap:round}
@@ -55,6 +57,8 @@ STYLE = '''<style>
  .nt{font-size:11.5px;fill:#4a5a66}
  .wn{font-size:11px;font-weight:bold;fill:#0d1c26;text-anchor:middle}
  .wnb{fill:#ffffff;stroke:#8b9aa6;stroke-width:1.2;rx:3}
+ .ldr{stroke:#7d8c99;stroke-width:1.3;fill:none}
+ .ldrf{fill:#7d8c99;stroke:none}
 </style>'''
 
 
@@ -94,6 +98,23 @@ class Sheet:
 
     def box(self, x, y, w, h, c="blk"):
         self.a(f'<rect class="{c}" x="{x}" y="{y}" width="{w}" height="{h}"/>')
+
+    def leader(self, x0, y0, x1, y1, bend=None):
+        """Cienki odnośnik od (x0,y0) do (x1,y1); grot przy (x1,y1)."""
+        pts = [(x0, y0)] + ([bend] if bend else []) + [(x1, y1)]
+        for i in range(len(pts) - 1):
+            a, b = pts[i], pts[i + 1]
+            self.a(f'<line class="ldr" x1="{a[0]}" y1="{a[1]}" '
+                   f'x2="{b[0]}" y2="{b[1]}"/>')
+        ax, ay = pts[-2]
+        dx, dy = x1 - ax, y1 - ay
+        ln = math.hypot(dx, dy) or 1.0
+        ux, uy = dx / ln, dy / ln
+        nx, ny = -uy, ux
+        p1 = (x1 - ux * 9 + nx * 3.4, y1 - uy * 9 + ny * 3.4)
+        p2 = (x1 - ux * 9 - nx * 3.4, y1 - uy * 9 - ny * 3.4)
+        self.a(f'<polygon class="ldrf" points="{x1},{y1} '
+               f'{p1[0]:.1f},{p1[1]:.1f} {p2[0]:.1f},{p2[1]:.1f}"/>')
 
     def sect(self, x, y, n, t):
         self.a(f'<rect class="sectb" x="{x}" y="{y-20}" width="26" height="26"/>')
@@ -170,9 +191,9 @@ class Sheet:
             if val:
                 self.txt(x + 20, y + 35, val, "v")
         else:
-            self.txt(x - 26, y + 20, ref, "re")
+            self.txt(x - 34, y + 20, ref, "re")
             if val:
-                self.txt(x - 26, y + 35, val, "ve")
+                self.txt(x - 34, y + 35, val, "ve")
         return y + 50
 
     def tvs_v(self, x, y, ref, val):
@@ -231,7 +252,7 @@ class Sheet:
         self.a(f'<circle class="sym" cx="{x+78}" cy="{y}" r="4.5" fill="#fff"/>')
         self.w(x + 82, y, x + 96, y)
         self.a(f'<line class="wd" x1="{x+48}" y1="{y-14}" x2="{x+48}" y2="{y+26}"/>')
-        self.txt(x + 48, y - 34, ref, "rc")
+        self.txt(x + 48, y - 34 if ny > 0 else y - 52, ref, "rc")
         self.txt(x + 14, y + 22, "30", "pin")
         self.txt(x + 82, y + 22, "87", "pine")
         if note:
@@ -294,7 +315,7 @@ class Sheet:
 # ======================================================================
 #  ARKUSZ 1 — ZASILANIE
 # ======================================================================
-s = Sheet(1620, 1800,
+s = Sheet(1620, 1870,
           "BCM v8.5 — arkusz 1/2: ZASILANIE (wariant testowo-rozwojowy, M910q)",
           "Każdy element osobno. Cewki i styki przekaźników rozdzielone — "
           "K1 i K2 to po jednym przekaźniku Bosch, narysowanym w dwóch "
@@ -330,7 +351,7 @@ s.txt(420, GA + 62, "bufor wejścia", "vc")
 # --- styk K1
 s.w(430, RAIL, 470, RAIL)
 s.wn(437, RAIL - 15, 3)
-x = s.contact(470, RAIL, "K1", "zwiera po zapłonie", ny=70)
+x = s.contact(470, RAIL, "K1", "zwiera po zapłonie", ny=-32)
 s.dot(600, RAIL)
 s.w(x, RAIL, 660, RAIL)
 s.wn(632, RAIL - 15, 5)
@@ -349,20 +370,21 @@ s.path([(444, 536), (444, 550), (518, 550)])
 s.dot(518, 550)
 
 # --- D1 MBR2545CT
-s.a('<rect class="dash" x="660" y="140" width="196" height="200"/>')
-s.txt(758, 128, "D1", "rc")
-s.txt(758, 362, "MBR2545CT — anody 1 i 3 zwarte", "vc")
-s.txt(758, 378, "blaszka = katoda (pin 2), izoluj od radiatora", "vc")
+s.a('<rect class="dash" x="660" y="130" width="196" height="224"/>')
+s.txt(758, 118, "D1", "rc")
+s.txt(758, 376, "MBR2545CT — anody 1 i 3 zwarte", "vc")
+s.txt(758, 392, "blaszka = katoda (pin 2), izoluj od radiatora", "vc")
 s.path([(660, RAIL), (686, RAIL)])
 s.dot(686, RAIL)
-s.path([(686, 180), (686, 300)])
-s.schottky_h(686, 180)
-s.schottky_h(686, 300)
-s.path([(738, 180), (830, 180), (830, 300), (738, 300)])
+s.path([(686, 190), (686, 290)])
+s.schottky_h(686, 190)
+s.schottky_h(686, 290)
+s.path([(738, 190), (830, 190), (830, 290), (738, 290)])
 s.dot(830, RAIL)
-s.txt(714, 160, "pin 1", "vc")
-s.txt(714, 336, "pin 3", "vc")
-s.txt(786, 250, "pin 2", "vc")
+s.txt(712, 176, "pin 1 — anoda", "vc")
+s.txt(712, 322, "pin 3 — anoda", "vc")
+s.txt(806, 254, "pin 2 — katoda", "ve")
+s.leader(810, 250, 828, 241)
 s.w(830, RAIL, 902, RAIL)
 s.wn(874, RAIL - 15, 6)
 
@@ -492,7 +514,10 @@ for bx, fr, fv, wnum, mr, mn, ms in conv:
 m4 = mo["M4"]
 s.w(m4["out+"][0], m4["out+"][1], 620, m4["out+"][1])
 s.dot(520, m4["out+"][1])
-yy = s.cap_v(520, m4["out+"][1], "C6", "470 µF/35 V", pol=True, side=1)
+yy = s.cap_v(520, m4["out+"][1], "", "", pol=True, side=1)
+s.txt(478, m4["out+"][1] + 136, "C6", "re")
+s.txt(478, m4["out+"][1] + 152, "470 µF / 35 V", "ve")
+s.leader(492, m4["out+"][1] + 116, 504, m4["out+"][1] + 26)
 s.w(520, yy, 520, LG)
 s.star_gnd(520, LG)
 s.path([(m4["out-"][0], m4["out-"][1]), (486, m4["out-"][1]), (486, LG)])
@@ -527,18 +552,20 @@ s.txt(1520, m6["out-"][1] + 5, "GND", "pin")
 s.txt(1490, m6["out-"][1] + 34, "→ ARKUSZ 2", "rc")
 s.txt(1490, m6["out-"][1] + 50, "Arduino Nano", "vc")
 
-s.txt(240, 1622, "45 W · dlatego F8 = 7,5 A, nie 5 A", "vc")
-s.txt(860, 1622, "logika i dotyk panelu idą po USB", "vc")
-s.txt(1250, 1622, "Nano musi żyć, gdy M910q śpi", "vc")
+for _bx, _t in ((240, "45 W · dlatego F8 = 7,5 A, nie 5 A"),
+                (860, "logika i dotyk panelu idą po USB"),
+                (1250, "Nano musi żyć, gdy M910q śpi")):
+    s.txt(_bx + 60, 1756, _t, "vc")
+    s.leader(_bx + 60, 1742, _bx + 60, 1620)
 
-s.box(60, 1728, 1000, 56, "note")
-s.txt(80, 1752, "MASA — punkt gwiazdowy", "nh")
-s.txt(80, 1772, "Wszystkie symbole masy na tym arkuszu to JEDEN punkt: "
+s.box(60, 1790, 1000, 56, "note")
+s.txt(80, 1814, "MASA — punkt gwiazdowy", "nh")
+s.txt(80, 1834, "Wszystkie symbole masy na tym arkuszu to JEDEN punkt: "
                 "„−” BT0, „−” D5 i C1, K1:85, K2:85, IN−/OUT− M1, V− M2, "
                 "szyna „−” banku, VIN−/VOUT− M3, IN− M4/M5/M6.", "nt")
-s.box(1090, 1728, 470, 56, "note")
-s.txt(1110, 1752, "Numery w ramkach", "nh")
-s.txt(1110, 1772, "= numery przewodów z tabel §10 docs/SCHEMATY_POLACZEN.md", "nt")
+s.box(1090, 1790, 470, 56, "note")
+s.txt(1110, 1814, "Numery w ramkach", "nh")
+s.txt(1110, 1834, "= numery przewodów z tabel §10 docs/SCHEMATY_POLACZEN.md", "nt")
 
 s.save("schematics/schematic_test_power.svg")
 
@@ -642,7 +669,7 @@ t.path([(u1["p3"][0], u1["p3"][1]), (530, u1["p3"][1]), (530, GNDY), (NX, GNDY)]
 t.wn(560, u1["p3"][1] - 15, 18)
 # U2 kolektor → D10  (korytarz x=680)
 t.path([(u2["p4"][0], u2["p4"][1]), (680, u2["p4"][1]), (680, D10Y), (NX, D10Y)])
-t.wn(730, D10Y - 15, "17a")
+t.wn(636, 440, "17a")
 # U2 emiter → GND    (korytarz x=740, na prawo od korytarza D10)
 t.path([(u2["p3"][0], u2["p3"][1]), (740, u2["p3"][1]), (740, GNDY)])
 t.dot(740, GNDY)

--- a/schematics/schematic_test_power.svg
+++ b/schematics/schematic_test_power.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1620" height="1800" viewBox="0 0 1620 1800" font-family="DejaVu Sans, Verdana, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" width="1620" height="1870" viewBox="0 0 1620 1870" font-family="DejaVu Sans, Verdana, sans-serif">
 <title>BCM v8.5 — arkusz 1/2: ZASILANIE (wariant testowo-rozwojowy, M910q)</title>
 <style>
  .bg{fill:#ffffff}
@@ -43,8 +43,10 @@
  .nt{font-size:11.5px;fill:#4a5a66}
  .wn{font-size:11px;font-weight:bold;fill:#0d1c26;text-anchor:middle}
  .wnb{fill:#ffffff;stroke:#8b9aa6;stroke-width:1.2;rx:3}
+ .ldr{stroke:#7d8c99;stroke-width:1.3;fill:none}
+ .ldrf{fill:#7d8c99;stroke:none}
 </style>
-<rect class="bg" x="0" y="0" width="1620" height="1800"/>
+<rect class="bg" x="0" y="0" width="1620" height="1870"/>
 <text class="ttl" x="40" y="44">BCM v8.5 — arkusz 1/2: ZASILANIE (wariant testowo-rozwojowy, M910q)</text>
 <text class="sub" x="40" y="68">Każdy element osobno. Cewki i styki przekaźników rozdzielone — K1 i K2 to po jednym przekaźniku Bosch, narysowanym w dwóch miejscach. Moduły kupne jako prostokąty z zaciskami.</text>
 <rect class="sectb" x="40" y="98" width="26" height="26"/>
@@ -117,10 +119,10 @@
 <circle class="sym" cx="548" cy="240" r="4.5" fill="#fff"/>
 <line class="w" x1="552" y1="240" x2="566" y2="240"/>
 <line class="wd" x1="518" y1="226" x2="518" y2="266"/>
-<text class="rc" x="518" y="206">K1</text>
+<text class="rc" x="518" y="188">K1</text>
 <text class="pin" x="484" y="262">30</text>
 <text class="pine" x="552" y="262">87</text>
-<text class="vc" x="518" y="310">zwiera po zapłonie</text>
+<text class="vc" x="518" y="208">zwiera po zapłonie</text>
 <circle class="symf" cx="600" cy="240" r="3.8"/>
 <line class="w" x1="566" y1="240" x2="660" y2="240"/>
 <rect class="wnb" x="620" y="215" width="24" height="18"/>
@@ -149,33 +151,35 @@
 <polygon class="symf" points="433,502 455,502 444,520"/>
 <line class="sym" x1="431" y1="502" x2="457" y2="502"/>
 <line class="w" x1="444" y1="502" x2="444" y2="536"/>
-<text class="re" x="418" y="506">D6</text>
-<text class="ve" x="418" y="521">1N4007</text>
+<text class="re" x="410" y="506">D6</text>
+<text class="ve" x="410" y="521">1N4007</text>
 <line class="w" x1="444" y1="536" x2="444" y2="550"/>
 <line class="w" x1="444" y1="550" x2="518" y2="550"/>
 <circle class="symf" cx="518" cy="550" r="3.8"/>
-<rect class="dash" x="660" y="140" width="196" height="200"/>
-<text class="rc" x="758" y="128">D1</text>
-<text class="vc" x="758" y="362">MBR2545CT — anody 1 i 3 zwarte</text>
-<text class="vc" x="758" y="378">blaszka = katoda (pin 2), izoluj od radiatora</text>
+<rect class="dash" x="660" y="130" width="196" height="224"/>
+<text class="rc" x="758" y="118">D1</text>
+<text class="vc" x="758" y="376">MBR2545CT — anody 1 i 3 zwarte</text>
+<text class="vc" x="758" y="392">blaszka = katoda (pin 2), izoluj od radiatora</text>
 <line class="w" x1="660" y1="240" x2="686" y2="240"/>
 <circle class="symf" cx="686" cy="240" r="3.8"/>
-<line class="w" x1="686" y1="180" x2="686" y2="300"/>
-<line class="w" x1="686" y1="180" x2="702" y2="180"/>
-<polygon class="symf" points="702,169 702,191 720,180"/>
-<path class="sym" d="M 726 165 L 720 165 L 720 195 L 714 195"/>
-<line class="w" x1="720" y1="180" x2="738" y2="180"/>
-<line class="w" x1="686" y1="300" x2="702" y2="300"/>
-<polygon class="symf" points="702,289 702,311 720,300"/>
-<path class="sym" d="M 726 285 L 720 285 L 720 315 L 714 315"/>
-<line class="w" x1="720" y1="300" x2="738" y2="300"/>
-<line class="w" x1="738" y1="180" x2="830" y2="180"/>
-<line class="w" x1="830" y1="180" x2="830" y2="300"/>
-<line class="w" x1="830" y1="300" x2="738" y2="300"/>
+<line class="w" x1="686" y1="190" x2="686" y2="290"/>
+<line class="w" x1="686" y1="190" x2="702" y2="190"/>
+<polygon class="symf" points="702,179 702,201 720,190"/>
+<path class="sym" d="M 726 175 L 720 175 L 720 205 L 714 205"/>
+<line class="w" x1="720" y1="190" x2="738" y2="190"/>
+<line class="w" x1="686" y1="290" x2="702" y2="290"/>
+<polygon class="symf" points="702,279 702,301 720,290"/>
+<path class="sym" d="M 726 275 L 720 275 L 720 305 L 714 305"/>
+<line class="w" x1="720" y1="290" x2="738" y2="290"/>
+<line class="w" x1="738" y1="190" x2="830" y2="190"/>
+<line class="w" x1="830" y1="190" x2="830" y2="290"/>
+<line class="w" x1="830" y1="290" x2="738" y2="290"/>
 <circle class="symf" cx="830" cy="240" r="3.8"/>
-<text class="vc" x="714" y="160">pin 1</text>
-<text class="vc" x="714" y="336">pin 3</text>
-<text class="vc" x="786" y="250">pin 2</text>
+<text class="vc" x="712" y="176">pin 1 — anoda</text>
+<text class="vc" x="712" y="322">pin 3 — anoda</text>
+<text class="ve" x="806" y="254">pin 2 — katoda</text>
+<line class="ldr" x1="810" y1="250" x2="828" y2="241"/>
+<polygon class="ldrf" points="828,241 821.5,248.1 818.4,242.0"/>
 <line class="w" x1="830" y1="240" x2="902" y2="240"/>
 <rect class="wnb" x="862" y="215" width="24" height="18"/>
 <text class="wn" x="874" y="229">6</text>
@@ -530,8 +534,12 @@
 <path class="sym" d="M 503 1550 Q 520 1540 537 1550"/>
 <text class="vb" x="494" y="1531">+</text>
 <line class="w" x1="520" y1="1546" x2="520" y2="1566"/>
-<text class="r" x="544" y="1536">C6</text>
-<text class="v" x="544" y="1551">470 µF/35 V</text>
+<text class="r" x="544" y="1536"></text>
+<text class="v" x="544" y="1551"></text>
+<text class="re" x="478" y="1652">C6</text>
+<text class="ve" x="478" y="1668">470 µF / 35 V</text>
+<line class="ldr" x1="492" y1="1632" x2="504" y2="1542"/>
+<polygon class="ldrf" points="504,1542 506.2,1551.4 499.4,1550.5"/>
 <line class="w" x1="520" y1="1566" x2="520" y2="1700"/>
 <line class="w" x1="520" y1="1700" x2="520" y2="1712"/>
 <line class="wg" x1="502" y1="1712" x2="538" y2="1712"/>
@@ -569,13 +577,19 @@
 <text class="pin" x="1520" y="1557">GND</text>
 <text class="rc" x="1490" y="1586">→ ARKUSZ 2</text>
 <text class="vc" x="1490" y="1602">Arduino Nano</text>
-<text class="vc" x="240" y="1622">45 W · dlatego F8 = 7,5 A, nie 5 A</text>
-<text class="vc" x="860" y="1622">logika i dotyk panelu idą po USB</text>
-<text class="vc" x="1250" y="1622">Nano musi żyć, gdy M910q śpi</text>
-<rect class="note" x="60" y="1728" width="1000" height="56"/>
-<text class="nh" x="80" y="1752">MASA — punkt gwiazdowy</text>
-<text class="nt" x="80" y="1772">Wszystkie symbole masy na tym arkuszu to JEDEN punkt: „−” BT0, „−” D5 i C1, K1:85, K2:85, IN−/OUT− M1, V− M2, szyna „−” banku, VIN−/VOUT− M3, IN− M4/M5/M6.</text>
-<rect class="note" x="1090" y="1728" width="470" height="56"/>
-<text class="nh" x="1110" y="1752">Numery w ramkach</text>
-<text class="nt" x="1110" y="1772">= numery przewodów z tabel §10 docs/SCHEMATY_POLACZEN.md</text>
+<text class="vc" x="300" y="1756">45 W · dlatego F8 = 7,5 A, nie 5 A</text>
+<line class="ldr" x1="300" y1="1742" x2="300" y2="1620"/>
+<polygon class="ldrf" points="300,1620 303.4,1629.0 296.6,1629.0"/>
+<text class="vc" x="920" y="1756">logika i dotyk panelu idą po USB</text>
+<line class="ldr" x1="920" y1="1742" x2="920" y2="1620"/>
+<polygon class="ldrf" points="920,1620 923.4,1629.0 916.6,1629.0"/>
+<text class="vc" x="1310" y="1756">Nano musi żyć, gdy M910q śpi</text>
+<line class="ldr" x1="1310" y1="1742" x2="1310" y2="1620"/>
+<polygon class="ldrf" points="1310,1620 1313.4,1629.0 1306.6,1629.0"/>
+<rect class="note" x="60" y="1790" width="1000" height="56"/>
+<text class="nh" x="80" y="1814">MASA — punkt gwiazdowy</text>
+<text class="nt" x="80" y="1834">Wszystkie symbole masy na tym arkuszu to JEDEN punkt: „−” BT0, „−” D5 i C1, K1:85, K2:85, IN−/OUT− M1, V− M2, szyna „−” banku, VIN−/VOUT− M3, IN− M4/M5/M6.</text>
+<rect class="note" x="1090" y="1790" width="470" height="56"/>
+<text class="nh" x="1110" y="1814">Numery w ramkach</text>
+<text class="nt" x="1110" y="1834">= numery przewodów z tabel §10 docs/SCHEMATY_POLACZEN.md</text>
 </svg>

--- a/schematics/schematic_test_signals.svg
+++ b/schematics/schematic_test_signals.svg
@@ -43,6 +43,8 @@
  .nt{font-size:11.5px;fill:#4a5a66}
  .wn{font-size:11px;font-weight:bold;fill:#0d1c26;text-anchor:middle}
  .wnb{fill:#ffffff;stroke:#8b9aa6;stroke-width:1.2;rx:3}
+ .ldr{stroke:#7d8c99;stroke-width:1.3;fill:none}
+ .ldrf{fill:#7d8c99;stroke:none}
 </style>
 <rect class="bg" x="0" y="0" width="1620" height="1230"/>
 <text class="ttl" x="40" y="44">BCM v8.5 — arkusz 2/2: SYGNAŁY I STEROWANIE (Arduino Nano)</text>
@@ -171,8 +173,8 @@
 <line class="w" x1="468" y1="454" x2="680" y2="454"/>
 <line class="w" x1="680" y1="454" x2="680" y2="466"/>
 <line class="w" x1="680" y1="466" x2="900" y2="466"/>
-<rect class="wnb" x="718" y="441" width="24" height="18"/>
-<text class="wn" x="730" y="455">17a</text>
+<rect class="wnb" x="624" y="430" width="24" height="18"/>
+<text class="wn" x="636" y="444">17a</text>
 <line class="w" x1="468" y1="532" x2="740" y2="532"/>
 <line class="w" x1="740" y1="532" x2="740" y2="388"/>
 <circle class="symf" cx="740" cy="388" r="3.8"/>


### PR DESCRIPTION
Four places where a label sat close enough to a wire or symbol to read as part of it:

- **"zwiera po zapłonie"** sat directly under C1's value, so it read as C1's caption when it describes the K1 contact. Moved above the contact, where there is nothing else.
- **D1's pin labels.** The dashed outline is 24 px taller now so "pin 1" and "pin 3" have clearance from the diode bodies, and "pin 2 — katoda" — which had nothing near it to attach to — gets a leader with an arrowhead landing on the cathode node.
- **C6.** Its value ran through the OUT− return wire. Label moved clear below and to the left, leader up to the capacitor.
- **The three converter captions** ("45 W · dlatego F8 = 7,5 A…" and the other two) each crossed their own module's IN− ground corridor. Moved below the ground symbols, each with a leader pointing up at the module it describes. Sheet is 70 px taller to make room.

Also nudged D6's value further from the diode body and moved the "17a" wire number off the U2 emitter corridor on sheet 2.

New `leader()` helper in the generator draws a thin line with an arrowhead, so future labels can be pulled out the same way.


Claude-Session: https://claude.ai/code/session_017cXmt2HyZ8iv3aQHpkNA4c