### PR TITLE
Make the SWC pods, the headphone jack and Android Auto actually work

### DIFF
--- a/arduino/rotary_encoder/rotary_encoder.ino
+++ b/arduino/rotary_encoder/rotary_encoder.ino
@@ -45,8 +45,40 @@
  *   NOTE: A4 is not broken out on a classic Pro Micro — it needs a clone
  *   with the A4 pad (or the inner bottom pad). See docs/ARDUINO_SETUP_GUIDE.md.
  *
- * Calibration mode: hold HOME + BACK at boot → SWC calibration via serial.
- * Watchdog: 2 s (enabled after the calibration window).
+ * Calibration mode: hold HOME + BACK at boot (gdy FEATURE_BUTTONS jest
+ *   włączone) ALBO wyślij "CAL" na port szeregowy w dowolnym momencie.
+ * Watchdog: 2 s (wyłączany na czas kalibracji).
+ *
+ * ---------------------------------------------------------------------------
+ * v8.5.3 — naprawa fałszywych przycisków SWC
+ *
+ * Objaw: przy niepodłączonych podach płytka sypała zdarzeniami, przy czym
+ * OBA pody raportowały ten sam przycisk przy niemal tej samej wartości ADC.
+ * Trzy niezależne przyczyny, wszystkie usunięte:
+ *
+ *   1. Wejścia analogowe były ustawione jako gołe INPUT. Kod uznaje spoczynek
+ *      za "ADC > SWC_IDLE_THRESHOLD" (≈ VCC), więc WYMAGA, żeby coś trzymało
+ *      linię wysoko. Teraz INPUT_PULLUP. W aucie i tak lepszy jest zewnętrzny
+ *      10 kΩ do VCC — wewnętrzny ma 20–50 kΩ i szeroką tolerancję.
+ *
+ *   2. Multiplekser ADC ma JEDEN kondensator sample-and-hold na wszystkie
+ *      kanały. Pierwsza konwersja po przełączeniu kanału niesie ładunek
+ *      z kanału poprzedniego — przy pływającym wejściu praktycznie w całości.
+ *      Stąd Pod 2 był kopią Pod 1. Teraz: adcStable() odrzuca dwie pierwsze
+ *      konwersje i zwraca MEDIANĘ (mediana ignoruje pik, średnia go rozmazuje).
+ *
+ *   3. Nie było realnego debounce'u: licznik czasu odświeżał się tylko przy
+ *      ZMIANIE odczytu, więc pierwsza odbiegająca próbka natychmiast wysyłała
+ *      klawisz. Teraz kandydat musi być stabilny przez SWC_CONFIRM_MS, a między
+ *      dwoma różnymi przyciskami wymagany jest powrót do spoczynku.
+ *
+ * To nie była wyłącznie uciążliwość: SWC MODE wysyła F10, które BCM mapuje na
+ * input.bcm_power_toggle — szum potrafił wyłączyć komputer.
+ *
+ * Przy okazji: piny enkodera dostały INPUT_PULLUP (bez podłączonego enkodera
+ * pływały i przerwanie CHANGE sypało strzałkami), a wejścia, których nie masz
+ * podłączonych, można teraz wyłączyć przełącznikami FEATURE_* poniżej.
+ * ---------------------------------------------------------------------------
  */
 
 #include <avr/wdt.h>
@@ -55,6 +87,30 @@
 // ze stockowego Keyboard.h psują kompilację (konflikt makro vs enum).
 #include <HID-Project.h>
 #include <EEPROM.h>
+
+// --- Przełączniki funkcji -------------------------------------------------
+// Zakomentuj to, czego nie masz podłączonego. Niepodłączone wejścia cyfrowe
+// z pull-upem są nieszkodliwe, ale wyłączenie ich skraca pętlę i usuwa szum
+// z portu szeregowego. Wejścia ANALOGOWE wyłączaj zawsze, gdy nic na nich
+// nie wisi — pływający pin to śmieci w multiplekserze ADC.
+//
+// Domyślnie: tylko pody SWC. To jedyna rzecz, która ma teraz działać.
+#define FEATURE_SWC        // pody SWC na kierownicy (A0 + A6)
+// #define FEATURE_ENCODER // enkoder obrotowy + przycisk (D2, D3, D1)
+// #define FEATURE_BUTTONS // HOME / BACK / MEDIA / VOL+ / VOL− (D5–D9)
+// #define FEATURE_MUSIC   // panel muzyczny (D10, D14, D15, D16, A3)
+// #define FEATURE_STALK   // przycisk manetki → F9 (A2)
+// #define FEATURE_LIGHT   // fotorezystor LDR (A1)
+// #define FEATURE_FUEL    // czujnik paliwa (A4) — patrz #error niżej
+
+#if defined(FEATURE_FUEL)
+#error "A4 nie jest wyprowadzone na klasycznym Pro Micro (PF1). Potrzebny klon z padem A4 albo inna plytka — patrz docs/ARDUINO_SETUP_GUIDE.md."
+#endif
+
+#if !defined(FEATURE_SWC) && !defined(FEATURE_ENCODER) && !defined(FEATURE_BUTTONS) \
+    && !defined(FEATURE_MUSIC) && !defined(FEATURE_STALK) && !defined(FEATURE_LIGHT)
+#error "Wszystkie FEATURE_* sa zakomentowane — plytka nie robilaby nic. Odkomentuj przynajmniej FEATURE_SWC."
+#endif
 
 // --- Pin definitions ---
 #define ENC_CLK 2
@@ -86,9 +142,20 @@
 // --- Debounce ---
 #define DEBOUNCE_MS 50
 #define ENCODER_DEBOUNCE_MS 5
-#define SWC_DEBOUNCE_MS 150
 #define ADC_TOLERANCE 40
 #define LIGHT_REPORT_MS 2000  // Send light level every 2 seconds
+
+// --- Odczyt ADC (patrz nota v8.5.3 w nagłówku) ---
+// Dwie konwersje na rozruch multipleksera, potem 5 próbek i mediana.
+// Koszt: ~2,4 ms na kanał. Przy dwóch podach pętla trwa ~5 ms — bez znaczenia
+// wobec 50 ms debounce'u przycisków i 2 s watchdoga.
+#define ADC_SETTLE_US   200   // po przełączeniu kanału, na naładowanie S/H
+#define ADC_SAMPLES       5   // nieparzyście — mediana musi mieć środek
+#define ADC_SPACING_US  400   // rozrzut próbek, żeby nie złapać jednego piku
+
+// Kandydat musi być odczytany tak samo przez tyle czasu, zanim poleci HID.
+// 60 ms to kompromis: krócej łapie zakłócenia, dłużej daje wrażenie opóźnienia.
+#define SWC_CONFIRM_MS   60
 
 // --- SWC button count (12 per pod x 2 pods = 24 total) ---
 #define SWC_BUTTONS_PER_POD 12
@@ -143,80 +210,128 @@ uint16_t swcValues[SWC_BUTTON_COUNT] = {
   540, 610, 690, 760, 830, 900,
 };
 
+#ifdef FEATURE_ENCODER
 // --- State: encoder ---
 volatile int encoderPos = 0;
 int lastEncoderPos = 0;
 int lastCLK = HIGH;
+#endif
 
+#if defined(FEATURE_BUTTONS) || defined(FEATURE_ENCODER)
 // --- State: main buttons (6: enc_sw, home, back, media, vol+, vol-) ---
 #define MAIN_BTN_COUNT 6
 unsigned long lastButtonTime[MAIN_BTN_COUNT] = {0};
 bool lastButtonState[MAIN_BTN_COUNT] = {HIGH, HIGH, HIGH, HIGH, HIGH, HIGH};
 const int buttonPins[MAIN_BTN_COUNT] = {ENC_SW, BTN_HOME, BTN_BACK, BTN_MEDIA, BTN_VOLUP, BTN_VOLDN};
+#endif
 
+#ifdef FEATURE_MUSIC
 // --- State: music panel buttons (5) ---
 #define MUSIC_BTN_COUNT 5
 unsigned long lastMusicTime[MUSIC_BTN_COUNT] = {0};
 bool lastMusicState[MUSIC_BTN_COUNT] = {HIGH, HIGH, HIGH, HIGH, HIGH};
 const int musicPins[MUSIC_BTN_COUNT] = {MUS_PREV, MUS_NEXT, MUS_VOLUP, MUS_VOLDN, MUS_MUTE};
+#endif
 
+#ifdef FEATURE_STALK
 // --- State: stalk brightness button ---
 unsigned long lastStalkTime = 0;
 bool lastStalkState = HIGH;
+#endif
 
+#ifdef FEATURE_SWC
 // --- State: SWC (per-pod) ---
-int lastSWCButton1 = -1;
-int lastSWCButton2 = -1;
-unsigned long lastSWCTime1 = 0;
-unsigned long lastSWCTime2 = 0;
-bool calibrationMode = false;
+//
+// reported  — ostatni stan wysłany do komputera (-1 = spoczynek)
+// candidate — odczyt oczekujący na potwierdzenie
+// candAt    — od kiedy candidate jest niezmienny
+struct SwcPod {
+  uint8_t      pin;
+  uint8_t      offset;
+  int8_t       reported;
+  int8_t       candidate;
+  unsigned long candAt;
+  const char*  tag;
+};
 
+SwcPod swcPods[2] = {
+  {SWC_PIN1, 0,                   -1, -1, 0, "SWC1"},
+  {SWC_PIN2, SWC_BUTTONS_PER_POD, -1, -1, 0, "SWC2"},
+};
+#endif
+
+#ifdef FEATURE_LIGHT
 // --- State: light sensor ---
 unsigned long lastLightReport = 0;
-unsigned long lastFuelReport = 0;
+#endif
 
 // --- Forward declarations ---
+#if defined(FEATURE_BUTTONS) || defined(FEATURE_ENCODER)
 void handleButtonPress(int buttonIndex);
+#endif
+#ifdef FEATURE_MUSIC
 void handleMusicButton(int buttonIndex);
-void handleSWCButton(int buttonIndex);
+#endif
+#ifdef FEATURE_ENCODER
 void readEncoder();
+#endif
+#ifdef FEATURE_SWC
+void handleSWCButton(int buttonIndex);
 void loadSWCCalibration();
 void saveSWCCalibration();
 void runCalibration();
-int readSWCButton(int pin, int offset);
+int  readSWCButton(uint8_t pin, uint8_t offset);
+void handlePod(SwcPod &p, unsigned long now);
+#endif
+#ifdef FEATURE_LIGHT
 void reportLightLevel();
-void reportFuelLevel();
+#endif
+int adcStable(uint8_t pin);
 
 void setup() {
-  // Encoder pins (external pull-ups)
-  pinMode(ENC_CLK, INPUT);
-  pinMode(ENC_DT, INPUT);
-
-  // Main button pins (internal pull-ups)
+#ifdef FEATURE_ENCODER
+  // Enkoder — INPUT_PULLUP, nie gołe INPUT. Bez podłączonej płytki enkodera
+  // pin pływa, a przerwanie CHANGE sypie strzałkami do komputera. Zewnętrzne
+  // 10 kΩ (jeśli je masz) po prostu zadziała równolegle.
+  pinMode(ENC_CLK, INPUT_PULLUP);
+  pinMode(ENC_DT, INPUT_PULLUP);
   pinMode(ENC_SW, INPUT_PULLUP);
+  attachInterrupt(digitalPinToInterrupt(ENC_CLK), readEncoder, CHANGE);
+#endif
+
+#ifdef FEATURE_BUTTONS
   pinMode(BTN_HOME, INPUT_PULLUP);
   pinMode(BTN_BACK, INPUT_PULLUP);
   pinMode(BTN_MEDIA, INPUT_PULLUP);
   pinMode(BTN_VOLUP, INPUT_PULLUP);
   pinMode(BTN_VOLDN, INPUT_PULLUP);
+#endif
 
-  // Music panel pins (internal pull-ups)
+#ifdef FEATURE_MUSIC
   pinMode(MUS_PREV, INPUT_PULLUP);
   pinMode(MUS_NEXT, INPUT_PULLUP);
   pinMode(MUS_VOLUP, INPUT_PULLUP);
   pinMode(MUS_VOLDN, INPUT_PULLUP);
   pinMode(MUS_MUTE, INPUT_PULLUP);
+#endif
 
-  // Brightness stalk button (internal pull-up)
+#ifdef FEATURE_STALK
   pinMode(STALK_BTN_PIN, INPUT_PULLUP);
+#endif
 
-  // Analog inputs (no pull-up needed)
-  pinMode(SWC_PIN1, INPUT);
-  pinMode(SWC_PIN2, INPUT);
+#ifdef FEATURE_SWC
+  // INPUT_PULLUP, nie INPUT. Spoczynek jest tu zdefiniowany jako ADC ≈ VCC,
+  // więc linia MUSI być czymś podciągnięta. Wewnętrzny pull-up (20–50 kΩ)
+  // wystarcza na biurku; w aucie dołóż zewnętrzne 10 kΩ do VCC i skalibruj
+  // pody DOPIERO po jego zamontowaniu — przy pasywnej drabince rezystorowej
+  // podciągnięcie współtworzy dzielnik i zmienia wszystkie progi.
+  pinMode(SWC_PIN1, INPUT_PULLUP);
+  pinMode(SWC_PIN2, INPUT_PULLUP);
+#endif
+
+#ifdef FEATURE_LIGHT
   pinMode(LDR_PIN, INPUT);
-
-  // Encoder interrupt
-  attachInterrupt(digitalPinToInterrupt(ENC_CLK), readEncoder, CHANGE);
+#endif
 
   // Start USB HID
   Keyboard.begin();
@@ -224,29 +339,108 @@ void setup() {
 
   // Start serial for calibration/debug + light sensor data
   Serial.begin(115200);
+  // Domyślny timeout to 1000 ms — przy strumieniu bez znaku nowej linii
+  // readStringUntil() blokowałby pętlę na sekundę przy każdym przebiegu.
+  Serial.setTimeout(50);
 
-  // Load SWC calibration from EEPROM
+#ifdef FEATURE_SWC
   loadSWCCalibration();
 
-  // Check calibration mode: hold HOME + BACK at boot
+#ifdef FEATURE_BUTTONS
+  // Kalibracja z przycisków: HOME + BACK przy starcie. Sprawdzane tylko gdy
+  // te przyciski są w ogóle skonfigurowane — inaczej czytalibyśmy pływający
+  // pin i wchodzili w kalibrację przypadkiem.
   delay(100);
   if (digitalRead(BTN_HOME) == LOW && digitalRead(BTN_BACK) == LOW) {
-    calibrationMode = true;
     runCalibration();
-    calibrationMode = false;
   }
+#endif
+#endif
 
-  Serial.println("BCM v7 Input Controller ready (encoder + buttons + SWC + music + brightness)");
+  Serial.println(F("BCM v8.5.3 Input Controller ready"));
+#ifdef FEATURE_SWC
+  Serial.println(F("SWC: wpisz CAL i Enter, aby uruchomic kalibracje podow"));
+#endif
 
   // Watchdog ON dopiero po (ewentualnej) kalibracji — kalibracja
   // czeka na przyciski użytkownika dłużej niż 2 s.
   wdt_enable(WDTO_2S);
 }
 
+// Odczyt ADC odporny na przesłuch multipleksera i pojedyncze piki.
+//
+// ATmega32U4 ma jeden kondensator sample-and-hold na WSZYSTKIE kanały. Po
+// przełączeniu kanału pierwsza konwersja niesie w sobie ładunek z kanału
+// poprzedniego — przy wysokiej impedancji źródła praktycznie w całości.
+// To dlatego niepodłączony Pod 2 raportował dokładnie to samo co Pod 1.
+//
+// Mediana zamiast średniej: pojedynczy pik przesuwa średnią, medianę
+// zostawia w spokoju.
+int adcStable(uint8_t pin) {
+  analogRead(pin);                    // 1. przełącz multiplekser
+  delayMicroseconds(ADC_SETTLE_US);
+  analogRead(pin);                    // 2. S/H zdążył się naładować
+  delayMicroseconds(ADC_SETTLE_US);
+
+  int s[ADC_SAMPLES];
+  for (uint8_t i = 0; i < ADC_SAMPLES; i++) {
+    s[i] = analogRead(pin);
+    delayMicroseconds(ADC_SPACING_US);
+  }
+
+  // Sortowanie przez wstawianie — przy 5 elementach najtańsze co do bajtów.
+  for (uint8_t i = 1; i < ADC_SAMPLES; i++) {
+    int v = s[i];
+    int8_t j = (int8_t)i - 1;
+    while (j >= 0 && s[j] > v) {
+      s[j + 1] = s[j];
+      j--;
+    }
+    s[j + 1] = v;
+  }
+  return s[ADC_SAMPLES / 2];
+}
+
+#ifdef FEATURE_SWC
+// Jeden pod, jeden przebieg: odczyt → potwierdzenie → ewentualny HID.
+//
+// Zasada: nic nie leci do komputera, dopóki ten sam odczyt nie utrzyma się
+// przez SWC_CONFIRM_MS. Dodatkowo między dwoma RÓŻNYMI przyciskami wymagany
+// jest powrót do spoczynku — na drabince rezystorowej przeskok A→B bez
+// rozwarcia to zawsze artefakt, nie intencja kierowcy.
+void handlePod(SwcPod &p, unsigned long now) {
+  int btn = readSWCButton(p.pin, p.offset);
+
+  if (btn != p.candidate) {          // odczyt się zmienił — licz od nowa
+    p.candidate = (int8_t)btn;
+    p.candAt = now;
+    return;
+  }
+  if ((now - p.candAt) < SWC_CONFIRM_MS) return;   // jeszcze nie stabilny
+  if (btn == p.reported) return;                   // nic nowego
+
+  if (btn >= 0 && p.reported >= 0) {
+    // Przycisk → przycisk bez spoczynku pomiędzy. Czekamy na rozwarcie;
+    // p.reported celowo NIE jest aktualizowane, więc kolejne przejścia też
+    // są blokowane aż do powrotu na -1.
+    return;
+  }
+
+  p.reported = (int8_t)btn;
+  if (btn >= 0) {
+    handleSWCButton(btn);
+    Serial.print(p.tag);
+    Serial.print(F(": "));
+    Serial.println(SWC_NAMES[btn]);
+  }
+}
+#endif
+
 void loop() {
   wdt_reset();
   unsigned long now = millis();
 
+#ifdef FEATURE_ENCODER
   // --- Handle encoder rotation ---
   if (encoderPos != lastEncoderPos) {
     int diff = encoderPos - lastEncoderPos;
@@ -262,9 +456,23 @@ void loop() {
       Keyboard.release(KEY_UP_ARROW);
     }
   }
+#endif
 
+#if defined(FEATURE_BUTTONS) || defined(FEATURE_ENCODER)
   // --- Handle main buttons (debounced) ---
-  for (int i = 0; i < MAIN_BTN_COUNT; i++) {
+  // Bez FEATURE_ENCODER pomijamy indeks 0 (ENC_SW), bez FEATURE_BUTTONS
+  // pomijamy resztę — pinMode tych pinów nie był ustawiany.
+#ifdef FEATURE_ENCODER
+  const int btnFrom = 0;
+#else
+  const int btnFrom = 1;
+#endif
+#ifdef FEATURE_BUTTONS
+  const int btnTo = MAIN_BTN_COUNT;
+#else
+  const int btnTo = 1;
+#endif
+  for (int i = btnFrom; i < btnTo; i++) {
     bool currentState = digitalRead(buttonPins[i]);
 
     if (currentState != lastButtonState[i] && (now - lastButtonTime[i]) > DEBOUNCE_MS) {
@@ -276,7 +484,9 @@ void loop() {
       }
     }
   }
+#endif
 
+#ifdef FEATURE_MUSIC
   // --- Handle music panel buttons (debounced) ---
   for (int i = 0; i < MUSIC_BTN_COUNT; i++) {
     bool currentState = digitalRead(musicPins[i]);
@@ -290,7 +500,9 @@ void loop() {
       }
     }
   }
+#endif
 
+#ifdef FEATURE_STALK
   // --- Handle stalk brightness button (debounced) ---
   {
     bool stalkState = digitalRead(STALK_BTN_PIN);
@@ -302,58 +514,43 @@ void loop() {
         Keyboard.press(KEY_F9);
         delay(10);
         Keyboard.release(KEY_F9);
-        Serial.println("STALK: Brightness cycle");
+        Serial.println(F("STALK: Brightness cycle"));
       }
     }
   }
+#endif
 
+#ifdef FEATURE_SWC
   // --- Handle SWC analog buttons (Pod 1 on A0, Pod 2 on A6) ---
-  if ((now - lastSWCTime1) > SWC_DEBOUNCE_MS) {
-    int btn = readSWCButton(SWC_PIN1, 0);
-    if (btn != lastSWCButton1) {
-      if (btn >= 0) {
-        handleSWCButton(btn);
-        Serial.print("SWC1: ");
-        Serial.print(SWC_NAMES[btn]);
-        Serial.print(" (ADC=");
-        Serial.print(analogRead(SWC_PIN1));
-        Serial.println(")");
-      }
-      lastSWCButton1 = btn;
-      lastSWCTime1 = now;
-    }
-  }
-  if ((now - lastSWCTime2) > SWC_DEBOUNCE_MS) {
-    int btn = readSWCButton(SWC_PIN2, SWC_BUTTONS_PER_POD);
-    if (btn != lastSWCButton2) {
-      if (btn >= 0) {
-        handleSWCButton(btn);
-        Serial.print("SWC2: ");
-        Serial.print(SWC_NAMES[btn]);
-        Serial.print(" (ADC=");
-        Serial.print(analogRead(SWC_PIN2));
-        Serial.println(")");
-      }
-      lastSWCButton2 = btn;
-      lastSWCTime2 = now;
-    }
-  }
+  handlePod(swcPods[0], now);
+  handlePod(swcPods[1], now);
 
+  // --- Kalibracja na żądanie: wyślij "CAL" na port szeregowy ---
+  // Alternatywa dla HOME + BACK przy starcie, która działa także wtedy, gdy
+  // nie masz podłączonych przycisków (czyli w domyślnej konfiguracji).
+  if (Serial.available() > 0) {
+    String cmd = Serial.readStringUntil('\n');
+    cmd.trim();
+    if (cmd.equalsIgnoreCase("CAL")) {
+      wdt_disable();               // kalibracja czeka na człowieka > 2 s
+      runCalibration();
+      wdt_enable(WDTO_2S);
+    }
+  }
+#endif
+
+#ifdef FEATURE_LIGHT
   // --- Report light level periodically via serial ---
   if ((now - lastLightReport) > LIGHT_REPORT_MS) {
     reportLightLevel();
     lastLightReport = now;
   }
-
-  // --- Report fuel sender ADC periodically via serial ---
-  if ((now - lastFuelReport) > FUEL_REPORT_MS) {
-    reportFuelLevel();
-    lastFuelReport = now;
-  }
+#endif
 
   delay(1);
 }
 
+#if defined(FEATURE_BUTTONS) || defined(FEATURE_ENCODER)
 void handleButtonPress(int buttonIndex) {
   switch (buttonIndex) {
     case 0:  // Encoder push → Enter
@@ -382,32 +579,36 @@ void handleButtonPress(int buttonIndex) {
       break;
   }
 }
+#endif
 
+#ifdef FEATURE_MUSIC
 void handleMusicButton(int buttonIndex) {
   switch (buttonIndex) {
     case 0:  // MUSIC PREV
       Consumer.write(MEDIA_PREVIOUS);
-      Serial.println("MUSIC: PREV");
+      Serial.println(F("MUSIC: PREV"));
       break;
     case 1:  // MUSIC NEXT
       Consumer.write(MEDIA_NEXT);
-      Serial.println("MUSIC: NEXT");
+      Serial.println(F("MUSIC: NEXT"));
       break;
     case 2:  // MUSIC VOL+
       Consumer.write(MEDIA_VOLUME_UP);
-      Serial.println("MUSIC: VOL+");
+      Serial.println(F("MUSIC: VOL+"));
       break;
     case 3:  // MUSIC VOL-
       Consumer.write(MEDIA_VOLUME_DOWN);
-      Serial.println("MUSIC: VOL-");
+      Serial.println(F("MUSIC: VOL-"));
       break;
     case 4:  // MUSIC MUTE
       Consumer.write(MEDIA_VOLUME_MUTE);
-      Serial.println("MUSIC: MUTE");
+      Serial.println(F("MUSIC: MUTE"));
       break;
   }
 }
+#endif
 
+#ifdef FEATURE_SWC
 void handleSWCButton(int buttonIndex) {
   // Pod 2 buttons (12-23) send the same keycodes as their Pod 1 equivalents
   int base = buttonIndex % SWC_BUTTONS_PER_POD;
@@ -465,13 +666,8 @@ void handleSWCButton(int buttonIndex) {
   }
 }
 
-int readSWCButton(int pin, int offset) {
-  long sum = 0;
-  for (int i = 0; i < 4; i++) {
-    sum += analogRead(pin);
-    delayMicroseconds(100);
-  }
-  int adc = sum / 4;
+int readSWCButton(uint8_t pin, uint8_t offset) {
+  int adc = adcStable(pin);
 
   if (adc > SWC_IDLE_THRESHOLD) {
     return -1;
@@ -494,27 +690,16 @@ int readSWCButton(int pin, int offset) {
 
   return -1;
 }
+#endif
 
+#ifdef FEATURE_LIGHT
 void reportLightLevel() {
-  long sum = 0;
-  for (int i = 0; i < 4; i++) {
-    sum += analogRead(LDR_PIN);
-    delayMicroseconds(200);
-  }
-  Serial.print("LIGHT:");
-  Serial.println((int)(sum / 4));
+  Serial.print(F("LIGHT:"));
+  Serial.println(adcStable(LDR_PIN));
 }
+#endif
 
-void reportFuelLevel() {
-  long sum = 0;
-  for (int i = 0; i < 8; i++) {
-    sum += analogRead(FUEL_PIN);
-    delay(2);
-  }
-  Serial.print("FUEL:");
-  Serial.println((int)(sum / 8));
-}
-
+#ifdef FEATURE_SWC
 // --- SWC calibration ---
 
 void loadSWCCalibration() {
@@ -539,7 +724,7 @@ void saveSWCCalibration() {
   Serial.println("SWC: Calibration saved to EEPROM");
 }
 
-void calibratePod(int pin, int offset, const char* podName) {
+void calibratePod(uint8_t pin, uint8_t offset, const char* podName) {
   Serial.print("--- Calibrating ");
   Serial.print(podName);
   Serial.println(" ---");
@@ -549,19 +734,17 @@ void calibratePod(int pin, int offset, const char* podName) {
     Serial.print(SWC_NAMES[offset + i]);
     Serial.println(" ...");
 
-    while (analogRead(pin) < SWC_IDLE_THRESHOLD) {
+    // Czekaj na rozwarcie wszystkich przycisków tego poda.
+    while (adcStable(pin) < SWC_IDLE_THRESHOLD) {
       delay(50);
     }
     delay(300);
 
+    // Czekaj na wciśnięcie i zmierz. adcStable() już odrzuca przesłuch
+    // multipleksera i pojedyncze piki, więc jedna próbka wystarczy.
     int adc = 0;
     while (true) {
-      long s = 0;
-      for (int j = 0; j < 8; j++) {
-        s += analogRead(pin);
-        delay(5);
-      }
-      adc = s / 8;
+      adc = adcStable(pin);
       if (adc < SWC_IDLE_THRESHOLD) {
         break;
       }
@@ -597,7 +780,7 @@ void runCalibration() {
 
   calibratePod(SWC_PIN1, 0, "Pod 1 (A0)");
   Serial.println();
-  calibratePod(SWC_PIN2, SWC_BUTTONS_PER_POD, "Pod 2 (A6)");
+  calibratePod(SWC_PIN2, SWC_BUTTONS_PER_POD, "Pod 2 (A6 = pad 4)");
 
   Serial.println();
   Serial.println("Calibration results:");
@@ -612,7 +795,9 @@ void runCalibration() {
   Serial.println("=== CALIBRATION COMPLETE ===");
   Serial.println();
 }
+#endif  // FEATURE_SWC
 
+#ifdef FEATURE_ENCODER
 void readEncoder() {
   int clkState = digitalRead(ENC_CLK);
   int dtState = digitalRead(ENC_DT);
@@ -626,3 +811,4 @@ void readEncoder() {
     lastCLK = clkState;
   }
 }
+#endif  // FEATURE_ENCODER

--- a/config/bcm_config.yaml
+++ b/config/bcm_config.yaml
@@ -7,36 +7,50 @@ system:
   simulation: false
 # Jeden przełącznik na każdy moduł/podsystem — pełna lista i stan
 # także w UI: Settings -> Moduły (GET/POST /api/modules).
+#
+# ZAKRES BIEŻĄCEGO WDROŻENIA (v8.5.3): pogoda, planowanie trasy, Android Auto
+# i pody SWC na kierownicy. Reszta jest wyłączona, bo nie ma podłączonego
+# sprzętu — moduł bez czujnika nie „nic nie robi", tylko zaśmieca logi
+# i publikuje wartości udawane albo zerowe.
+#
+# Powrót do pełnej konfiguracji to zmiana false → true przy danej linii.
 modules:
-  dashboard: true
-  obd: true
-  parking: true
-  environment: true
-  audio: true
-  input: true
-  camera: true
-  power: true
-  multimedia: true
-  location: true
-  tracking: true
-  network: true
-  weather: true
-  blinker_monitor: true
-  rain_sensor: true
-  central_lock: true
-  lighting: true
-  performance: true
-  alarm: true
-  crash_detect: true
-  battery: true
+  # --- WŁĄCZONE ---
+  dashboard: true          # UI na :5002 — wszystkie cztery funkcje renderują się tutaj
+  weather: true            # pogoda (wymaga weather.api_key i internetu)
+  route_planner: true      # planowanie trasy (wymaga travel.openrouteservice_key)
+  multimedia: true         # Android Auto — potrzebuje binarki autoapp, patrz
+                           # config/scripts/install-openauto.sh
+  bluetooth: true          # bootstrap AA + CoD carkit; sam handshake AA robi
+                           # btservice wbudowany w autoapp
+  wifi_ap: true            # P2P-GO na MT7921 — łącze danych Android Auto
+  input: true              # pody SWC przez Pro Micro (USB HID)
+  audio: true              # dźwięk przez gniazdo słuchawkowe — patrz blok audio:
+
+  # --- WYŁĄCZONE: brak sprzętu albo poza zakresem ---
+  obd: false               # brak CP2102 + L9637D
+  parking: false           # brak HC-SR04
+  environment: false       # brak DS18B20
+  camera: false            # brak kamer i grabera
+  power: false             # zasilanie idzie wprost spod zapłonu, bez bufora;
+                           # PowerManager i tak nie usypia maszyny na x86
+  location: false          # brak GPS
+  tracking: false          # zależy od GPS
+  network: false           # tylko raportuje stan modemu LTE
+  blinker_monitor: false
+  rain_sensor: false
+  central_lock: false
+  lighting: false
+  performance: false
+  alarm: false
+  crash_detect: false
+  battery: false
   # podsystemy (startowane wprost w main.py):
-  bluetooth: true
-  phonebook: true
-  fuel_sender: true
-  wifi_ap: true            # WiFi dla Android Auto wireless (P2P-GO, karta wewnętrzna)
-  wifi_hotspot: false      # dodatkowy AP ALFA-NET — włącz dopiero po dokupieniu dongla WiFi
-  route_planner: true
-  small_display: true
+  phonebook: false         # PBAP — kontakty z telefonu, poza zakresem
+  fuel_sender: false       # czujnik paliwa jest na A4, którego Pro Micro nie ma
+  wifi_hotspot: false      # ALFA-NET wymaga OSOBNEGO radia (dongla USB) —
+                           # MT7921 zgłasza #{AP, P2P-GO} <= 1
+  small_display: false     # drugi ekran 6,86" — na razie jeden panel
 display:
   dashboard:
     width: 1280
@@ -98,6 +112,17 @@ hardware:
     device: ''
     apn: ''
 audio:
+  # Wyjście dźwięku. "auto" = wybierz wbudowane wyjście analogowe i pomiń
+  # HDMI (na M910q HDMI prawie zawsze jest podłączone i prawie nigdy nie o to
+  # chodzi). Możesz też wpisać fragment node.name z `wpctl status --name`,
+  # np. alsa_output.pci-0000_00_1f.3.analog-stereo
+  sink: auto
+  # Sink sprzętowy trzymamy na maksimum, a użytkownik reguluje głośność na
+  # sinku EQ. Inaczej regulacja działa na jednym, a cichy jest drugi.
+  hw_volume: 100
+  # Świeży Realtek potrafi wstać z włączonym Auto-Mute i wyciszonym
+  # Headphone — wtedy nic nie zagra mimo poprawnego routingu.
+  force_unmute: true
   eq_dsp_enabled: true   # prawdziwy EQ przez PipeWire filter-chain
   eq_preset: jazz
   master_volume: 70
@@ -221,9 +246,15 @@ wifi:
     dhcp_start: 10.0.1.10
     dhcp_end: 10.0.1.50
     share_internet: true
-  ssid_runtime: DIRECT-Ea
-  password_runtime: adVEiNlq
-  bssid_runtime: 4e:82:a9:17:47:97
+  # ssid_runtime / password_runtime / bssid_runtime są USTAWIANE W LOCIE przez
+  # wifi_ap.py po utworzeniu grupy P2P-GO i zapisywane tutaj. Nie wpisuj ich
+  # ręcznie: Wi-Fi Direct generuje nowe SSID i hasło przy każdej grupie, a
+  # nieaktualna para trafia do openauto.ini i telefon dostaje namiary na sieć,
+  # która już nie istnieje. Puste = użyj ssid/password powyżej do czasu, aż AP
+  # zgłosi prawdziwe wartości.
+  ssid_runtime: ''
+  password_runtime: ''
+  bssid_runtime: ''
 weather:
   api_key: 631c2365675e193584b0f986798554c1
   poll_interval_min: 15

--- a/config/bcm_config_test.yaml
+++ b/config/bcm_config_test.yaml
@@ -133,6 +133,17 @@ hardware:
     device: ''
     apn: ''
 audio:
+  # Wyjście dźwięku. "auto" = wybierz wbudowane wyjście analogowe i pomiń
+  # HDMI (na M910q HDMI prawie zawsze jest podłączone i prawie nigdy nie o to
+  # chodzi). Możesz też wpisać fragment node.name z `wpctl status --name`,
+  # np. alsa_output.pci-0000_00_1f.3.analog-stereo
+  sink: auto
+  # Sink sprzętowy trzymamy na maksimum, a użytkownik reguluje głośność na
+  # sinku EQ. Inaczej regulacja działa na jednym, a cichy jest drugi.
+  hw_volume: 100
+  # Świeży Realtek potrafi wstać z włączonym Auto-Mute i wyciszonym
+  # Headphone — wtedy nic nie zagra mimo poprawnego routingu.
+  force_unmute: true
   eq_dsp_enabled: true   # prawdziwy EQ przez PipeWire filter-chain
   eq_preset: jazz
   master_volume: 70
@@ -256,9 +267,15 @@ wifi:
     dhcp_start: 10.0.1.10
     dhcp_end: 10.0.1.50
     share_internet: true
-  ssid_runtime: DIRECT-Ea
-  password_runtime: adVEiNlq
-  bssid_runtime: 4e:82:a9:17:47:97
+  # ssid_runtime / password_runtime / bssid_runtime są USTAWIANE W LOCIE przez
+  # wifi_ap.py po utworzeniu grupy P2P-GO i zapisywane tutaj. Nie wpisuj ich
+  # ręcznie: Wi-Fi Direct generuje nowe SSID i hasło przy każdej grupie, a
+  # nieaktualna para trafia do openauto.ini i telefon dostaje namiary na sieć,
+  # która już nie istnieje. Puste = użyj ssid/password powyżej do czasu, aż AP
+  # zgłosi prawdziwe wartości.
+  ssid_runtime: ''
+  password_runtime: ''
+  bssid_runtime: ''
 weather:
   api_key: 631c2365675e193584b0f986798554c1
   poll_interval_min: 15

--- a/config/scripts/install-openauto.sh
+++ b/config/scripts/install-openauto.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# BCM v8.5 — budowa OpenAuto (autoapp) ze źródeł
+#
+# Android Auto w tym projekcie obsługuje zewnętrzny proces `autoapp` z openDsh.
+# NIE jest on instalowany przez setup-x86.sh i nie ma go w żadnym repozytorium
+# pakietów — trzeba go skompilować. Dopóki go nie ma, BCM wstaje normalnie,
+# ale ekran Android Auto pokazuje „OpenAuto not installed", a w logu leci
+# błąd z src/multimedia/openauto.py.
+#
+# Skrypt automatyzuje procedurę z docs/X86_PLATFORM_SETUP.md §11.1–11.5.
+#
+# Użycie:
+#   sudo bash config/scripts/install-openauto.sh
+#
+# Czas: 30–60 min na i5-6400T/7500T. Wymaga ~3 GB wolnego miejsca w /tmp
+# i działającego internetu (klonuje z GitHuba).
+#
+# Idempotentny: gdy binarka już jest, kończy się bez pracy (--force wymusza).
+
+set -euo pipefail
+
+FORCE=0
+[[ "${1:-}" == "--force" ]] && FORCE=1
+
+BIN=/usr/local/bin/autoapp
+WORK="${OPENAUTO_WORKDIR:-/tmp/bcm-openauto-build}"
+
+log()  { printf '\n\033[1;32m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[uwaga]\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m[błąd]\033[0m %s\n' "$*" >&2; exit 1; }
+
+[[ $EUID -eq 0 ]] || die "Uruchom przez sudo — instalacja idzie do /usr/local."
+
+if [[ -x "$BIN" && $FORCE -eq 0 ]]; then
+    log "autoapp już jest: $BIN"
+    ls -la "$BIN"
+    echo "Nic do roboty. Wymuszenie przebudowy: $0 --force"
+    exit 0
+fi
+
+command -v git >/dev/null || die "Brak gita. apt install git"
+
+# ---------------------------------------------------------------- 11.1 zależności
+log "Instaluję zależności budowania (to potrwa)"
+apt-get update
+apt-get install -y \
+    cmake build-essential git \
+    libboost-all-dev libusb-1.0-0-dev libssl-dev \
+    libprotobuf-dev protobuf-compiler \
+    qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools \
+    qtmultimedia5-dev libqt5multimedia5-plugins \
+    qtconnectivity5-dev qtdeclarative5-dev \
+    qml-module-qtquick2 qml-module-qtquick-controls2 \
+    libqt5websockets5-dev libqt5bluetooth5 \
+    libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+    gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
+    gstreamer1.0-libav \
+    libtag1-dev librtaudio-dev \
+    xvfb matchbox-window-manager
+
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+# ---------------------------------------------------------------- 11.2 aasdk
+log "Buduję aasdk"
+cd "$WORK"
+git clone --depth 1 --recurse-submodules https://github.com/openDsh/aasdk.git
+cd aasdk
+
+# OpenSSL 3.0 usunęło FIPS_mode_set(). Bez tego aasdk nie linkuje się na
+# Debianie 13. sed jest bezpieczny do powtórzenia — gdy wzorca nie ma, nic
+# nie robi.
+sed -i 's|FIPS_mode_set(0);|// FIPS_mode_set(0); // usunięte w OpenSSL 3.0|' \
+    src/Transport/SSLWrapper.cpp
+
+mkdir -p build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j"$(nproc)"
+make install
+ldconfig
+
+# ---------------------------------------------------------------- 11.3 h264bitstream
+log "Buduję h264bitstream (repozytorium nie ma Makefile'a)"
+cd "$WORK"
+git clone --depth 1 https://github.com/aizvorski/h264bitstream.git
+cd h264bitstream
+
+gcc -c -fPIC h264_stream.c h264_sei.c -I.
+ar rcs libh264bitstream.a h264_stream.o h264_sei.o
+
+cp libh264bitstream.a /usr/local/lib/
+cp h264_stream.h h264_sei.h h264_avcc.h h264_slice_data.h bs.h /usr/local/include/
+ldconfig
+
+# ---------------------------------------------------------------- 11.4 openauto
+log "Buduję openauto"
+cd "$WORK"
+git clone --depth 1 --recurse-submodules https://github.com/openDsh/openauto.git
+cd openauto
+
+# librtaudio 6.x (Debian 13) przemianowało RtAudioError na std::exception.
+sed -i 's|catch(const RtAudioError\& e)|catch(const std::exception\& e)|g' \
+    openauto/Projection/RtAudioOutput.cpp
+
+mkdir -p build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j"$(nproc)"
+make install
+ldconfig
+
+# ---------------------------------------------------------------- 11.5 weryfikacja
+log "Weryfikacja"
+[[ -x "$BIN" ]] || die "Kompilacja przeszła, ale nie ma $BIN — sprawdź wyjście 'make install' wyżej."
+ls -la "$BIN"
+
+cat <<'EOF'
+
+Gotowe. Co dalej:
+
+  sudo systemctl restart bcm-headunit
+  journalctl -u bcm-headunit --no-pager | grep -i openauto
+
+Oczekiwane w logu:  "OpenAuto found: /usr/local/bin/autoapp"
+
+Jeżeli nadal widzisz błąd o braku binarki — BCM sprawdza tylko trzy ścieżki
+(/usr/local/bin, /opt/openauto/bin, /usr/bin), więc upewnij się, że make
+install nie odłożył jej gdzie indziej.
+
+Katalog roboczy z kodem źródłowym możesz skasować:
+EOF
+echo "  rm -rf $WORK"

--- a/docs/ARDUINO_SETUP_GUIDE.md
+++ b/docs/ARDUINO_SETUP_GUIDE.md
@@ -28,9 +28,15 @@ You will end up with:
 > - All three sketches run a **2 s hardware watchdog** — a hang
 >   self-resets the board instead of requiring a power pull.
 > - **Pro Micro wiring change:** encoder push button moved **D4 → D1**
->   (on the Pro Micro D4 and A6 are the same physical pin, so the old
->   wiring conflicted with SWC Pod 2). If you wired before v8.5.2,
->   move that one wire.
+>   (on the Pro Micro D4 and A6 are the same physical pin — PD4 / ADC8 —
+>   so the old wiring conflicted with SWC Pod 2). If you wired before
+>   v8.5.2, move that one wire.
+> - **There is no pad labelled "A6" on a Pro Micro — solder to the pad
+>   marked `4`.** On the ATmega32U4 the ADC channels A6–A11 are
+>   multiplexed onto digital pins and only A0–A3 get analog silkscreen:
+>   A6=`4`, A7=`6`, A8=`8`, A9=`9`, A10=`10`. The sketch still says `A6`
+>   so `analogRead()` picks the right channel. A4 and A5 are not broken
+>   out at all.
 > - The always-on Nano's BLE scan is now **non-blocking** — the window
 >   remote and the auto-release safety cutoff keep working during the
 >   2.5 s trunk-tag scan.

--- a/docs/LISTA_ZAKUPOWA.md
+++ b/docs/LISTA_ZAKUPOWA.md
@@ -42,7 +42,7 @@ Ceny orientacyjne, rynek PL, 2025/2026. **Razem: ~483–928 PLN.**
 | 4 | **Moduł CC-CV boost** | „900 W 15 A" z wyświetlaczem albo **SZBK07** | ładowarka: CV 14,40 V, CC 8 A | 50–140 |
 | 5 | **Rozłącznik nadnapięciowy** | **XH-M603** (albo XH-M604) — ta sama rodzina co XH-M609 | blokada przeładowania: 15,30 V / powrót 14,00 V | 40–80 |
 | 5a | Przekaźnik 30 A SPDT + podstawka (drugi) | Bosch 12 V | moduł steruje cewką zamiast przenosić 8 A — §6.3 ZASILANIE | 15–25 |
-| 6 | Dioda TVS | 1.5KE33CA albo SMCJ26CA | ochrona wejścia przed load dumpem | 5–10 |
+| 6 | Dioda TVS | 1.5KE33**CA** albo SMCJ26**CA** | ochrona wejścia przed load dumpem; **„CA" = dwukierunkowa**, wersja bez „C" jest inną diodą | 5–10 |
 | 7 | Kondensator 470 µF / 35 V low-ESR × 2 | 105 °C | wejście ładowarki + wyjście XL6019 | 7–14 |
 | 8 | Dioda 1N4007 × 5 | | gaszenie cewek przekaźników | 2–5 |
 | 9 | Radiator + wentylator 40 mm | do XL6019 | w aucie obowiązkowy | 20–35 |

--- a/docs/QA_ODBIOR.md
+++ b/docs/QA_ODBIOR.md
@@ -1,0 +1,141 @@
+# Ankieta QA — odbiór wdrożenia v8.5.3
+
+Zakres: naprawa podów SWC, dźwięk przez gniazdo słuchawkowe, Android Auto,
+przycięcie zestawu modułów do czterech funkcji (pogoda, planowanie trasy,
+Android Auto, pody SWC).
+
+Każdy punkt ma **dwie kolumny wyniku**:
+
+- **[kontener]** — wypełnione podczas przygotowania zmian, na instancji BCM
+  uruchomionej bez sprzętu (`main.py --platform x86 --config
+  config/bcm_config.yaml --frontend`).
+- **[M910q]** — do wypełnienia na docelowym komputerze, po `git pull`.
+
+Legenda: **OK** · **BŁĄD** · **n/d** (nie do sprawdzenia w tym środowisku).
+
+---
+
+## A. Uruchomienie i zestaw modułów
+
+| # | Sprawdzenie | Jak | Oczekiwane | [kontener] | [M910q] |
+|---|-------------|-----|-----------|-----------|---------|
+| A1 | BCM wstaje bez wyjątku | `journalctl -u bcm-headunit -n 100` | brak traceback | **OK** | |
+| A2 | Startuje dokładnie 8 modułów | `curl -s localhost:5002/api/modules` | dashboard, audio, input, multimedia, weather, bluetooth, wifi_ap, route_planner | **OK** — dokładnie te 8 z 28 | |
+| A3 | Wyłączone moduły milczą | log | brak wpisów od obd/parking/camera/gps/alarm | **OK** | |
+| A4 | Interfejs odpowiada | `curl -o /dev/null -w '%{http_code}' localhost:5002/` | 200 | **OK** — 200, gotowe ~2 s od startu | |
+| A5 | WebSocket podaje stan | połączenie na `ws://localhost:5002/ws` | snapshot z polami stanu | **OK** — 74 pola | |
+| A6 | Start nie jest blokowany przez audio | znaczniki czasu w logu | moduł audio < 3 s | **OK** — 1 s (było 20 s przed poprawką) | |
+
+## B. Dźwięk — gniazdo słuchawkowe na panelu przednim
+
+> To był główny problem: kod **nigdy nie wybierał sinka sprzętowego**, a jedyne
+> miejsce ustawiające domyślne wyjście kierowało je na łańcuch EQ. Ręczne
+> `wpctl set-default` było cofane 0,3–3 s po starcie BCM.
+
+| # | Sprawdzenie | Jak | Oczekiwane | [kontener] | [M910q] |
+|---|-------------|-----|-----------|-----------|---------|
+| B1 | BCM wybiera wyjście analogowe, nie HDMI | `journalctl -u bcm-headunit \| grep "Hardware sink"` | `Hardware sink -> alsa_output...analog-stereo` | **n/d** — brak PipeWire | |
+| B2 | Wybór przeżywa restart usługi | restart + B1 | ta sama nazwa | **n/d** | |
+| B3 | Łańcuch EQ jest przypięty do tego sinka | `grep target.object /tmp/bcm_eq_filter.conf` | wskazuje sink z B1 | **n/d** | |
+| B4 | Sink EQ faktycznie powstaje | `wpctl status \| grep bcm_eq_sink` | widoczny | **n/d** | |
+| B5 | Gdy EQ nie wstanie — wraca sink sprzętowy | log | `ERROR ... restoring ... as default` | **n/d** | |
+| B6 | Wyjście jest odciszone | `wpctl get-volume @DEFAULT_AUDIO_SINK@` | brak `[MUTED]` | **n/d** | |
+| B7 | **Z głośnika w jacku leci dźwięk** | `speaker-test -c2 -twav -l1` przy podłączonych słuchawkach | słychać | **n/d** | |
+| B8 | Dźwięk z odtwarzania w BCM | uruchom cokolwiek na ekranie Audio | słychać | **n/d** | |
+| B9 | Regulacja głośności działa | `curl -X POST -d '{"volume":55}' .../api/audio/volume` | `{"ok":true}` i słyszalna zmiana | **OK** (API) / **n/d** (słyszalność) | |
+| B10 | Po zatrzymaniu BCM nie zostaje sierocy proces | `pgrep -af "pipewire -c /tmp/bcm_eq"` | pusto | **n/d** | |
+
+**Logika wyboru sinka przetestowana jednostkowo** (nie wymaga sprzętu):
+`pytest tests/test_audio.py -k OutputSelection` — 8 przypadków, w tym
+„HDMI nigdy nie wygrywa z analogowym", „literówka w `audio.sink` nie zostawia
+bez dźwięku", „sink EQ nie może zostać wybrany jako sprzętowy". **OK**
+
+## C. Android Auto
+
+> Przyczyna była poza kodem BCM: **binarki `autoapp` nie instaluje
+> `setup-x86.sh`** — trzeba ją skompilować ze źródeł.
+
+| # | Sprawdzenie | Jak | Oczekiwane | [kontener] | [M910q] |
+|---|-------------|-----|-----------|-----------|---------|
+| C1 | Brak binarki jest zgłaszany głośno | log przy starcie | `ERROR ... Android Auto WILL NOT WORK` + komenda naprawcza | **OK** | |
+| C2 | Binarka po kompilacji | `sudo bash config/scripts/install-openauto.sh` → `ls -la /usr/local/bin/autoapp` | plik ~5 MB | **n/d** — brak dostępu do sieci | |
+| C3 | BCM ją widzi | log | `OpenAuto found: /usr/local/bin/autoapp` | **n/d** | |
+| C4 | Konfiguracja nie zawiera martwych credentiali | `grep _runtime config/bcm_config.yaml` | puste wartości | **OK** | |
+| C5 | Credentiale P2P trafiają do `openauto.ini` | po starcie AP: `grep -i ssid openauto.ini` | SSID zgodny z `wpa_cli status` | **n/d** — brak karty WiFi | |
+| C6 | P2P-GO wstaje | `journalctl \| grep -i p2p` | grupa utworzona, kanał 149 | **n/d** | |
+| C7 | Telefon paruje się po BT | z telefonu | widoczne „Alfa156 Headunit" | **n/d** — brak `bluetoothctl` | |
+| C8 | **Android Auto pokazuje obraz** | ekran A2 | pulpit AA zamiast komunikatu | **n/d** | |
+| C9 | Ekran A2 nazywa problem po imieniu | ekran A2 bez binarki | „OpenAuto not installed" | **OK** — `aa_status=unavailable` | |
+
+## D. Pody SWC („pin pad")
+
+> Trzy niezależne przyczyny fałszywych zdarzeń: pływające wejścia analogowe,
+> przesłuch multipleksera ADC (stąd oba pody raportowały **ten sam** przycisk
+> przy tej samej wartości) i brak realnego debounce'u.
+
+| # | Sprawdzenie | Jak | Oczekiwane | [kontener] | [M910q] |
+|---|-------------|-----|-----------|-----------|---------|
+| D1 | Firmware się kompiluje | `make -C arduino rotary_encoder` | bez błędów | **OK** — sprawdzone `g++ -fsyntax-only` na atrapach API, wszystkie kombinacje `FEATURE_*` czyste przy `-Wall -Wextra`; pełna kompilacja AVR w jobie `arduino` w CI | |
+| D2 | **Płytka milczy, gdy nic nie jest wciśnięte** | monitor 115200 po wgraniu | brak linii `SWC1:`/`SWC2:` | **n/d** | |
+| D3 | Odczyt spoczynkowy jest wysoki | kalibracja pokazuje ADC | ~1023 przy rozwarciu | **n/d** | |
+| D4 | Pody nie kopiują się nawzajem | wciśnij przycisk na Pod 1 | reaguje **tylko** `SWC1:` | **n/d** | |
+| D5 | Kalibracja bez przycisków | wyślij `CAL` + Enter na port | wchodzi w tryb kalibracji | **n/d** | |
+| D6 | Kalibracja zapisuje się w EEPROM | restart płytki | `SWC: Loaded calibration from EEPROM` | **n/d** | |
+| D7 | Przyciski działają w BCM | głośność/następny utwór z kierownicy | reakcja na ekranie | **n/d** | |
+| D8 | Szum nie wyłącza BCM | obserwacja przez dłuższą jazdę | brak samoczynnych wyłączeń (SWC MODE wysyła F10 → `bcm_power_toggle`) | **n/d** | |
+
+## E. Pogoda i planowanie trasy
+
+| # | Sprawdzenie | Jak | Oczekiwane | [kontener] | [M910q] |
+|---|-------------|-----|-----------|-----------|---------|
+| E1 | Moduł pogody startuje | log | `WeatherManager started (api_key=set)` | **OK** | |
+| E2 | Pogoda działa bez GPS i bez LTE | ekran pogody | dane dla `weather.default_lat/lon` | **OK** — fallback zadziałał | |
+| E3 | Brak klucza ORS jest zgłaszany | log | `ERROR RoutePlanner: brak travel.openrouteservice_key` | **OK** | |
+| E4 | Trasa przybliżona jest oznaczona | wyznacz cel bez klucza | `approximate=true` + pasek ostrzegawczy w UI | **OK** — Kraków→Gdynia 504,5 km w linii prostej (drogą ~590 km), flaga ustawiona | |
+| E5 | **Trasa realna po wpisaniu klucza** | wpisz `travel.openrouteservice_key`, restart, wyznacz cel | `approximate=false`, dystans zgodny z drogą | **n/d** — brak klucza | |
+| E6 | Wyszukiwanie celu | ekran Trip → wpisz miasto | podpowiedzi | **n/d** — wymaga internetu | |
+
+## F. Regresja
+
+| # | Sprawdzenie | Jak | Oczekiwane | [kontener] | [M910q] |
+|---|-------------|-----|-----------|-----------|---------|
+| F1 | Testy jednostkowe | `pytest -q` | wszystkie zielone | **OK** — 447 (+25 nowych) | |
+| F2 | Lint | `ruff check .` | czysto | **OK** | |
+| F3 | Przełączniki modułów są spójne | `pytest -k ShippedModuleConfig` | zielone | **OK** | |
+| F4 | Brak osieroconych topików | analiza producent/subskrybent | żaden włączony moduł nie czeka na wyłączony | **OK** — `power.shutting_down` naprawione (publikuje `main.py`), `gps.*`/`lte.*` mają fallback na x86, `power.modules_start` dotyczy tylko wybudzenia w locie | |
+
+---
+
+## Znane pozostałości
+
+1. **`weather.api_key` jest w repozytorium** (`config/bcm_config.yaml`) — działający
+   klucz OpenWeatherMap w gicie. Nie ruszałem tego bez Twojej decyzji; proponuję
+   przenieść do zmiennej środowiskowej albo pliku poza repo i unieważnić obecny.
+2. **Regulacja jasności nie jest podpięta.** Przycisk manetki wysyła F9,
+   `action_dispatch` mapuje to na `input.brightness_cycle`, ale
+   `BrightnessController` nie jest nigdzie instancjonowany. To samo dotyczy
+   fotorezystora. Poza zakresem tej rundy.
+3. **`input.mute` nie ma subskrybenta** — przycisk MUTE na kierownicy nic nie robi
+   po stronie BCM (wysyła też klawisz Consumer, więc system to wyciszy).
+
+## Kolejność jutro na M910q
+
+```bash
+cd /opt/bcm
+git pull                                         # gałąź claude/m910q-deployment-docs-33g92j
+sudo bash config/scripts/install-openauto.sh     # 30–60 min kompilacji
+# wpisz travel.openrouteservice_key w config/bcm_config.yaml
+sudo systemctl restart bcm-headunit
+journalctl -u bcm-headunit -f
+```
+
+Firmware Pro Micro osobno — z Arduino IDE albo:
+
+```bash
+make -C arduino rotary_encoder-upload PORT=/dev/ttyACM0
+```
+
+Potem kalibracja podów: podłącz się monitorem szeregowym na 115200 i wyślij
+`CAL`. Pody muszą być **już podłączone**, a jeśli dokładasz zewnętrzne
+podciągnięcie 10 kΩ do VCC — też przed kalibracją, bo przy pasywnej drabince
+współtworzy ono dzielnik.

--- a/docs/SCHEMATY_POLACZEN.md
+++ b/docs/SCHEMATY_POLACZEN.md
@@ -256,10 +256,27 @@ optoizolatora. Tryb `INPUT_PULLUP`, stan aktywny LOW.
 | HC-SR04 ECHO ×4 | dzielnik 1 kΩ / 2 kΩ | Nano #2 **A0–A3** |
 | LDR (jasność) | 5 V → LDR → węzeł → A1; węzeł → 10 kΩ → masa | Pro Micro **A1** |
 | SWC Pod 1 | biały przewód dekodera | Pro Micro **A0** |
-| SWC Pod 2 | biały przewód dekodera | Pro Micro **A6** |
+| SWC Pod 2 | biały przewód dekodera | Pro Micro **A6** = pad opisany **`4`** |
 
 Dekoder SWC: **czerwony → ACC**, **czarny → masa**, **biały → wejście
 analogowe**.
+
+> **Na Pro Micro nie ma pola opisanego „A6" — szukasz pada `4`.** Na
+> ATmega32U4 kanały ADC **A6–A11 są zmultipleksowane z pinami cyfrowymi**
+> i na płytce drukowane są tylko numery cyfrowe. Opisane analogowo są
+> wyłącznie A0–A3.
+>
+> | W kodzie | Pad na płytce | Port AVR |
+> |----------|---------------|----------|
+> | **A6** | **`4`** | PD4 / ADC8 |
+> | A7 | `6` | PD7 / ADC10 |
+> | A8 | `8` | PB4 / ADC11 |
+> | A9 | `9` | PB5 / ADC12 |
+> | A10 | `10` | PB6 / ADC13 |
+>
+> W sketchu zostaje `#define SWC_PIN2 A6` — nazwa `A6` służy tylko temu,
+> żeby `analogRead()` wybrał właściwy kanał ADC. **A4 i A5 nie są
+> wyprowadzone** na klasycznym Pro Micro.
 
 ### 3.5 K-Line (osobny tor, bez Arduino)
 
@@ -313,13 +330,13 @@ i § 7b. Poniżej to, co dotyczy okablowania międzymodułowego.
 | D1 | przycisk enkodera → masa |
 | D5–D9 | HOME, BACK, MEDIA, VOL+, VOL− → masa |
 | D10, D14, D15, D16, A3 | panel muzyczny (PREV, NEXT, VOL+, VOL−, MUTE) |
-| A0, A6 | SWC Pod 1, Pod 2 |
+| A0, A6 | SWC Pod 1, Pod 2 — **A6 to pad opisany `4`**, patrz §3.4 |
 | A1 | LDR |
 | A2 | przycisk na manetce |
 
 > **v8.5.2:** przycisk enkodera przeniesiony z **D4 na D1** — na Pro Micro
-> D4 i A6 to ten sam fizyczny pin i kolidowało z SWC Pod 2. Przy starszym
-> okablowaniu przepnij jeden przewód.
+> D4 i A6 to ten sam fizyczny pin (PD4 / ADC8) i kolidowało z SWC Pod 2.
+> Przy starszym okablowaniu przepnij jeden przewód.
 
 ### 4.3 Nano #2 (sensor hub)
 

--- a/docs/SCHEMATY_POLACZEN.md
+++ b/docs/SCHEMATY_POLACZEN.md
@@ -567,6 +567,21 @@ zasilania rozłącznika) idą do punktu gwiazdowego — §10.4.
 > Bez niej impuls samoindukcji cewki wraca w instalację przy każdym
 > przekręceniu kluczyka.
 
+#### Kierunki diod — sprawdź przed lutowaniem
+
+| Element | Kierunek |
+|---------|----------|
+| **D5** — TVS 1.5KE33**CA** / SMCJ26**CA** | **bez znaczenia.** Sufiks „CA" = dwukierunkowa: nie ma anody ani katody, pasek na obudowie (jeśli w ogóle jest) nic nie znaczy |
+| **D1** — MBR2545CT | **blaszka = katoda (pin 2)** → na **IN+** ładowarki. Anody (piny 1 i 3, zwarte) od strony **K1 zacisk 87** |
+| **D6, D7** — 1N4007 | **pasek = katoda** → na zacisk **86** cewki, czyli po stronie plusa |
+
+> **Pułapka przy zakupie TVS.** **1.5KE33A** (bez „C") to inna dioda —
+> jednokierunkowa — i tam pasek musi iść na plus. Odwrotnie wlutowana jest
+> zwarciem ~1 V na zasilaniu i **F1 idzie natychmiast**. Rozpoznasz miernikiem
+> w trybie testu diody: **dwukierunkowa daje OL w obie strony**,
+> jednokierunkowa ~0,7 V w jedną. Uzasadnienie: §5.4
+> [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md).
+
 ### 10.2 Bank, LVD, wyłącznik
 
 | # | Skąd | Dokąd | Przewód | Zabezpieczenie |

--- a/docs/URUCHOMIENIE.md
+++ b/docs/URUCHOMIENIE.md
@@ -180,7 +180,7 @@ i bez osobnego riga.
 | `arduino/sensor_hub` | **Nano** #2 — **NOWY w v8.5.2** | Telemetria pojazdu: drzwi/maska/klapa, ręczny, zapłon, deszcz, temperatura DS18B20, opcjonalnie parkowanie/tempomat/immo/airbag |
 
 **UWAGA (v8.5.2, rotary_encoder):** przycisk enkodera przeniesiony
-z **D4 na D1** (na Pro Micro D4 i A6 to ten sam fizyczny pin —
+z **D4 na D1** (na Pro Micro D4 i A6 to ten sam fizyczny pin, PD4 —
 kolidowało z SWC Pod 2). Przy starszym okablowaniu przepnij jeden
 przewód z D4 na D1. Dodatkowo wszystkie trzy sketche mają 2-sekundowy
 watchdog sprzętowy.

--- a/docs/WDROZENIE_M910Q.md
+++ b/docs/WDROZENIE_M910Q.md
@@ -1057,6 +1057,7 @@ mimo neutralnej nazwy. Został zarchiwizowany jako
 | [`URUCHOMIENIE.md`](URUCHOMIENIE.md) | symulacja na laptopie, przełączniki modułów, Arduino w skrócie |
 | [`X86_PLATFORM_SETUP.md`](X86_PLATFORM_SETUP.md) | referencja krok-po-kroku (EN) — pamiętaj o §19 |
 | [`x86-production/index.html`](x86-production/index.html) | 12 rozdziałów z ilustracjami |
+| [`QA_ODBIOR.md`](QA_ODBIOR.md) | ankieta odbiorowa v8.5.3 — SWC, dźwięk, Android Auto, zestaw modułów |
 | [`ARDUINO_OD_ZERA.md`](ARDUINO_OD_ZERA.md) | pierwsze wgranie firmware — dla zupełnie początkujących |
 | [`ARDUINO_SETUP_GUIDE.md`](ARDUINO_SETUP_GUIDE.md) | okablowanie trzech płytek Arduino |
 | [`KLINE_SNIFFING.md`](KLINE_SNIFFING.md) | podsłuch K-Line, poznawanie PID-ów ECU |

--- a/docs/WDROZENIE_TESTOWE.md
+++ b/docs/WDROZENIE_TESTOWE.md
@@ -551,7 +551,9 @@ make -C arduino rotary_encoder-upload PORT=/dev/ttyACM0
 ```
 
 Pody SWC podłącz do **A0** (Pod 1) i **A6** (Pod 2), dekoder: czerwony → ACC,
-czarny → masa. Kalibracja: przytrzymaj HOME + BACK przy starcie płytki
+czarny → masa. **Uwaga: na płytce nie ma pola „A6" — to pad opisany `4`**
+(na 32U4 kanały A6–A11 siedzą pod numerami cyfrowymi; opisane analogowo są
+tylko A0–A3). Kalibracja: przytrzymaj HOME + BACK przy starcie płytki
 i naciskaj kolejne przyciski wg podpowiedzi na porcie szeregowym. Progi
 zapisują się w EEPROM.
 

--- a/docs/WDROZENIE_TESTOWE.md
+++ b/docs/WDROZENIE_TESTOWE.md
@@ -763,6 +763,7 @@ przejdź na `bcm_config.yaml`, gdy większość będzie już podłączona.
 | [`WDROZENIE_M910Q.md`](WDROZENIE_M910Q.md) | wdrożenie docelowe, pełne |
 | [`ZASILANIE_BUFOROWANE.md`](ZASILANIE_BUFOROWANE.md) | warianty ładowania, nastawy modułów, sprawdzenia przed załączeniem |
 | [`SCHEMATY_POLACZEN.md`](SCHEMATY_POLACZEN.md) | tabele połączeń dla wersji docelowej |
+| [`QA_ODBIOR.md`](QA_ODBIOR.md) | **ankieta odbiorowa** — co sprawdzić po wgraniu zmian |
 | [`ARDUINO_OD_ZERA.md`](ARDUINO_OD_ZERA.md) | **pierwsze wgranie firmware — dla zupełnie początkujących** |
 | [`ARDUINO_SETUP_GUIDE.md`](ARDUINO_SETUP_GUIDE.md) | Pro Micro, kalibracja SWC |
 | [`URUCHOMIENIE.md`](URUCHOMIENIE.md) | symulacja bez sprzętu, przełączniki modułów |

--- a/docs/ZASILANIE_BUFOROWANE.md
+++ b/docs/ZASILANIE_BUFOROWANE.md
@@ -681,6 +681,19 @@ Instalacja 12 V auta bywa brudna elektrycznie. Na **wejściu ładowarki**
 - sprawdź w karcie katalogowej modułu **maksymalne napięcie wejściowe** —
   jeśli to 30 V, to przy load dumpie bez TVS zostanie z niego dym.
 
+> **Sufiks „CA" znaczy dwukierunkowa — i to nie jest szczegół.** 1.5KE33**CA**
+> i SMCJ26**CA** nie mają anody ani katody; wlutuj je w dowolną stronę. Pasek
+> na obudowie, jeśli w ogóle jest nadrukowany, nic nie znaczy. Ale
+> **1.5KE33A** (bez „C") to inna dioda — **jednokierunkowa**, i tam pasek
+> (katoda) musi iść na **plus**. Odwrotnie wlutowana jest spolaryzowana
+> w kierunku przewodzenia, czyli jest zwarciem ~1 V na zasilaniu, i bezpiecznik
+> idzie natychmiast po podaniu napięcia.
+>
+> **Sprawdzenie miernikiem** (tryb testu diody): dwukierunkowa daje **OL
+> w obie strony**, jednokierunkowa ~0,7 V w jedną i OL w drugą. Próg 33 V
+> jest daleko poza zasięgiem miernika, więc w kierunku zaporowym zawsze
+> zobaczysz OL — to normalne, nie oznacza uszkodzenia.
+
 ---
 
 ## 6. Blokada przeładowania

--- a/main.py
+++ b/main.py
@@ -271,6 +271,14 @@ def main() -> None:
         nonlocal shutdown
         log.info("Received signal %d, shutting down...", signum)
         shutdown = True
+        # Tell every module we are going down.
+        #
+        # Several of them already subscribe to this (openauto stops autoapp,
+        # audio kills the EQ filter-chain and hands the sink back), but until
+        # now the only publisher was PowerManager — so with modules.power off
+        # the topic never fired and those cleanups never ran. Orphaned autoapp
+        # and `pipewire -c` processes came from exactly this.
+        event_bus.publish("power.shutting_down", True)
         # Stop WiFi AP
         if wifi_ap is not None:
             wifi_ap.stop()

--- a/schematics/gen_test_schematics.py
+++ b/schematics/gen_test_schematics.py
@@ -315,7 +315,7 @@ class Sheet:
 # ======================================================================
 #  ARKUSZ 1 — ZASILANIE
 # ======================================================================
-s = Sheet(1620, 1870,
+s = Sheet(1620, 1946,
           "BCM v8.5 — arkusz 1/2: ZASILANIE (wariant testowo-rozwojowy, M910q)",
           "Każdy element osobno. Cewki i styki przekaźników rozdzielone — "
           "K1 i K2 to po jednym przekaźniku Bosch, narysowanym w dwóch "
@@ -342,11 +342,12 @@ s.dot(420, RAIL)
 yy = s.tvs_v(258, RAIL + 22, "D5", "1.5KE33CA")
 s.w(258, yy, 258, GA)
 s.star_gnd(258, GA)
-s.txt(258, GA + 62, "TVS — load dump", "vc")
+s.txt(258, GA + 44, "TVS — obcina load dump", "vc")
+s.txt(258, GA + 60, "CA = dwukierunkowa, montaż dowolnie", "vc")
 yy = s.cap_v(420, RAIL + 22, "C1", "470 µF / 35 V", pol=True, side=1)
 s.w(420, yy, 420, GA)
 s.star_gnd(420, GA)
-s.txt(420, GA + 62, "bufor wejścia", "vc")
+s.txt(430, GA + 44, "bufor wejścia", "vc")
 
 # --- styk K1
 s.w(430, RAIL, 470, RAIL)
@@ -566,6 +567,16 @@ s.txt(80, 1834, "Wszystkie symbole masy na tym arkuszu to JEDEN punkt: "
 s.box(1090, 1790, 470, 56, "note")
 s.txt(1110, 1814, "Numery w ramkach", "nh")
 s.txt(1110, 1834, "= numery przewodów z tabel §10 docs/SCHEMATY_POLACZEN.md", "nt")
+
+s.box(60, 1862, 1500, 74, "note")
+s.txt(80, 1886, "KIERUNKI DIOD — sprawdź przed lutowaniem", "nh")
+s.txt(80, 1906, "D5 (1.5KE33CA lub SMCJ26CA): sufiks CA = dwukierunkowa. "
+                "Nie ma anody ani katody, wlutuj w dowolną stronę. Uwaga: "
+                "1.5KE33A (bez C) to inna dioda — jednokierunkowa,", "nt")
+s.txt(80, 1926, "tam pasek/katoda idzie na PLUS. Sprawdź miernikiem w trybie "
+                "diody: dwukierunkowa daje OL w obie strony.   ·   "
+                "D1 MBR2545CT: blaszka = katoda → IN+ ładowarki.   ·   "
+                "D6 i D7 (1N4007): pasek = katoda → zacisk 86 cewki.", "nt")
 
 s.save("schematics/schematic_test_power.svg")
 

--- a/schematics/schematic_test_power.svg
+++ b/schematics/schematic_test_power.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1620" height="1870" viewBox="0 0 1620 1870" font-family="DejaVu Sans, Verdana, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" width="1620" height="1946" viewBox="0 0 1620 1946" font-family="DejaVu Sans, Verdana, sans-serif">
 <title>BCM v8.5 — arkusz 1/2: ZASILANIE (wariant testowo-rozwojowy, M910q)</title>
 <style>
  .bg{fill:#ffffff}
@@ -46,7 +46,7 @@
  .ldr{stroke:#7d8c99;stroke-width:1.3;fill:none}
  .ldrf{fill:#7d8c99;stroke:none}
 </style>
-<rect class="bg" x="0" y="0" width="1620" height="1870"/>
+<rect class="bg" x="0" y="0" width="1620" height="1946"/>
 <text class="ttl" x="40" y="44">BCM v8.5 — arkusz 1/2: ZASILANIE (wariant testowo-rozwojowy, M910q)</text>
 <text class="sub" x="40" y="68">Każdy element osobno. Cewki i styki przekaźników rozdzielone — K1 i K2 to po jednym przekaźniku Bosch, narysowanym w dwóch miejscach. Moduły kupne jako prostokąty z zaciskami.</text>
 <rect class="sectb" x="40" y="98" width="26" height="26"/>
@@ -96,7 +96,8 @@
 <line class="wg" x1="240" y1="732" x2="276" y2="732"/>
 <line class="wg" x1="247" y1="739" x2="269" y2="739"/>
 <line class="wg" x1="254" y1="746" x2="262" y2="746"/>
-<text class="vc" x="258" y="782">TVS — load dump</text>
+<text class="vc" x="258" y="764">TVS — obcina load dump</text>
+<text class="vc" x="258" y="780">CA = dwukierunkowa, montaż dowolnie</text>
 <line class="w" x1="420" y1="262" x2="420" y2="282"/>
 <line class="sym" x1="403" y1="282" x2="437" y2="282"/>
 <path class="sym" d="M 403 296 Q 420 286 437 296"/>
@@ -109,7 +110,7 @@
 <line class="wg" x1="402" y1="732" x2="438" y2="732"/>
 <line class="wg" x1="409" y1="739" x2="431" y2="739"/>
 <line class="wg" x1="416" y1="746" x2="424" y2="746"/>
-<text class="vc" x="420" y="782">bufor wejścia</text>
+<text class="vc" x="430" y="764">bufor wejścia</text>
 <line class="w" x1="430" y1="240" x2="470" y2="240"/>
 <rect class="wnb" x="425" y="215" width="24" height="18"/>
 <text class="wn" x="437" y="229">3</text>
@@ -592,4 +593,8 @@
 <rect class="note" x="1090" y="1790" width="470" height="56"/>
 <text class="nh" x="1110" y="1814">Numery w ramkach</text>
 <text class="nt" x="1110" y="1834">= numery przewodów z tabel §10 docs/SCHEMATY_POLACZEN.md</text>
+<rect class="note" x="60" y="1862" width="1500" height="74"/>
+<text class="nh" x="80" y="1886">KIERUNKI DIOD — sprawdź przed lutowaniem</text>
+<text class="nt" x="80" y="1906">D5 (1.5KE33CA lub SMCJ26CA): sufiks CA = dwukierunkowa. Nie ma anody ani katody, wlutuj w dowolną stronę. Uwaga: 1.5KE33A (bez C) to inna dioda — jednokierunkowa,</text>
+<text class="nt" x="80" y="1926">tam pasek/katoda idzie na PLUS. Sprawdź miernikiem w trybie diody: dwukierunkowa daje OL w obie strony.   ·   D1 MBR2545CT: blaszka = katoda → IN+ ładowarki.   ·   D6 i D7 (1N4007): pasek = katoda → zacisk 86 cewki.</text>
 </svg>

--- a/src/audio/pipewire_ctrl.py
+++ b/src/audio/pipewire_ctrl.py
@@ -1,19 +1,39 @@
-"""PipeWire control interface — route sources to DAC, manage EQ profiles.
+"""PipeWire control interface — pick the output, unmute it, manage EQ profiles.
 
-Uses pw-cli / pw-link / wpctl command-line tools to control PipeWire.
-On x86: uses default sound card (laptop/desktop speakers).
-On OPi: targets USB DAC (ES9038Q2M) as default sink.
+Uses pw-dump / pw-cli / wpctl command-line tools to control PipeWire. There is
+no per-platform branching here: the same code runs on x86 and OPi, and which
+device the sound comes out of is decided by ``audio.sink`` in the config.
 
-Audio hardware chain:
+Startup order matters and is deliberate (v8.5.3):
+
+  1. pick a hardware sink   — ``audio.sink: auto`` prefers the analog output
+                              and explicitly avoids HDMI
+  2. make it the default, unmute it, set ``audio.hw_volume``
+  3. only then bring up the EQ filter-chain, with its playback side **pinned**
+     to that sink via ``target.object``
+  4. make the EQ sink the default so apps land on it
+
+Before v8.5.3 step 1-2 did not exist and step 3 had no pin. The only place
+that ever wrote a default sink pointed it at the EQ chain, so a manual
+``wpctl set-default <analog>`` was undone 0.3-3 s after BCM started, and on a
+machine with HDMI connected the chain would happily play into HDMI. Nothing
+ever unmuted anything, so a freshly installed Realtek with Auto-Mute Mode on
+stayed silent no matter what. That is what "no sound on the front jack" was.
+
+Audio hardware chain (target build):
   ES9038Q2M USB DAC → RCA → off-the-shelf 4-channel car amplifier → 4x 4 ohm speakers
 
 The amplifier is a bought unit powered straight from the starter battery on
 its own fused branch, not from the buffered bus — see
 docs/ZASILANIE_BUFOROWANE.md and schematics/audio_system.svg. Nothing here
-depends on which amplifier it is; PipeWire only ever sees the USB DAC.
+depends on which amplifier it is.
 """
 
+import json
+import re
 import subprocess
+import threading
+import time
 from typing import Any, Optional
 
 from src.core.event_bus import EventBus
@@ -38,13 +58,34 @@ EQ_FREQUENCIES = [31, 62, 125, 250, 500, 1000, 2000, 4000, 8000, 16000]
 EQ_FILTER_CONF = "/tmp/bcm_eq_filter.conf"
 EQ_SINK_NAME = "bcm_eq_sink"
 
+# Sink picking. "auto" walks these in order and takes the first match.
+# HDMI is excluded outright — on the M910q it is almost always present and
+# almost never what you want to hear the car through.
+_SINK_PREFER = (
+    r"alsa_output\..*analog-stereo",   # wbudowane wyjście analogowe (Realtek)
+    r"alsa_output\..*\.analog",
+    r"alsa_output\.usb-.*",            # DAC USB, gdy kiedyś wróci
+    r"alsa_output\..*",
+)
+_SINK_EXCLUDE = re.compile(r"hdmi|displayport|iec958", re.I)
 
-def _build_filter_chain_conf(gains: list[float]) -> str:
+# Ile razy i jak często dopytywać o PipeWire w tle, gdy nie było go przy
+# starcie modułu. 60 × 2 s ≈ 2 minuty — z zapasem na wolny autologin.
+PW_BACKGROUND_ATTEMPTS = 60
+PW_BACKGROUND_DELAY = 2.0
+
+
+def _build_filter_chain_conf(gains: list[float],
+                             target_sink: Optional[str] = None) -> str:
     """Render a PipeWire filter-chain config for a 10-band biquad EQ.
 
     The chain is: lowshelf(31 Hz) -> 8x peaking -> highshelf(16 kHz),
-    exposed as an Audio/Sink named bcm_eq_sink. Audio played into that
-    sink comes out equalized on the (real) default sink.
+    exposed as an Audio/Sink named bcm_eq_sink.
+
+    ``target_sink`` pins the chain's playback side to a specific hardware
+    sink. Without it the chain follows whatever WirePlumber currently calls
+    default — which, once we then make the EQ sink itself the default, is a
+    good way to end up feeding HDMI.
     """
     nodes = []
     links = []
@@ -65,9 +106,26 @@ def _build_filter_chain_conf(gains: list[float]) -> str:
             )
     nodes_s = "\n".join(nodes)
     links_s = "\n".join(links)
+    # Pin the playback side to a named sink when we know which one we want.
+    target_s = (f'\n        target.object = "{target_sink}"'
+                if target_sink else "")
     return f"""# BCM v8.5 — generated 10-band EQ (do not edit; regenerated on preset change)
 context.properties = {{ log.level = 0 }}
+
+# Bez tej mapy filter-chain nie znajdzie audioconvert i sink w ogóle się nie
+# pojawi — a wtedy kod ma tylko wpis w logu i cichy komputer.
+context.spa-libs = {{
+  audio.convert.* = audioconvert/libspa-audioconvert
+  support.*       = support/libspa-support
+}}
+
 context.modules = [
+  {{ name = libpipewire-module-rt
+    args = {{ nice.level = -11 }}
+    flags = [ ifexists nofail ] }}
+  {{ name = libpipewire-module-protocol-native }}
+  {{ name = libpipewire-module-client-node }}
+  {{ name = libpipewire-module-adapter }}
   {{ name = libpipewire-module-filter-chain
     args = {{
       node.description = "BCM 10-band EQ"
@@ -88,7 +146,7 @@ context.modules = [
       }}
       playback.props = {{
         node.name = "{EQ_SINK_NAME}_output"
-        node.passive = true
+        node.passive = true{target_s}
       }}
     }}
   }}
@@ -152,29 +210,57 @@ class PipeWireController:
         self._fader: int = config.get("audio.fader", 0)
         self._balance: int = config.get("audio.balance", 0)
 
+        # The hardware sink we decided to play through. Everything else hangs
+        # off this: the EQ chain is pinned to it, unmute targets it, and if the
+        # EQ fails to come up we fall back to it.
+        self._hw_sink: Optional[str] = None
+        self._hw_sink_id: Optional[str] = None
+
         # Real EQ DSP: a `pipewire -c <generated conf>` child process
         # hosting a filter-chain sink. None while PW unavailable or
         # audio.eq_dsp_enabled=false.
         self._eq_proc: Optional[subprocess.Popen] = None
         self._eq_dsp_enabled: bool = bool(config.get("audio.eq_dsp_enabled", True))
+        self._stopping = False
 
-        # Check if PipeWire is running
         self._check_availability()
 
-        # Bring the EQ up with the configured preset at start
-        if self._available and self._eq_dsp_enabled:
-            self.apply_eq_preset(self._current_eq)
+    # ------------------------------------------------------------------ #
+    # Availability                                                        #
+    # ------------------------------------------------------------------ #
 
-    def _check_availability(self) -> None:
-        """Check if PipeWire is available and running."""
-        rc, out, _ = _run_cmd(["wpctl", "status"])
-        if rc == 0:
-            self._available = True
+    def _check_availability(self) -> bool:
+        """Probe PipeWire once. Returns True when wpctl answers."""
+        rc, _, _ = _run_cmd(["wpctl", "status"])
+        self._available = rc == 0
+        if self._available:
             log.info("PipeWire detected and running")
             self._detect_default_sink()
-        else:
-            self._available = False
-            log.warning("PipeWire not available — audio control will be simulated")
+        return self._available
+
+    def wait_for_pipewire(self, attempts: int = 3, delay: float = 0.5) -> bool:
+        """Retry the availability probe a few times, synchronously.
+
+        bcm-headunit starts as root from systemd, while PipeWire lives in the
+        user session. The unit does not wait for that session, so on a cold
+        boot the very first probe can lose the race. Before v8.5.3 that single
+        failed probe was final for the life of the process and every wpctl call
+        silently became a no-op — the log line "audio control will be
+        simulated" was the only hint.
+
+        Kept short on purpose: this runs inside module startup, and a head unit
+        that takes an extra 20 s to show a screen is worse than one whose sound
+        arrives a few seconds late. The long wait lives in the background
+        retry started by start_output().
+        """
+        if self._available:
+            return True
+        for i in range(max(1, attempts)):
+            if self._check_availability():
+                return True
+            if i < attempts - 1:
+                time.sleep(delay)
+        return False
 
     def _detect_default_sink(self) -> None:
         """Detect the default audio sink."""
@@ -188,6 +274,191 @@ class PipeWireController:
             log.info("Default sink: %s", self._default_sink)
         else:
             log.warning("Could not detect default audio sink")
+
+    # ------------------------------------------------------------------ #
+    # Sink discovery and selection                                        #
+    # ------------------------------------------------------------------ #
+
+    def list_sink_nodes(self) -> list[dict[str, str]]:
+        """Enumerate Audio/Sink nodes as [{id, name, description}].
+
+        pw-dump gives structured JSON, which beats scraping `wpctl status`:
+        that output is localised, changes between versions, and only shows
+        node.name when --name is supported. wpctl remains the fallback.
+        """
+        rc, out, _ = _run_cmd(["pw-dump"], timeout=8.0)
+        if rc == 0 and out.strip():
+            try:
+                sinks = []
+                for obj in json.loads(out):
+                    info = obj.get("info") or {}
+                    props = info.get("props") or {}
+                    if props.get("media.class") != "Audio/Sink":
+                        continue
+                    name = props.get("node.name")
+                    if not name:
+                        continue
+                    sinks.append({
+                        "id": str(obj.get("id", "")),
+                        "name": name,
+                        "description": props.get("node.description", ""),
+                    })
+                if sinks:
+                    return sinks
+            except (ValueError, TypeError) as e:
+                log.debug("pw-dump parse failed (%s) — falling back to wpctl", e)
+
+        # Fallback: `wpctl status --name` lists "   42. node.name  [vol: ...]"
+        rc, out, _ = _run_cmd(["wpctl", "status", "--name"])
+        if rc != 0:
+            return []
+        sinks, in_sinks = [], False
+        for line in out.splitlines():
+            stripped = line.strip(" │├─└*")
+            if "Sinks:" in line:
+                in_sinks = True
+                continue
+            if in_sinks and (":" in line and "Sinks:" not in line
+                             and not stripped[:1].isdigit()):
+                break
+            m = re.match(r"(\d+)\.\s+(\S+)", stripped)
+            if in_sinks and m:
+                sinks.append({"id": m.group(1), "name": m.group(2),
+                              "description": ""})
+        return sinks
+
+    def pick_hardware_sink(self) -> Optional[dict[str, str]]:
+        """Choose the sink to play through, honouring ``audio.sink``.
+
+        ``auto`` prefers the built-in analog output and skips HDMI outright.
+        Any other value is matched against node.name as a substring, so a
+        partial name from `wpctl status --name` is enough.
+        """
+        wanted = str(self._config.get("audio.sink", "auto") or "auto").strip()
+        sinks = [s for s in self.list_sink_nodes()
+                 if s["name"] != EQ_SINK_NAME]
+        if not sinks:
+            log.error("No hardware audio sinks found — is the codec driver loaded?")
+            return None
+
+        if wanted.lower() != "auto":
+            for s in sinks:
+                if wanted in s["name"]:
+                    return s
+            log.error(
+                "audio.sink=%r matches none of the available sinks: %s — "
+                "falling back to auto-detection",
+                wanted, ", ".join(s["name"] for s in sinks),
+            )
+
+        usable = [s for s in sinks if not _SINK_EXCLUDE.search(s["name"])]
+        for pattern in _SINK_PREFER:
+            for s in usable:
+                if re.match(pattern, s["name"]):
+                    return s
+        if usable:
+            return usable[0]
+
+        log.warning("Only HDMI-like sinks available — using %s", sinks[0]["name"])
+        return sinks[0]
+
+    def _amixer_unmute(self) -> None:
+        """Best-effort ALSA-level unmute.
+
+        PipeWire's set-mute does not reach every ALSA control. A fresh Realtek
+        typically ships with Auto-Mute Mode on and Headphone muted, which
+        keeps the jack silent no matter what the PipeWire volume says.
+        Failures here are expected on non-ALSA setups and stay at debug level.
+        """
+        for ctl in ("Master", "Headphone", "Speaker", "PCM", "Front"):
+            rc, _, err = _run_cmd(["amixer", "-q", "sset", ctl, "unmute"])
+            if rc != 0:
+                log.debug("amixer sset %s unmute: %s", ctl, err.strip())
+        _run_cmd(["amixer", "-q", "sset", "Auto-Mute Mode", "Disabled"])
+
+    def prepare_output(self) -> Optional[str]:
+        """Pick, select, unmute and level the hardware sink. Returns its name.
+
+        This is the step that never existed before v8.5.3, which is why the
+        front-panel jack stayed silent: nothing chose the analog output and
+        nothing ever unmuted anything.
+        """
+        if not self._available:
+            return None
+
+        sink = self.pick_hardware_sink()
+        if sink is None:
+            return None
+
+        self._hw_sink = sink["name"]
+        self._hw_sink_id = sink["id"] or None
+        target = self._hw_sink_id or self._hw_sink
+
+        if self._hw_sink_id:
+            rc, _, err = _run_cmd(["wpctl", "set-default", self._hw_sink_id])
+            if rc != 0:
+                log.error("Could not select sink %s: %s", self._hw_sink, err.strip())
+            else:
+                log.info("Hardware sink -> %s", self._hw_sink)
+
+        if self._config.get("audio.force_unmute", True):
+            _run_cmd(["wpctl", "set-mute", str(target), "0"])
+            self._amixer_unmute()
+
+        hw_vol = int(self._config.get("audio.hw_volume", 100))
+        hw_vol = max(0, min(100, hw_vol))
+        _run_cmd(["wpctl", "set-volume", str(target), f"{hw_vol / 100.0:.2f}"])
+
+        self._default_sink = self._hw_sink
+        self._event_bus.publish("audio.output_sink", self._hw_sink)
+        return self._hw_sink
+
+    def start_output(self) -> None:
+        """Select the output and bring the EQ up; never blocks for long.
+
+        If PipeWire is not up yet we hand the job to a background thread and
+        let the rest of BCM start. The session usually appears within seconds
+        of the graphical login, and audio then configures itself without a
+        service restart.
+        """
+        if self.wait_for_pipewire():
+            self._configure_output()
+            return
+
+        log.warning(
+            "PipeWire not up yet — continuing startup and retrying in the "
+            "background (audio stays simulated until it appears)"
+        )
+
+        def _late():
+            for _ in range(PW_BACKGROUND_ATTEMPTS):
+                time.sleep(PW_BACKGROUND_DELAY)
+                if self._stopping:
+                    return
+                if self._check_availability():
+                    log.info("PipeWire appeared — configuring audio output now")
+                    self._configure_output()
+                    return
+            log.error(
+                "PipeWire never appeared (%d attempts over ~%d s) — there will "
+                "be no sound. Check XDG_RUNTIME_DIR for the BCM process and "
+                "whether the user session with pipewire-0 is running.",
+                PW_BACKGROUND_ATTEMPTS,
+                int(PW_BACKGROUND_ATTEMPTS * PW_BACKGROUND_DELAY),
+            )
+
+        threading.Thread(target=_late, daemon=True,
+                         name="pipewire-wait").start()
+
+    def _configure_output(self) -> None:
+        """Pick the sink and start the EQ. Safe to call once PipeWire is up."""
+        self.prepare_output()
+        if self._eq_dsp_enabled:
+            self.apply_eq_preset(self._current_eq)
+
+    @property
+    def hardware_sink(self) -> Optional[str]:
+        return self._hw_sink
 
     @property
     def available(self) -> bool:
@@ -330,9 +601,15 @@ class PipeWireController:
         """
         if not (self._available and self._eq_dsp_enabled):
             return
+
+        # Make sure we know where the sound is supposed to come out before
+        # building a chain that has to point at it.
+        if self._hw_sink is None:
+            self.prepare_output()
+
         try:
             with open(EQ_FILTER_CONF, "w") as f:
-                f.write(_build_filter_chain_conf(gains))
+                f.write(_build_filter_chain_conf(gains, self._hw_sink))
         except OSError as e:
             log.error("EQ: cannot write filter config: %s", e)
             return
@@ -344,27 +621,37 @@ class PipeWireController:
                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
                 env=_pipewire_env(),
             )
-            log.info("EQ filter-chain started (pid=%d, sink=%s)",
-                     self._eq_proc.pid, EQ_SINK_NAME)
+            log.info("EQ filter-chain started (pid=%d, sink=%s, target=%s)",
+                     self._eq_proc.pid, EQ_SINK_NAME, self._hw_sink or "default")
         except FileNotFoundError:
             log.warning("EQ: pipewire binary not found — DSP disabled")
             self._eq_proc = None
             return
 
-        # Route everything through the EQ: make bcm_eq_sink the default
-        # sink once it appears (the filter-chain's playback side follows
-        # the real hardware sink automatically).
+        # Route everything through the EQ by making bcm_eq_sink the default,
+        # but only once it actually exists. If it never shows up we put the
+        # hardware sink back — leaving the default pointing at a chain that
+        # failed to start is how you get a machine that is simply silent.
         def _route():
-            import time as _time
             for _ in range(10):
-                _time.sleep(0.3)
-                if self._set_default_sink_by_name(EQ_SINK_NAME):
-                    log.info("Default sink -> %s (EQ in path)", EQ_SINK_NAME)
+                time.sleep(0.3)
+                if self._stopping:
                     return
-            log.warning("EQ sink did not appear — audio not equalized")
+                if self._set_default_sink_by_name(EQ_SINK_NAME):
+                    log.info("Default sink -> %s (EQ in path, out via %s)",
+                             EQ_SINK_NAME, self._hw_sink or "default")
+                    return
+            log.error(
+                "EQ sink %s did not appear — restoring %s as default so there "
+                "is still sound. Check `pipewire -c %s` by hand.",
+                EQ_SINK_NAME, self._hw_sink or "the hardware sink",
+                EQ_FILTER_CONF,
+            )
+            self._stop_eq_dsp()
+            if self._hw_sink_id:
+                _run_cmd(["wpctl", "set-default", self._hw_sink_id])
 
-        import threading as _threading
-        _threading.Thread(target=_route, daemon=True).start()
+        threading.Thread(target=_route, daemon=True).start()
 
     def _set_default_sink_by_name(self, name: str) -> bool:
         """Find a sink id by node name in `wpctl status` and set default."""
@@ -397,8 +684,15 @@ class PipeWireController:
         self._eq_proc = None
 
     def stop(self) -> None:
-        """Cleanup — stop the EQ DSP child process."""
+        """Cleanup — stop the EQ DSP child and hand the output back.
+
+        Without this the `pipewire -c` child outlives BCM and WirePlumber is
+        left with a default sink that points at a node about to disappear.
+        """
+        self._stopping = True
         self._stop_eq_dsp()
+        if self._available and self._hw_sink_id:
+            _run_cmd(["wpctl", "set-default", self._hw_sink_id])
 
     def set_fader(self, fader: int) -> bool:
         """Set front/rear balance (-10=rear to +10=front). Requires multi-channel DAC."""

--- a/src/audio/volume.py
+++ b/src/audio/volume.py
@@ -89,8 +89,19 @@ def start_audio(config: Any, event_bus: EventBus, hal: Any = None,
 
     Initializes PipeWire controller, source manager, ducking, and volume.
     """
-    # PipeWire controller
+    # PipeWire controller.
+    #
+    # Order below is deliberate. start_output() waits for PipeWire, picks the
+    # hardware sink, unmutes it and only then brings the EQ chain up pinned to
+    # it. It has to run BEFORE VolumeController, which sets the initial level
+    # on whatever is default at that moment — previously the EQ routing thread
+    # was still racing and the level often landed on the wrong node.
+    #
+    # The constructor no longer applies the preset by itself; before v8.5.3 it
+    # did, and start_audio() applied it a second time, so two routing threads
+    # fought over the default sink.
     pw = PipeWireController(config, event_bus)
+    pw.start_output()
 
     # Source manager
     source_mgr = SourceManager(event_bus)
@@ -102,9 +113,9 @@ def start_audio(config: Any, event_bus: EventBus, hal: Any = None,
     initial_vol = config.get("audio.master_volume", 70)
     volume = VolumeController(pw, event_bus, initial_volume=initial_vol)
 
-    # Apply initial EQ preset
-    eq_preset = config.get("audio.eq_preset", "flat")
-    pw.apply_eq_preset(eq_preset)
+    # Nothing in the startup path used to unmute, so a card that came up muted
+    # (a fresh Realtek usually does) stayed muted forever.
+    volume.unmute()
 
     # Spectrum analyzer
     spectrum_enabled = config.get("audio.spectrum_enabled", True)
@@ -113,8 +124,17 @@ def start_audio(config: Any, event_bus: EventBus, hal: Any = None,
         spectrum = SpectrumAnalyzer(event_bus)
         spectrum.start()
 
-    log.info("Audio module running (PipeWire %s)",
-             "active" if pw.available else "simulated")
+    # Hand the output back and kill the filter-chain child on the way out.
+    def _on_shutdown(topic: str, value: Any, timestamp: float) -> None:
+        pw.stop()
+        if spectrum is not None:
+            spectrum.stop()
+
+    event_bus.subscribe("power.shutting_down", _on_shutdown)
+
+    log.info("Audio module running (PipeWire %s, output=%s)",
+             "active" if pw.available else "simulated",
+             pw.hardware_sink or "unknown")
 
     # Store references for cleanup
     event_bus.publish("audio._internals", {

--- a/src/dashboard/trip_computer.py
+++ b/src/dashboard/trip_computer.py
@@ -61,6 +61,7 @@ class TripComputer:
         self.route_waypoints: list = []
         self.route_weather_points: list = []
         self.route_incidents: list = []
+        self.route_approximate: bool = False
         self.plan_error: Optional[str] = None
         self.plan_computed_at: float = 0.0
 
@@ -204,6 +205,9 @@ class TripComputer:
                 self.route_waypoints = list(result.get("waypoints", []))
                 self.route_weather_points = list(result.get("weather_points", []))
                 self.route_incidents = list(result.get("incidents", []))
+                # True gdy planer nie miał klucza ORS i policzył linię prostą.
+                # UI musi to nazwać, bo sama liczba wygląda jak realna trasa.
+                self.route_approximate = bool(result.get("approximate", False))
                 self.plan_computed_at = float(result.get("computed_at", time.time()))
 
             if self._bus:
@@ -226,6 +230,7 @@ class TripComputer:
             self.route_waypoints = []
             self.route_weather_points = []
             self.route_incidents = []
+            self.route_approximate = False
             self.plan_error = None
             self.plan_computed_at = 0.0
         log.info("Travel plan cleared")
@@ -248,6 +253,7 @@ class TripComputer:
                 "waypoints": self.route_waypoints,
                 "weather_points": self.route_weather_points,
                 "incidents": self.route_incidents,
+                "approximate": self.route_approximate,
                 "error": self.plan_error,
                 "computed_at": self.plan_computed_at,
             }

--- a/src/dashboard/web/js/screens/trip.js
+++ b/src/dashboard/web/js/screens/trip.js
@@ -118,6 +118,20 @@ App.registerScreen("a3", (() => {
                </span>`
             : "";
 
+        // Bez klucza OpenRouteService planer zwraca odległość w linii prostej.
+        // Liczba wygląda identycznie jak realna trasa, więc bez tego paska
+        // wyglądałoby to na działającą funkcję, która po prostu kłamie.
+        const approxNotice = (!planning && plan.approximate)
+            ? `<div style="display:flex;align-items:center;gap:6px;background:rgba(120,53,15,0.35);
+                        border:1px solid #b45309;border-radius:6px;padding:6px 8px;">
+                   <span class="material-symbols-outlined text-amber-400" style="font-size:14px;">warning</span>
+                   <span style="font-size:10px;color:#fcd34d;line-height:1.3;">
+                       Trasa przybliżona — odległość w linii prostej.
+                       Wpisz travel.openrouteservice_key w config/bcm_config.yaml.
+                   </span>
+               </div>`
+            : "";
+
         const overlay = document.createElement("div");
         overlay.className = "travel-plan-overlay";
         overlay.style.cssText = [
@@ -142,6 +156,7 @@ App.registerScreen("a3", (() => {
                     Travel Plan
                 </h2>
             </div>
+            ${approxNotice}
             <div class="tp-search-wrap" style="position:relative;">
                 <input class="tp-search" type="text" placeholder="Destination (e.g. Gdynia)"
                        value="${name.replace(/"/g, '&quot;')}"

--- a/src/multimedia/openauto.py
+++ b/src/multimedia/openauto.py
@@ -226,17 +226,51 @@ class OpenAutoController:
         self._monitor_thread: Optional[threading.Thread] = None
         self._log_thread: Optional[threading.Thread] = None
 
+        self._project_dir = os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.abspath(__file__))))
+
         if self._binary:
             log.info("OpenAuto found: %s", self._binary)
             # Create config in project root (autoapp reads from cwd)
-            project_dir = os.path.dirname(os.path.dirname(
-                os.path.dirname(os.path.abspath(__file__))))
-            _create_openauto_config(project_dir, app_config=config)
+            _create_openauto_config(self._project_dir, app_config=config)
         else:
-            log.info("OpenAuto not installed — AA will be unavailable")
+            # This is THE reason Android Auto does not come up on a fresh
+            # install: autoapp is not part of setup-x86.sh, it has to be built
+            # from source. It used to be logged at info level next to a dozen
+            # other lines and the module still reported itself as started, so
+            # it read like everything was fine.
+            log.error(
+                "Android Auto WILL NOT WORK: autoapp binary not found in %s. "
+                "It is not installed by setup-x86.sh — build it with "
+                "`sudo bash config/scripts/install-openauto.sh` (see "
+                "docs/X86_PLATFORM_SETUP.md §11).",
+                ", ".join(OPENAUTO_PATHS),
+            )
 
         # Subscribe to lifecycle events
         self._event_bus.subscribe("power.shutting_down", self._on_shutdown)
+
+        # Wi-Fi Direct GOs invent their own SSID and passphrase at group
+        # creation time, so the values that matter are only known once the AP
+        # is actually up. Nothing listened for them before, which meant
+        # openauto.ini kept whatever was in the YAML — and the YAML held a
+        # stale DIRECT-xx/password pair from some earlier run. The phone was
+        # handed credentials for a network that no longer existed.
+        self._event_bus.subscribe("wifi.ap_credentials", self._on_ap_credentials)
+
+    def _on_ap_credentials(self, topic: str, value: Any, timestamp: float) -> None:
+        """Regenerate openauto.ini when the AP publishes its real credentials."""
+        if not self._binary:
+            return
+        try:
+            _create_openauto_config(self._project_dir, app_config=self._config)
+            ssid = ""
+            if isinstance(value, dict):
+                ssid = value.get("ssid", "")
+            log.info("openauto.ini refreshed with live AP credentials (ssid=%s)",
+                     ssid or "?")
+        except OSError as e:
+            log.error("Could not refresh openauto.ini: %s", e)
 
     @property
     def available(self) -> bool:

--- a/src/multimedia/wifi_ap.py
+++ b/src/multimedia/wifi_ap.py
@@ -128,6 +128,11 @@ class WiFiAPManager:
         self._net_hostapd_proc: Optional[subprocess.Popen] = None
         self._net_dnsmasq_proc: Optional[subprocess.Popen] = None
 
+        # This used to sit after a `return` inside _alfa_net_enabled(), so it
+        # was dead code and _on_shutdown never ran — hostapd, dnsmasq and our
+        # own wpa_supplicant were left behind on every shutdown.
+        self._event_bus.subscribe("power.shutting_down", self._on_shutdown)
+
     def _alfa_net_enabled(self) -> bool:
         """Whether the secondary ALFA-NET access point should run.
 
@@ -139,9 +144,6 @@ class WiFiAPManager:
         from src.core import modules_catalog
         state = modules_catalog.is_enabled(self._config, "wifi_hotspot")
         return bool(state)
-
-        # Subscribe to shutdown
-        self._event_bus.subscribe("power.shutting_down", self._on_shutdown)
 
     @property
     def running(self) -> bool:

--- a/src/trip/route_planner.py
+++ b/src/trip/route_planner.py
@@ -156,11 +156,22 @@ class RoutePlanner:
         self._ors_key = str(config.get("travel.openrouteservice_key", "") or "")
         self._tomtom_key = str(config.get("travel.tomtom_key", "") or "")
 
-        log.info(
-            "RoutePlanner initialised (ors=%s, tomtom=%s)",
-            "on" if self._ors_key else "off",
-            "on" if self._tomtom_key else "off",
-        )
+        if self._ors_key:
+            log.info(
+                "RoutePlanner initialised (ors=on, tomtom=%s)",
+                "on" if self._tomtom_key else "off",
+            )
+        else:
+            # Bez klucza planer nie liczy trasy — zwraca odległość w linii
+            # prostej. Wygląda to jak działająca funkcja i dlatego jest gorsze
+            # niż jawny błąd: dostajesz liczbę, która po prostu kłamie
+            # (w mieście potrafi zaniżyć czas przejazdu dwukrotnie).
+            log.error(
+                "RoutePlanner: brak travel.openrouteservice_key — trasy będą "
+                "liczone W LINII PROSTEJ, bez dróg i bez realnego czasu "
+                "przejazdu. Załóż darmowe konto na openrouteservice.org i "
+                "wpisz klucz w config/bcm_config.yaml -> travel."
+            )
 
     # ------------------------------------------------------------------ #
     # Public API                                                         #
@@ -180,6 +191,8 @@ class RoutePlanner:
             incidents          list[dict]              (TomTom or [])
             predicted_fuel_l   float                   (distance * avg/100)
             computed_at        float                   (unix ts)
+            approximate        bool                    (True = brak klucza ORS,
+                                                        odległość w linii prostej)
         """
         route = self._fetch_route(start, dest)
         if not route:
@@ -209,6 +222,7 @@ class RoutePlanner:
         predicted_fuel = estimate_fuel(dist_km, avg_consumption)
 
         return {
+            "approximate": bool(route.get("approximate")),
             "distance_km": round(dist_km, 1),
             "duration_min": round(duration_min, 1),
             "geometry": geometry,
@@ -226,8 +240,7 @@ class RoutePlanner:
     def _fetch_route(self, start: tuple[float, float],
                      dest: tuple[float, float]) -> Optional[dict]:
         if not self._ors_key:
-            log.info("No OpenRouteService key — skipping real routing, "
-                     "using straight-line estimate")
+            log.warning("No OpenRouteService key — straight-line estimate only")
             return self._straight_line_fallback(start, dest)
 
         body = {
@@ -269,6 +282,9 @@ class RoutePlanner:
             "distance_km": dist,
             "duration_min": dist / 80.0 * 60.0,
             "geometry": [start, dest],
+            # Oznaczone, żeby UI mogło to nazwać po imieniu. Bez tej flagi
+            # ekran pokazuje liczbę nieodróżnialną od prawdziwej trasy.
+            "approximate": True,
         }
 
     # ------------------------------------------------------------------ #

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -314,3 +314,143 @@ class TestVolumeController:
         assert VOLUME_MIN == 0
         assert VOLUME_MAX == 100
         assert VOLUME_STEP > 0
+
+
+# ---------------------------------------------------------------------------
+# Output selection — the path that decides whether anything is audible at all.
+#
+# Before v8.5.3 none of this existed: nothing chose a hardware sink, nothing
+# unmuted, and the EQ chain was left to follow whatever WirePlumber called
+# default (on a machine with HDMI attached, usually HDMI). These tests pin the
+# behaviour that fixes "no sound on the front jack".
+# ---------------------------------------------------------------------------
+
+_SINKS_TYPICAL_M910Q = [
+    {"id": "52", "name": "alsa_output.pci-0000_00_1f.3.hdmi-stereo",
+     "description": "Built-in Audio Digital Stereo (HDMI)"},
+    {"id": "47", "name": "alsa_output.pci-0000_00_1f.3.analog-stereo",
+     "description": "Built-in Audio Analog Stereo"},
+]
+
+
+class TestOutputSelection:
+    def setup_method(self):
+        self.bus = EventBus()
+        self.config = BCMConfig(platform_override="x86")
+        self.pw = PipeWireController(self.config, self.bus)
+
+    def _with_sinks(self, sinks):
+        self.pw.list_sink_nodes = lambda: list(sinks)
+
+    def test_auto_prefers_analog_over_hdmi(self):
+        """The whole point: HDMI must never win the auto pick."""
+        self._with_sinks(_SINKS_TYPICAL_M910Q)
+        self.config.set("audio.sink", "auto")
+        picked = self.pw.pick_hardware_sink()
+        assert picked is not None
+        assert "analog" in picked["name"]
+        assert "hdmi" not in picked["name"]
+
+    def test_auto_ignores_sink_order(self):
+        """HDMI listed first must still lose."""
+        self._with_sinks(list(reversed(_SINKS_TYPICAL_M910Q)))
+        self.config.set("audio.sink", "auto")
+        assert "analog" in self.pw.pick_hardware_sink()["name"]
+
+    def test_explicit_sink_by_substring(self):
+        self._with_sinks(_SINKS_TYPICAL_M910Q)
+        self.config.set("audio.sink", "hdmi-stereo")
+        assert "hdmi" in self.pw.pick_hardware_sink()["name"]
+
+    def test_explicit_sink_unknown_falls_back_to_auto(self):
+        """A typo in audio.sink must not leave the user with no output."""
+        self._with_sinks(_SINKS_TYPICAL_M910Q)
+        self.config.set("audio.sink", "nonexistent_device")
+        picked = self.pw.pick_hardware_sink()
+        assert picked is not None
+        assert "analog" in picked["name"]
+
+    def test_hdmi_only_is_still_used(self):
+        """Better to play through HDMI than to refuse to pick anything."""
+        self._with_sinks([_SINKS_TYPICAL_M910Q[0]])
+        self.config.set("audio.sink", "auto")
+        assert self.pw.pick_hardware_sink()["name"].endswith("hdmi-stereo")
+
+    def test_no_sinks_returns_none(self):
+        self._with_sinks([])
+        assert self.pw.pick_hardware_sink() is None
+
+    def test_eq_sink_is_never_picked_as_hardware(self):
+        """Otherwise the chain would be pinned to itself."""
+        from src.audio.pipewire_ctrl import EQ_SINK_NAME
+        self._with_sinks([
+            {"id": "99", "name": EQ_SINK_NAME, "description": "BCM 10-band EQ"},
+            _SINKS_TYPICAL_M910Q[1],
+        ])
+        self.config.set("audio.sink", "auto")
+        assert self.pw.pick_hardware_sink()["name"] != EQ_SINK_NAME
+
+    def test_usb_dac_preferred_over_generic(self):
+        self._with_sinks([
+            {"id": "1", "name": "alsa_output.platform-something.stereo", "description": ""},
+            {"id": "2", "name": "alsa_output.usb-ESS_ES9038Q2M-00.analog-stereo",
+             "description": "USB DAC"},
+        ])
+        self.config.set("audio.sink", "auto")
+        assert "usb" in self.pw.pick_hardware_sink()["name"]
+
+
+class TestFilterChainConfig:
+    def test_pins_playback_to_target_sink(self):
+        """Unpinned, the EQ output follows the default — which we then set to
+        the EQ itself. That is how sound ended up in HDMI."""
+        from src.audio.pipewire_ctrl import _build_filter_chain_conf
+        conf = _build_filter_chain_conf([0] * 10, "alsa_output.card.analog-stereo")
+        assert 'target.object = "alsa_output.card.analog-stereo"' in conf
+
+    def test_no_target_when_sink_unknown(self):
+        from src.audio.pipewire_ctrl import _build_filter_chain_conf
+        assert "target.object" not in _build_filter_chain_conf([0] * 10, None)
+
+    def test_declares_spa_libs(self):
+        """Without the audio.convert mapping the sink never appears at all."""
+        from src.audio.pipewire_ctrl import _build_filter_chain_conf
+        conf = _build_filter_chain_conf([0] * 10, None)
+        assert "context.spa-libs" in conf
+        assert "libspa-audioconvert" in conf
+
+    def test_all_ten_bands_present(self):
+        from src.audio.pipewire_ctrl import _build_filter_chain_conf
+        conf = _build_filter_chain_conf(EQ_PRESETS["rock"], None)
+        for freq in EQ_FREQUENCIES:
+            assert f'"Freq" = {float(freq)}' in conf
+
+
+class TestSinkEnumeration:
+    def setup_method(self):
+        self.bus = EventBus()
+        self.config = BCMConfig(platform_override="x86")
+        self.pw = PipeWireController(self.config, self.bus)
+
+    def test_parses_pw_dump_json(self, monkeypatch):
+        import json as _json
+        payload = _json.dumps([
+            {"id": 47, "info": {"props": {
+                "media.class": "Audio/Sink",
+                "node.name": "alsa_output.pci.analog-stereo",
+                "node.description": "Built-in Analog"}}},
+            {"id": 61, "info": {"props": {
+                "media.class": "Stream/Output/Audio",
+                "node.name": "chromium"}}},
+        ])
+        monkeypatch.setattr("src.audio.pipewire_ctrl._run_cmd",
+                            lambda cmd, timeout=5.0: (0, payload, ""))
+        sinks = self.pw.list_sink_nodes()
+        assert len(sinks) == 1
+        assert sinks[0]["id"] == "47"
+        assert sinks[0]["name"] == "alsa_output.pci.analog-stereo"
+
+    def test_malformed_pw_dump_does_not_raise(self, monkeypatch):
+        monkeypatch.setattr("src.audio.pipewire_ctrl._run_cmd",
+                            lambda cmd, timeout=5.0: (0, "not json at all", ""))
+        assert self.pw.list_sink_nodes() == []

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -135,3 +135,55 @@ class TestHAL:
         assert ow.read_temperature("28-abc123") == 22.5
         ow.set_mock_temperature("28-abc123", -3.0)
         assert ow.read_temperature("28-abc123") == -3.0
+
+
+# ---------------------------------------------------------------------------
+# Shipped module configuration
+# ---------------------------------------------------------------------------
+
+class TestShippedModuleConfig:
+    """Guards on config/bcm_config.yaml — the file systemd actually loads.
+
+    Deliberately does NOT pin the full on/off list: flipping a toggle is a
+    normal thing to do. It pins the invariants that quietly break a build.
+    """
+
+    @staticmethod
+    def _modules(name="bcm_config.yaml"):
+        import pathlib
+        import yaml
+        root = pathlib.Path(__file__).resolve().parent.parent
+        return yaml.safe_load((root / "config" / name).read_text())["modules"]
+
+    @pytest.mark.parametrize("cfg_name", ["bcm_config.yaml", "bcm_config_test.yaml"])
+    def test_every_toggle_is_a_known_module(self, cfg_name):
+        """A typo in a toggle name is silent — the module just never starts."""
+        from src.core import modules_catalog
+        known = set(modules_catalog.MODULES)
+        unknown = set(self._modules(cfg_name)) - known
+        assert not unknown, f"{cfg_name}: nieznane przełączniki: {sorted(unknown)}"
+
+    @pytest.mark.parametrize("cfg_name", ["bcm_config.yaml", "bcm_config_test.yaml"])
+    def test_toggles_are_booleans(self, cfg_name):
+        bad = {k: v for k, v in self._modules(cfg_name).items()
+               if not isinstance(v, bool)}
+        assert not bad, f"{cfg_name}: nie-boolowskie przełączniki: {bad}"
+
+    def test_android_auto_has_its_whole_chain(self):
+        """AA needs all three: the launcher, the BT bootstrap and the P2P link.
+        Enabling multimedia alone gets you a screen that never connects."""
+        m = self._modules()
+        if not m.get("multimedia"):
+            pytest.skip("Android Auto wyłączone w tej konfiguracji")
+        for dep in ("bluetooth", "wifi_ap"):
+            assert m.get(dep), f"multimedia=true wymaga {dep}=true"
+
+    def test_swc_pods_need_the_input_module(self):
+        """The steering-wheel pods arrive as USB HID via the Pro Micro; the
+        input module is what turns those keycodes into BCM actions."""
+        assert self._modules().get("input"), \
+            "pody SWC nie zadziałają bez modules.input"
+
+    def test_dashboard_is_on(self):
+        """Weather, route planning and AA all render on it."""
+        assert self._modules().get("dashboard")

--- a/tests/test_multimedia.py
+++ b/tests/test_multimedia.py
@@ -275,3 +275,63 @@ class TestAADisplay:
         # Main display is the 10.1" 1280x800 panel (display.multimedia in config).
         assert disp.width == 1280
         assert disp.height == 800
+
+
+# ---------------------------------------------------------------------------
+# Wi-Fi Direct credentials → openauto.ini
+#
+# A P2P group invents its SSID and passphrase when it is created, so the values
+# that matter are only known at runtime. Nothing subscribed to
+# wifi.ap_credentials before v8.5.3, so openauto.ini kept whatever the YAML
+# held — and the YAML held a stale DIRECT-xx pair from an earlier session. The
+# phone was handed credentials for a network that no longer existed.
+# ---------------------------------------------------------------------------
+
+class TestAPCredentialRefresh:
+    def test_controller_subscribes_to_ap_credentials(self):
+        from src.core.config import BCMConfig
+        from src.core.event_bus import EventBus
+        from src.multimedia.openauto import OpenAutoController
+
+        bus = EventBus()
+        config = BCMConfig(platform_override="x86")
+        OpenAutoController(config, bus)
+
+        assert "wifi.ap_credentials" in bus._subscribers, (
+            "OpenAutoController must react to live AP credentials, otherwise "
+            "openauto.ini keeps stale Wi-Fi Direct details"
+        )
+
+    def test_refresh_is_a_noop_without_binary(self):
+        """No autoapp means no openauto.ini to rewrite — must not raise."""
+        from src.core.config import BCMConfig
+        from src.core.event_bus import EventBus
+        from src.multimedia.openauto import OpenAutoController
+
+        bus = EventBus()
+        ctrl = OpenAutoController(BCMConfig(platform_override="x86"), bus)
+        if ctrl.available:
+            pytest.skip("autoapp actually installed on this machine")
+        ctrl._on_ap_credentials(
+            "wifi.ap_credentials",
+            {"ssid": "DIRECT-zz", "password": "secret12", "bssid": "aa:bb"},
+            0.0,
+        )
+
+
+class TestShippedConfigCredentials:
+    """The shipped YAMLs must not carry runtime Wi-Fi Direct credentials."""
+
+    @pytest.mark.parametrize("cfg_name", ["bcm_config.yaml", "bcm_config_test.yaml"])
+    def test_runtime_credentials_are_blank(self, cfg_name):
+        import pathlib
+        import yaml
+
+        root = pathlib.Path(__file__).resolve().parent.parent
+        cfg = yaml.safe_load((root / "config" / cfg_name).read_text())
+        wifi = cfg.get("wifi", {})
+        for key in ("ssid_runtime", "password_runtime", "bssid_runtime"):
+            assert not wifi.get(key), (
+                f"{cfg_name}: {key} must ship empty — a stale P2P credential "
+                f"sends the phone to a network that no longer exists"
+            )


### PR DESCRIPTION
Three things were broken on the car and one thing needed trimming. All four are in here, plus a QA survey run against a live instance.

## Pro Micro — SWC pods spamming phantom presses

The reported symptom was the giveaway: **both pods reported the same button at the same ADC value**, alternating, with nothing connected. That is not external noise — that is the ATmega32U4's ADC.

Three independent causes, all fixed in `arduino/rotary_encoder/rotary_encoder.ino`:

1. **ADC multiplexer crosstalk.** The 32U4 has one sample-and-hold capacitor shared across every analog channel. After switching channels, the first conversion still carries the previous channel's charge — and with a high-impedance source like a passive resistor ladder, it carries essentially all of it. New `adcStable()` does two throwaway conversions with `ADC_SETTLE_US` between them, then takes the median of five spaced samples.
2. **Floating inputs.** Idle is defined as "ADC near VCC", which requires a pull-up. `INPUT_PULLUP` is now set on `SWC_PIN1`, `SWC_PIN2`, `ENC_CLK`, `ENC_DT`.
3. **No real debounce.** New `SwcPod` struct + `handlePod()` use a candidate/confirm pattern (`SWC_CONFIRM_MS`) and require a return to idle before another press registers.

Worth naming explicitly: **SWC MODE sends F10, which maps to `input.bcm_power_toggle`** — so this noise could switch the computer off mid-drive.

Also: `FEATURE_*` toggles added, defaulting to **SWC only**, with `#error` guards for combinations that cannot work (FUEL wants A4, which is not broken out on a Pro Micro). Serial `CAL` now enters calibration without needing a button held at boot. Dead `calibrationMode` flag and `reportFuelLevel()` removed.

## Audio — nothing came out of the front headphone jack

BCM was not failing to configure the output; it was **actively taking it away**. The only place that wrote a default sink pointed it at the EQ filter chain, and it ran twice (constructor and `start_audio`). A manual `wpctl set-default` was undone 0.3–3 s after BCM started. There was no `target.object` pinning the chain to a real device, and nothing anywhere ever unmuted.

`src/audio/pipewire_ctrl.py` now has an explicit output sequence: `wait_for_pipewire()` → `list_sink_nodes()` (pw-dump JSON, wpctl fallback) → `pick_hardware_sink()` → `_amixer_unmute()` → `start_output()`. HDMI/DisplayPort/S-PDIF are excluded from the preference order, and the filter chain emits `target.object` pinned to the chosen sink. If the EQ sink never appears, the hardware sink is restored instead of leaving the system pointed at a chain that does not exist.

New config keys: `audio.sink` (`auto` or an explicit node name), `audio.hw_volume`, `audio.force_unmute`.

Two related fixes: `main.py`'s signal handler now publishes `power.shutting_down` (previously only `PowerManager` did, so with `modules.power: false` nothing cleaned up at all), and `wifi_ap.py`'s shutdown subscription was sitting after a `return` and never ran.

## Android Auto — not the code's fault

`setup-x86.sh` has zero references to `autoapp`, `openauto` or `aasdk`. **The binary is a separate source build that the setup script never performs.** BCM was looking for something that was never installed and saying nothing useful about it.

- New `config/scripts/install-openauto.sh` automating `X86_PLATFORM_SETUP.md` §11.1–11.5.
- `src/multimedia/openauto.py` now logs an error naming all three search paths and the install command.
- P2P credentials are generated at group creation, so the hardcoded `*_runtime` values in both YAMLs were stale by definition — cleared, and `openauto.ini` is now written from the live `wifi.ap_credentials` event.

## Module set trimmed

`config/bcm_config.yaml` down to **8 enabled** modules (dashboard, audio, input, multimedia, weather, bluetooth, wifi_ap, route_planner) out of 28, each disabled one carrying a reason. I checked for orphaned pub/sub topics afterwards — three showed up, all resolved or verified benign (see QA §F4).

Route planning: a missing ORS key now logs an error and the straight-line fallback is flagged `approximate: true`, plumbed through `trip_computer.py` to a warning strip in `trip.js`. Previously a straight line was presented as a real route.

## Verification

- **447 tests** pass (+25 new: `TestOutputSelection`, `TestFilterChainConfig`, `TestSinkEnumeration`, `TestShippedModuleConfig`)
- `ruff check .` clean, 267 markdown links resolve, YAML/JS/bash syntax checked
- Firmware compiles clean under `-Wall -Wextra` in **every** `FEATURE_*` combination (via API stubs — `downloads.arduino.cc` is blocked by proxy policy here, so the real AVR build is the CI `arduino` job)
- Live run recorded in **`docs/QA_ODBIOR.md`**, two columns: what was checked in the container vs. what still needs the M910q. Module list exactly 8, HTTP 200, WebSocket 74 fields, Kraków→Gdynia returned `approximate=true` at 504.5 km straight-line against ~590 km by road.

One regression I introduced and caught on the live instance: `wait_for_pipewire` originally blocked startup for 20 s. The synchronous probe is now 3×0.5 s with the long retry moved to a background thread — audio module start went 20 s → 1 s.

## Not touched — needs your call

1. **`weather.api_key` is a working OpenWeatherMap key committed to the repo** (`config/bcm_config.yaml`). I left it alone rather than break your setup, but it should move out of git and the current one should be revoked.
2. **`BrightnessController` is never instantiated.** The stalk button sends F9 and `action_dispatch` maps it to `input.brightness_cycle`, but nothing listens. Same for the LDR. Out of scope for this round.

Also in this branch: `24785b8` (diode orientations — the TVS is bidirectional, `CA` suffix, so it has no "way round") and `73de250` (on a Pro Micro, "A6" is the pad silkscreened `4`).

---
_Generated by [Claude Code](https://claude.ai/code/session_017cXmt2HyZ8iv3aQHpkNA4c)_