### PR TITLE
Quick-start test build: AA "Unknown sources" fix, single-pod SWC, dual audio, bigger 7" UI, PL keyboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ openauto_wifi_recent.ini
 
 # Local design-asset drop, never part of the repo (purged from history 2026-07)
 stitch_heritage_warmth_wood_glow_prd*.zip
+.ap-leftover-backup/

--- a/arduino/rotary_encoder/rotary_encoder.ino
+++ b/arduino/rotary_encoder/rotary_encoder.ino
@@ -16,8 +16,12 @@
  *   D7 ← MEDIA button (active LOW, internal pull-up)
  *   D8 ← VOL+ button  (active LOW, internal pull-up)
  *   D9 ← VOL- button  (active LOW, internal pull-up)
- *   A0 ← SWC Pod 1 (white wire, analog 0-5V)
- *   A6 ← SWC Pod 2 (white wire, analog 0-5V)
+ *   A0 ← SWC pod ("KEY", biały przewód) — analog 0-5V (drabinka rezystorów).
+ *        WYMAGA pull-up z A0 do VCC (5V). Dla TEGO modułu (rezystancje padów
+ *        1Ω..14,66kΩ) właściwa wartość to **1 kΩ** — 10 kΩ ściska sześć padów
+ *        o niskiej rezystancji w ADC 0-70 (nakładają się), a 330 kΩ pływa i
+ *        "wariuje". 1 kΩ rozkłada wszystkie 10 padów w 0-1023 (patrz swcValues).
+ *   A6 ← (NIEUŻYWANE) — drugi pod wyłączony w tej wersji (jeden pod).
  *
  *   Music panel (5 buttons near 7" AA screen, active LOW, internal pull-ups):
  *   D10 ← MUSIC PREV
@@ -30,7 +34,9 @@
  *   A1  ← LDR light sensor (voltage divider: LDR + 10kΩ to GND → A1)
  *   A2  ← Stalk button (spare button on column stalk, active LOW, internal pull-up)
  *
- * SWC decoder boxes: Pod 1 white → A0, Pod 2 white → A6, both black → GND, both red → 12V ACC
+ * Adapter SWC (uczący się, z Aliexpress): kostka red → 12V ACC, black → GND,
+ * KEY (biały) → A0. Masa kostki MUSI być wspólna z GND Pro Micro. Pro Micro
+ * zasilany z USB M910q (nie z 12V). Pull-up 1 kΩ z A0 do VCC. Jeden pod.
  *
  * Music panel buttons send same keycodes as SWC/encoder equivalents:
  *   MUSIC PREV  → MEDIA_PREVIOUS (consumer)
@@ -78,6 +84,15 @@
  * Przy okazji: piny enkodera dostały INPUT_PULLUP (bez podłączonego enkodera
  * pływały i przerwanie CHANGE sypało strzałkami), a wejścia, których nie masz
  * podłączonych, można teraz wyłączyć przełącznikami FEATURE_* poniżej.
+ * ---------------------------------------------------------------------------
+ * v8.5.4 — JEDEN pod, 10 przycisków, bez power-toggle
+ *
+ * Konfiguracja quick-start: tylko Pod 1 (A0), drugi pod (A6) wyłączony.
+ * Zestaw 10 przycisków w kolejności kalibracji: VOL+, VOL-, MUTE, NEXT, PREV,
+ * HOME, PICKUP (odbierz), HANGUP (odrzuć), VOICE (mikrofon), NAV (nawigacja).
+ * Slot "MODE" (dawniej F10 → input.bcm_power_toggle) SKASOWANY i zastąpiony
+ * przez HOME (KEY_HOME → ekran A1) — szum ADC nie wyłączy już komputera.
+ * Kalibracja pyta tylko o te 10 przycisków. Pull-up ma być 1 kΩ (patrz wyżej).
  * ---------------------------------------------------------------------------
  */
 
@@ -157,57 +172,44 @@
 // 60 ms to kompromis: krócej łapie zakłócenia, dłużej daje wrażenie opóźnienia.
 #define SWC_CONFIRM_MS   60
 
-// --- SWC button count (12 per pod x 2 pods = 24 total) ---
-#define SWC_BUTTONS_PER_POD 12
-#define SWC_BUTTON_COUNT 24
+// --- SWC button count (JEDEN pod, 10 przycisków) ---
+#define SWC_BUTTONS_PER_POD 10
+#define SWC_BUTTON_COUNT 10
 #define SWC_IDLE_THRESHOLD 1000
 
 // --- EEPROM layout ---
 #define EEPROM_MAGIC_ADDR 0
-#define EEPROM_MAGIC_VALUE 0xBD   // bumped from 0xBC to force re-calibration
-#define EEPROM_SWC_ADDR 1         // 24 x 2 bytes = 48 bytes
+#define EEPROM_MAGIC_VALUE 0xBF   // bumped: wstępne nastawy z pomiarów (pull-up 1k)
+#define EEPROM_SWC_ADDR 1         // 10 x 2 bytes = 20 bytes
 
-// SWC button indices — Pod 1 (0-11), Pod 2 (12-23)
+// SWC button indices — jeden pod (A0), 10 przycisków w kolejności kalibracji.
 enum SWCButton {
-  SWC_VOLUP   = 0,
-  SWC_VOLDN   = 1,
-  SWC_UP      = 2,
-  SWC_DOWN    = 3,
-  SWC_MUTE    = 4,
-  SWC_MODE    = 5,
-  SWC_NEXT    = 6,
-  SWC_PREV    = 7,
-  SWC_PICKUP  = 8,
-  SWC_HANGUP  = 9,
-  SWC_VOICE   = 10,
-  SWC_SRC     = 11,
-  SWC2_VOLUP  = 12,
-  SWC2_VOLDN  = 13,
-  SWC2_UP     = 14,
-  SWC2_DOWN   = 15,
-  SWC2_MUTE   = 16,
-  SWC2_MODE   = 17,
-  SWC2_NEXT   = 18,
-  SWC2_PREV   = 19,
-  SWC2_PICKUP = 20,
-  SWC2_HANGUP = 21,
-  SWC2_VOICE  = 22,
-  SWC2_SRC    = 23,
+  SWC_VOLUP  = 0,   // głośniej
+  SWC_VOLDN  = 1,   // ciszej
+  SWC_MUTE   = 2,   // wyciszenie
+  SWC_NEXT   = 3,   // następny utwór
+  SWC_PREV   = 4,   // poprzedni utwór
+  SWC_HOME   = 5,   // ekran główny (A1) — dawniej MODE/power-toggle
+  SWC_PICKUP = 6,   // odbierz połączenie
+  SWC_HANGUP = 7,   // odrzuć / zakończ połączenie
+  SWC_VOICE  = 8,   // mikrofon / asystent AA
+  SWC_SRC    = 9,   // nawigacja → ekran Android Auto (A2)
 };
 
 const char* SWC_NAMES[SWC_BUTTON_COUNT] = {
-  "VOL+", "VOL-", "UP", "DOWN", "MUTE", "MODE",
-  "NEXT", "PREV", "PICKUP", "HANGUP", "VOICE", "SRC",
-  "2:VOL+", "2:VOL-", "2:UP", "2:DOWN", "2:MUTE", "2:MODE",
-  "2:NEXT", "2:PREV", "2:PICKUP", "2:HANGUP", "2:VOICE", "2:SRC"
+  "VOL+", "VOL-", "MUTE", "NEXT", "PREV",
+  "HOME", "PICKUP", "HANGUP", "VOICE", "NAV"
 };
 
-// ADC calibration values — Pod 1 indices 0-11, Pod 2 indices 12-23
+// ADC calibration values (jeden pod). WSTĘPNE, policzone z rezystancji
+// zmierzonych na module SWC (biały↔GND) i pull-upu 1 kΩ do 5 V:
+//   ADC = 1023 * R / (R + 1000)
+//   VOL+ 734Ω→433  VOL- 181Ω→157  MUTE 1863Ω→666  NEXT 472Ω→328  PREV 1Ω→1
+//   HOME 331Ω→254  PICKUP 1237Ω→566  HANGUP 14660Ω→958  VOICE 4110Ω→823  NAV 82Ω→78
+// Rozrzut min. 74 (tolerancja 40) — pody rozróżnialne. Uruchom CAL, by
+// dostroić pod tolerancje własnego rezystora; te wartości działają od razu.
 uint16_t swcValues[SWC_BUTTON_COUNT] = {
-  75, 150, 230, 310, 390, 470,
-  540, 610, 690, 760, 830, 900,
-  75, 150, 230, 310, 390, 470,
-  540, 610, 690, 760, 830, 900,
+  433, 157, 666, 328, 1, 254, 566, 958, 823, 78,
 };
 
 #ifdef FEATURE_ENCODER
@@ -254,9 +256,8 @@ struct SwcPod {
   const char*  tag;
 };
 
-SwcPod swcPods[2] = {
-  {SWC_PIN1, 0,                   -1, -1, 0, "SWC1"},
-  {SWC_PIN2, SWC_BUTTONS_PER_POD, -1, -1, 0, "SWC2"},
+SwcPod swcPods[1] = {
+  {SWC_PIN1, 0, -1, -1, 0, "SWC"},
 };
 #endif
 
@@ -322,11 +323,11 @@ void setup() {
 #ifdef FEATURE_SWC
   // INPUT_PULLUP, nie INPUT. Spoczynek jest tu zdefiniowany jako ADC ≈ VCC,
   // więc linia MUSI być czymś podciągnięta. Wewnętrzny pull-up (20–50 kΩ)
-  // wystarcza na biurku; w aucie dołóż zewnętrzne 10 kΩ do VCC i skalibruj
+  // wystarcza na biurku; w aucie dołóż zewnętrzne 1 kΩ do VCC i skalibruj
   // pody DOPIERO po jego zamontowaniu — przy pasywnej drabince rezystorowej
   // podciągnięcie współtworzy dzielnik i zmienia wszystkie progi.
   pinMode(SWC_PIN1, INPUT_PULLUP);
-  pinMode(SWC_PIN2, INPUT_PULLUP);
+  // A6 (Pod 2) celowo nieużywane — jeden pod. Nie ustawiamy pinMode.
 #endif
 
 #ifdef FEATURE_LIGHT
@@ -521,9 +522,8 @@ void loop() {
 #endif
 
 #ifdef FEATURE_SWC
-  // --- Handle SWC analog buttons (Pod 1 on A0, Pod 2 on A6) ---
+  // --- Handle SWC analog buttons (jeden pod na A0) ---
   handlePod(swcPods[0], now);
-  handlePod(swcPods[1], now);
 
   // --- Kalibracja na żądanie: wyślij "CAL" na port szeregowy ---
   // Alternatywa dla HOME + BACK przy starcie, która działa także wtedy, gdy
@@ -610,55 +610,44 @@ void handleMusicButton(int buttonIndex) {
 
 #ifdef FEATURE_SWC
 void handleSWCButton(int buttonIndex) {
-  // Pod 2 buttons (12-23) send the same keycodes as their Pod 1 equivalents
-  int base = buttonIndex % SWC_BUTTONS_PER_POD;
-  switch (base) {
-    case 0:  // VOLUP
+  // Jeden pod — indeks 0..9 wprost (kolejność jak enum SWCButton / SWC_NAMES).
+  switch (buttonIndex) {
+    case 0:  // VOL+  → głośniej
       Consumer.write(MEDIA_VOLUME_UP);
       break;
-    case 1:  // VOLDN
+    case 1:  // VOL-  → ciszej
       Consumer.write(MEDIA_VOLUME_DOWN);
       break;
-    case 2:  // UP
-      Keyboard.press(KEY_UP_ARROW);
-      delay(10);
-      Keyboard.release(KEY_UP_ARROW);
-      break;
-    case 3:  // DOWN
-      Keyboard.press(KEY_DOWN_ARROW);
-      delay(10);
-      Keyboard.release(KEY_DOWN_ARROW);
-      break;
-    case 4:  // MUTE
+    case 2:  // MUTE  → wyciszenie
       Consumer.write(MEDIA_VOLUME_MUTE);
       break;
-    case 5:  // MODE → power toggle (F10)
-      Keyboard.press(KEY_F10);
-      delay(10);
-      Keyboard.release(KEY_F10);
-      break;
-    case 6:  // NEXT
+    case 3:  // NEXT  → następny utwór
       Consumer.write(MEDIA_NEXT);
       break;
-    case 7:  // PREV
+    case 4:  // PREV  → poprzedni utwór
       Consumer.write(MEDIA_PREVIOUS);
       break;
-    case 8:  // PICKUP
+    case 5:  // HOME  → ekran główny A1 (KEY_HOME). Dawniej MODE→F10 wyłączał BCM.
+      Keyboard.press(KEY_HOME);
+      delay(10);
+      Keyboard.release(KEY_HOME);
+      break;
+    case 6:  // PICKUP (odbierz) → F5 → input.phone_pickup
       Keyboard.press(KEY_F5);
       delay(10);
       Keyboard.release(KEY_F5);
       break;
-    case 9:  // HANGUP
+    case 7:  // HANGUP (odrzuć) → F6 → input.phone_hangup
       Keyboard.press(KEY_F6);
       delay(10);
       Keyboard.release(KEY_F6);
       break;
-    case 10: // VOICE → voice AA trigger (F7)
+    case 8:  // VOICE (mikrofon) → F7 → input.voice_aa_trigger
       Keyboard.press(KEY_F7);
       delay(10);
       Keyboard.release(KEY_F7);
       break;
-    case 11: // SRC → navigate AA (F8)
+    case 9:  // NAV (nawigacja) → F8 → input.navigate_aa → ekran A2 (Android Auto)
       Keyboard.press(KEY_F8);
       delay(10);
       Keyboard.release(KEY_F8);
@@ -773,14 +762,13 @@ void calibratePod(uint8_t pin, uint8_t offset, const char* podName) {
 
 void runCalibration() {
   Serial.println();
-  Serial.println("=== SWC CALIBRATION MODE (Dual Pod) ===");
-  Serial.println("Press each steering wheel button when prompted.");
-  Serial.println("Release all buttons between presses.");
+  Serial.println("=== SWC CALIBRATION (jeden pod, 10 przyciskow) ===");
+  Serial.println("Nacisnij kolejno: VOL+, VOL-, MUTE, NEXT, PREV,");
+  Serial.println("HOME, PICKUP(odbierz), HANGUP(odrzuc), VOICE(mik), NAV.");
+  Serial.println("Zwalniaj wszystkie przyciski miedzy wcisnieciami.");
   Serial.println();
 
-  calibratePod(SWC_PIN1, 0, "Pod 1 (A0)");
-  Serial.println();
-  calibratePod(SWC_PIN2, SWC_BUTTONS_PER_POD, "Pod 2 (A6 = pad 4)");
+  calibratePod(SWC_PIN1, 0, "Pod (A0)");
 
   Serial.println();
   Serial.println("Calibration results:");

--- a/config/bcm_config_temp.yaml
+++ b/config/bcm_config_temp.yaml
@@ -1,0 +1,281 @@
+system:
+  name: BCM v8.5
+  version: 8.5.1
+  platform: x86
+  log_level: DEBUG
+  log_file: logs/bcm.log
+  simulation: false
+modules:
+  dashboard: true
+  weather: true
+  route_planner: true
+  multimedia: true
+  bluetooth: true
+  wifi_ap: true
+  input: true
+  audio: true
+  obd: false
+  parking: false
+  environment: false
+  camera: false
+  power: false
+  location: false
+  tracking: false
+  network: false
+  blinker_monitor: false
+  rain_sensor: false
+  central_lock: false
+  lighting: false
+  performance: false
+  alarm: false
+  crash_detect: false
+  battery: false
+  phonebook: false
+  fuel_sender: false
+  wifi_hotspot: false
+  small_display: false
+display:
+  dashboard:
+    width: 1024
+    height: 600
+    fps: 15
+    theme: heritage
+    brightness: 70
+  multimedia:
+    width: 1024
+    height: 600
+  small:
+    width: 1280
+    height: 480
+  appbar_px: 48
+  navbar_px: 48
+units:
+  speed: km/h
+  temperature: C
+language: pl
+gpio:
+  parking_trig: 79
+  parking_echo:
+  - 80
+  - 81
+  - 82
+  - 83
+  buzzer: 84
+  backlight_dashboard: 32
+  backlight_multimedia: 33
+  onewire: 7
+  ignition: 85
+  door: 86
+  rain_sensor: 87
+  sprayer: 88
+  central_lock: 89
+  blinker_left: 90
+  blinker_right: 91
+vehicle:
+  blinker_active_low: true
+  blinker_hold_sec: 0.8
+serial:
+  kline:
+    port_opi: /dev/ttyS3
+    port_x86: /dev/ttyUSB_kline
+    baudrate: 10400
+    ecu_address: 1
+obd:
+  use_real_hardware: false
+  fast_init: false
+hardware:
+  gps:
+    enabled: true
+    port: /dev/ttyUSB0
+    baudrate: 9600
+  lte:
+    enabled: true
+    device: ''
+    apn: ''
+audio:
+  sink: bcm_combine
+  hw_volume: 100
+  force_unmute: true
+  eq_dsp_enabled: true
+  eq_preset: jazz
+  master_volume: 70
+  bass: 0
+  treble: 0
+  fader: 0
+  balance: 0
+  spectrum_enabled: true
+  dac: ES9038Q2M
+  amp_main: car-amp-4ch
+  amp_sub: none
+  mic_phone: ''
+  voice_duck_pct: 40
+  voice_listen_sec: 8
+camera:
+  segment_minutes: 5
+  max_storage_gb: 128
+  recording_path: /media/dashcam
+  front_device: /dev/video0
+  rear_device: /dev/video1
+  left_device: /dev/video2
+  right_device: /dev/video3
+  controller: true
+swc:
+  enabled: true
+  mapping:
+    volume_up:
+    - SWC_VOLUP
+    - SWC2_VOLUP
+    volume_down:
+    - SWC_VOLDN
+    - SWC2_VOLDN
+    next_track:
+    - SWC_NEXT
+    - SWC2_NEXT
+    prev_track:
+    - SWC_PREV
+    - SWC2_PREV
+    mute:
+    - SWC_MUTE
+    - SWC2_MUTE
+    phone_pickup:
+    - SWC_PICKUP
+    - SWC2_PICKUP
+    phone_hangup:
+    - SWC_HANGUP
+    - SWC2_HANGUP
+    bcm_power_toggle:
+    - SWC_MODE
+    - SWC2_MODE
+    voice_aa_trigger:
+    - SWC_VOICE
+    - SWC2_VOICE
+    navigate_aa:
+    - SWC_SRC
+    - SWC2_SRC
+    menu_up:
+    - SWC_UP
+    - SWC2_UP
+    menu_down:
+    - SWC_DOWN
+    - SWC2_DOWN
+brightness:
+  mode: auto
+  steps:
+  - 15
+  - 30
+  - 45
+  - 60
+  - 80
+  - 100
+music_panel:
+  enabled: true
+fuel_sender:
+  enabled: true
+  calibration:
+  - - 20
+    - 100
+  - - 50
+    - 75
+  - - 120
+    - 50
+  - - 220
+    - 25
+  - - 360
+    - 5
+  - - 400
+    - 0
+  tank_capacity_litres: 58
+wifi:
+  enabled: true
+  ssid: ALFA
+  password: 87654321
+  mode: p2p_go
+  band: a
+  channel: 149
+  country: US
+  regdom: US
+  share_internet: true
+  interface: ''
+  ip: 10.0.0.1
+  netmask: 255.255.255.0
+  dhcp_start: 10.0.0.10
+  dhcp_end: 10.0.0.50
+  alfa_net:
+    enabled: false
+    ssid: ALFA-NET
+    password: AlfaRomeo156
+    channel: 6
+    country: US
+    ip: 10.0.1.1
+    netmask: 255.255.255.0
+    dhcp_start: 10.0.1.10
+    dhcp_end: 10.0.1.50
+    share_internet: true
+  ssid_runtime: ''
+  password_runtime: ''
+  bssid_runtime: ''
+weather:
+  api_key: 631c2365675e193584b0f986798554c1
+  poll_interval_min: 15
+  default_lat: 50.06
+  default_lon: 19.94
+travel:
+  openrouteservice_key: PASTE_ORS_KEY_HERE
+  tomtom_key: ''
+power:
+  shutdown_delay_seconds: 30
+  backlight_fade_ms: 1000
+  standby_max_hours: 24
+  splash_duration_seconds: 15
+  ignition_watcher:
+    gpio_chip: gpiochip0
+    ignition_line: 7
+    bench_button_line: 21
+    debounce_ms: 200
+    active_low: true
+    autostart: true
+    suspend_on_stop: true
+    suspend_delay_seconds: 5
+rain_sensor:
+  sensitivity: medium
+central_lock:
+  port: /dev/ttyUSB1
+  baudrate: 9600
+lighting:
+  follow_me_home_seconds: 60
+  greeting_blinks: 2
+  leaving_home: true
+traffic:
+  api_key: ''
+  provider: tomtom
+  poll_interval_min: 5
+remote_status:
+  api_key: ''
+alarm:
+  siren_duration: 60
+  arming_delay: 30
+  sensors:
+    door: true
+    motion: true
+    tilt: true
+    shock: true
+crash_detection:
+  speed_drop_threshold: 30
+  g_force_threshold: 3.0
+  post_crash_record_sec: 60
+tracking:
+  db_path: data/gps_tracks.db
+  interval_sec: 30
+  trip_start_kmh: 5
+  trip_end_kmh: 2
+  trip_end_idle_sec: 60
+  lte_sync_min: 15
+  geofence_lat: 0
+  geofence_lon: 0
+  geofence_radius_km: 0
+  sms_number: ''
+multimedia:
+  last_bt_device: C0:7A:D6:90:E9:CC
+bluetooth:
+  enabled: true
+  preferred_adapter: ''

--- a/config/pipewire/pipewire.conf.d/50-bcm-combine.conf
+++ b/config/pipewire/pipewire.conf.d/50-bcm-combine.conf
@@ -1,0 +1,34 @@
+# BCM v8.5 — combine-sink: ten sam dźwięk jednocześnie z karty USB
+# (Lenovo USB Soundbar) i z wyjścia analogowego płyty (minijack front).
+#
+# Tworzy sink "bcm_combine" (Audio/Sink), który rozsyła sygnał do DWÓCH
+# konkretnych wyjść po node.name. HDMI/IEC celowo pominięte.
+#
+# BCM wybiera ten sink przez audio.sink=bcm_combine (config), robi go
+# domyślnym i pina na niego łańcuch EQ → EQ → combine → oba wyjścia.
+# Głośność/EQ działają na domyślnym (bcm_combine); sinki sprzętowe trzymaj
+# na 100% (WirePlumber pamięta poziom per-urządzenie).
+context.modules = [
+    {   name = libpipewire-module-combine-stream
+        args = {
+            combine.mode = sink
+            node.name = "bcm_combine"
+            node.description = "BCM Combine (USB + minijack)"
+            combine.latency-compensate = false
+            combine.props = {
+                audio.position = [ FL FR ]
+            }
+            stream.props = {
+                stream.dont-remix = true
+            }
+            stream.rules = [
+                {   matches = [
+                        { node.name = "alsa_output.usb-Lenovo_Lenovo_USB_Soundbar-00.analog-stereo" }
+                        { node.name = "alsa_output.pci-0000_00_1f.3.analog-stereo" }
+                    ]
+                    actions = { create-stream = { } }
+                }
+            ]
+        }
+    }
+]

--- a/config/systemd/bcm-headunit-x86.service
+++ b/config/systemd/bcm-headunit-x86.service
@@ -13,7 +13,7 @@ Type=simple
 # Platform and config are set here — edit for your target:
 #   x86:    --platform x86    --config config/bcm_config.yaml
 #   OPi PC (archived): --platform opi_pc --config Archive/orange-pi-pc/bcm_config_opi_pc.yaml
-ExecStart=/bin/bash -c 'VENV=/opt/bcm/.venv; [ -x "$VENV/bin/python" ] || VENV=/opt/bcm/venv; exec "$VENV/bin/python" main.py --platform x86 --config config/bcm_config.yaml --frontend'
+ExecStart=/bin/bash -c 'VENV=/opt/bcm/.venv; [ -x "$VENV/bin/python" ] || VENV=/opt/bcm/venv; exec "$VENV/bin/python" main.py --platform x86 --config config/bcm_config_temp.yaml --frontend'
 WorkingDirectory=/opt/bcm
 Environment=PYTHONPATH=/opt/bcm
 Environment=BCM_PLATFORM=x86

--- a/src/audio/volume.py
+++ b/src/audio/volume.py
@@ -38,10 +38,15 @@ class VolumeController:
         self._pw = pipewire
         self._event_bus = event_bus
         self._volume = max(VOLUME_MIN, min(VOLUME_MAX, initial_volume))
+        self._muted = False
 
         # Subscribe to input events
         self._event_bus.subscribe("input.volume_up", self._on_volume_up)
         self._event_bus.subscribe("input.volume_down", self._on_volume_down)
+        # SWC MUTE button (Arduino MEDIA_VOLUME_MUTE → KEY_MUTE → input.mute).
+        # Nothing used to consume input.mute, so the wheel mute button did
+        # nothing; make it a toggle.
+        self._event_bus.subscribe("input.mute", self._on_mute)
 
         # Set initial volume
         self._pw.set_volume(self._volume)
@@ -50,12 +55,20 @@ class VolumeController:
         log.info("VolumeController initialized at %d%%", self._volume)
 
     def _on_volume_up(self, topic: str, value: Any, timestamp: float) -> None:
+        if self._muted:
+            self.unmute()
         step = value if isinstance(value, int) else VOLUME_STEP
         self.set_volume(self._volume + step)
 
     def _on_volume_down(self, topic: str, value: Any, timestamp: float) -> None:
+        if self._muted:
+            self.unmute()
         step = value if isinstance(value, int) else VOLUME_STEP
         self.set_volume(self._volume - step)
+
+    def _on_mute(self, topic: str, value: Any, timestamp: float) -> None:
+        # SWC MUTE is a toggle.
+        self.unmute() if self._muted else self.mute()
 
     def set_volume(self, volume: int) -> None:
         """Set master volume (0-100)."""
@@ -75,11 +88,15 @@ class VolumeController:
     def mute(self) -> None:
         """Mute audio output."""
         self._pw.set_mute(True)
+        self._muted = True
+        self._event_bus.publish("audio.mute_changed", True)
         log.info("Audio muted")
 
     def unmute(self) -> None:
         """Unmute audio output."""
         self._pw.set_mute(False)
+        self._muted = False
+        self._event_bus.publish("audio.mute_changed", False)
         log.info("Audio unmuted")
 
 

--- a/src/dashboard/web/css/themes.css
+++ b/src/dashboard/web/css/themes.css
@@ -22,8 +22,31 @@
  * per-component pixel bumps in the JS templates (navbar/appbar/keyboard).
  */
 html {
-    font-size: 16px;   /* fallback — #bcm-adaptive-rem overrides per viewport */
+    font-size: 17px;   /* fallback — #bcm-adaptive-rem overrides per viewport */
 }
+
+/* Master volume slider on the A1 media card (all themes). Big touch thumb;
+ * accent colour follows the active theme. Chromium kiosk → -webkit- is fine. */
+.bcm-vol {
+    -webkit-appearance: none; appearance: none;
+    width: 100%; height: 10px; border-radius: 9999px;
+    background: rgba(255, 255, 255, 0.15);
+    outline: none; cursor: pointer;
+}
+.bcm-vol::-webkit-slider-thumb {
+    -webkit-appearance: none; appearance: none;
+    width: 30px; height: 30px; border-radius: 9999px;
+    background: #ef4444; border: 2px solid rgba(0, 0, 0, 0.35);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4); cursor: pointer;
+}
+[data-theme="modern"] .bcm-vol { background: rgba(0, 0, 0, 0.12); }
+[data-theme="modern"] .bcm-vol::-webkit-slider-thumb { background: #2563eb; }
+[data-theme="autodelta"] .bcm-vol::-webkit-slider-thumb { background: #FF5F00; }
+
+/* Utilities used by the rebuilt A1 media card that aren't in the precompiled
+ * Tailwind sheet (node was unavailable to re-run build-frontend.sh). Standard
+ * Tailwind values — a later CSS rebuild produces the same rule. */
+.max-w-2xl { max-width: 42rem; }
 
 /* When the on-screen keyboard (half-screen, 50vh) is open, pad the
  * scrollable content area up by the keyboard height + a margin so the

--- a/src/dashboard/web/index.html
+++ b/src/dashboard/web/index.html
@@ -19,14 +19,14 @@
          * (padding, gaps, button heights, standard text) WITHOUT a
          * transform:scale (which blurs text + breaks touch mapping).
          *
-         * Designed around a 1280-wide reference at 16px and clamped so a
-         * 1024x600 panel stays legible (~14px → denser than the old fixed
-         * 17px) while a 10.1" 1280x800 panel fills out proportionally
-         * (16px). Re-applied on resize so swapping panels needs no config.
-         * Pixel-literal labels (text-[Npx], icon font-size) are handled by
-         * the escape-bracket overrides in themes.css, not here. */
+         * Quick-start build runs on a 7" 1024x600 panel and the user asked
+         * for a BIGGER UI, so the base is bumped: floor 17px (was 14 → why
+         * everything looked tiny on 1024), reference 17px @ 1280, up to 20px
+         * on wider panels. Re-applied on resize so swapping panels needs no
+         * config. Pixel-literal labels (text-[Npx], icon font-size) are
+         * handled by the escape-bracket overrides in themes.css, not here. */
         (function () {
-            var REF_W = 1280, REF_PX = 16, MIN_PX = 14, MAX_PX = 17;
+            var REF_W = 1280, REF_PX = 17, MIN_PX = 17, MAX_PX = 20;
             function applyRem() {
                 var w = window.innerWidth || REF_W;
                 var px = Math.max(MIN_PX, Math.min(MAX_PX, REF_PX * (w / REF_W)));

--- a/src/dashboard/web/js/app.js
+++ b/src/dashboard/web/js/app.js
@@ -4,7 +4,9 @@
 
 const App = (() => {
     const SCREENS = ["init", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "settings"];
-    const NAV_SCREENS = ["a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8"]; // screens with navbar
+    // Quick-start build: swipe/navbar cycle only the four in-scope screens.
+    // A5-A8 stay registered (reachable by direct navigateTo) but are hidden.
+    const NAV_SCREENS = ["a1", "a2", "a3", "a4"]; // screens with navbar
 
     let _currentScreen = "init";
     let _currentTheme = "heritage";
@@ -355,7 +357,11 @@ const App = (() => {
 
     // --- Icing Alert ---
     function _checkIcingAlert(data) {
-        const temp = data.ext_temp;
+        // Quick-start build: ice/frost warnings disabled (user request). The
+        // environment module is off anyway, but hard-gate it so a stray
+        // ext_temp can never pop the overlay.
+        return;
+        const temp = data.ext_temp;   // eslint-disable-line no-unreachable
         if (temp != null && temp < 3 && !document.getElementById("icing-alert")) {
             const t = App.t.bind(App);
             const alert = document.createElement("div");
@@ -666,6 +672,11 @@ const App = (() => {
             // SWC navigate_aa → switch to Android Auto screen
             DataStore.subscribe("navigate_aa", (val) => {
                 if (val && _currentScreen !== "a2") navigateTo("a2");
+            });
+
+            // SWC HOME → main screen A1
+            DataStore.subscribe("home", (val) => {
+                if (val && _currentScreen !== "a1") navigateTo("a1");
             });
 
             // Keyboard input

--- a/src/dashboard/web/js/components/keyboard.js
+++ b/src/dashboard/web/js/components/keyboard.js
@@ -15,6 +15,9 @@ const OnScreenKeyboard = (() => {
         ["1","2","3","4","5","6","7","8","9","0"],
         ["q","w","e","r","t","y","u","i","o","p"],
         ["a","s","d","f","g","h","j","k","l"],
+        // Polskie znaki diakrytyczne — key() już robi toUpperCase(), więc
+        // shift daje wersaliki (Ą, Ć, …) bez dodatkowego kodu.
+        ["ą","ć","ę","ł","ń","ó","ś","ź","ż"],
         ["shift","z","x","c","v","b","n","m","backspace"],
         ["space","done"],
     ];

--- a/src/dashboard/web/js/components/media-player.js
+++ b/src/dashboard/web/js/components/media-player.js
@@ -1,76 +1,114 @@
 /**
- * Media Player component — theme-aware BT media display.
+ * Media Player component — theme-aware BT/AA now-playing card.
+ *
+ * All three themes render the SAME large, touch-friendly card: cover icon +
+ * title/artist, prev / play-pause / next transport, and a master volume
+ * slider. Elements carry stable ids (media-title, media-artist,
+ * media-playpause, media-volume, media-mute-icon) so main.js update() can
+ * refresh them live every tick — no full re-render needed.
  */
 
 const MediaPlayer = (() => {
-    // AVRCP transport control. The icons were previously decorative —
-    // they now POST to /api/media/<action>, which the web viewer
-    // republishes on bt.cmd.media for BluetoothManager to drive the
-    // phone's MediaPlayer1 over D-Bus.
+    // AVRCP transport control → /api/media/<action> → bt.cmd.media.
     async function cmd(action, ev) {
         if (ev) { ev.stopPropagation(); }
         try { await fetch("/api/media/" + action, { method: "POST" }); }
         catch (e) { /* phone may be disconnected — ignore */ }
     }
 
-    function renderHeritage(data) {
+    // Master volume → /api/audio/volume → VolumeController.set_volume.
+    // Dragging a range input fires oninput per pixel; throttle so we don't
+    // flood the single-threaded Flask server (~1 POST / 120 ms + final value).
+    let _volTimer = null, _volPending = null;
+    function _flushVolume() {
+        _volTimer = null;
+        if (_volPending == null) return;
+        const vol = _volPending; _volPending = null;
+        fetch("/api/audio/volume", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ volume: vol }),
+        }).catch(() => { /* audio not ready — ignore */ });
+    }
+    function setVolume(v, ev) {
+        if (ev) { ev.stopPropagation(); }
+        _volPending = Math.max(0, Math.min(100, parseInt(v, 10) || 0));
+        if (_volTimer) return;
+        _volTimer = setTimeout(_flushVolume, 120);
+    }
+
+    async function toggleMute(ev) {
+        if (ev) { ev.stopPropagation(); }
+        const icon = document.getElementById("media-mute-icon");
+        const muted = icon && icon.textContent.trim() === "volume_off";
+        try {
+            await fetch("/api/audio/volume", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ mute: !muted }),
+            });
+        } catch (e) { /* ignore */ }
+    }
+
+    // Theme token tables — keep the structure identical, vary the colours.
+    const THEMES = {
+        heritage: {
+            card: "bg-zinc-900/40 border-zinc-800",
+            iconWrap: "bg-red-950/30 border border-red-900/20",
+            icon: "text-red-500", play: "bg-red-600",
+            btn: "text-zinc-300", label: "text-zinc-500",
+            title: "text-zinc-100", artist: "text-zinc-400",
+        },
+        modern: {
+            card: "bg-white border-slate-100 shadow-lg",
+            iconWrap: "bg-blue-50 border border-slate-100",
+            icon: "text-blue-500", play: "bg-blue-600",
+            btn: "text-slate-500", label: "text-slate-400",
+            title: "text-slate-800", artist: "text-slate-500",
+        },
+        autodelta: {
+            card: "bg-[#111111] border-[#222222]",
+            iconWrap: "bg-[#222222] border border-[#222222]",
+            icon: "text-[#FF5F00]", play: "bg-[#FF5F00]",
+            btn: "text-gray-400", label: "text-gray-500",
+            title: "text-white", artist: "text-[#FF5F00]",
+        },
+    };
+
+    function _card(data, tk) {
         const title = data.bt_media_title || "No Media";
         const artist = data.bt_media_artist || "---";
         const playIcon = data.bt_media_playing ? "pause" : "play_arrow";
-        return `<div class="bg-zinc-900/30 rounded-xl border border-zinc-800 p-4 flex items-center gap-4">
-            <div class="w-12 h-12 bg-red-950/30 rounded-full flex items-center justify-center border border-red-900/20">
-                <span class="material-symbols-outlined text-red-500" style="font-variation-settings:'FILL' 1;">music_note</span>
-            </div>
-            <div class="flex-1 overflow-hidden">
-                <p class="text-[10px] text-zinc-500 font-black uppercase tracking-widest">Now Playing</p>
-                <p class="text-sm font-bold text-zinc-200 truncate" data-bind="media_info">${title} - ${artist}</p>
-            </div>
-        </div>`;
-    }
-
-    function renderModern(data) {
-        const title = data.bt_media_title || "No Media";
-        const artist = data.bt_media_artist || "---";
-        return `<div class="aspect-square bg-slate-900 rounded-xl overflow-hidden relative group shadow-lg">
-            <div class="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent"></div>
-            <div class="absolute inset-0 p-4 flex flex-col justify-between">
-                <div class="flex justify-end">
-                    <span class="material-symbols-outlined text-white" style="font-size:18px;">music_note</span>
+        const vol = (data.audio_volume != null) ? data.audio_volume : 70;
+        const muteIcon = data.audio_muted ? "volume_off" : "volume_up";
+        return `<div class="rounded-2xl border p-5 flex flex-col gap-5 ${tk.card}">
+            <div class="flex items-center gap-4">
+                <div class="w-16 h-16 rounded-xl flex items-center justify-center shrink-0 ${tk.iconWrap}">
+                    <span class="material-symbols-outlined ${tk.icon}" style="font-size:34px;font-variation-settings:'FILL' 1;">music_note</span>
                 </div>
-                <div>
-                    <div class="text-xs font-bold text-white leading-tight" data-bind="bt_media_title">${title}</div>
-                    <div class="text-[10px] text-zinc-300 font-medium" data-bind="bt_media_artist">${artist}</div>
-                    <div class="mt-2 flex items-center gap-2">
-                        <span class="material-symbols-outlined text-white active:scale-90 transition-transform" style="font-size:16px;cursor:pointer;" onclick="MediaPlayer.cmd('previous', event)">skip_previous</span>
-                        <span class="material-symbols-outlined text-white active:scale-90 transition-transform" style="font-size:24px;cursor:pointer;" onclick="MediaPlayer.cmd('playpause', event)">${data.bt_media_playing ? 'pause' : 'play_arrow'}</span>
-                        <span class="material-symbols-outlined text-white active:scale-90 transition-transform" style="font-size:16px;cursor:pointer;" onclick="MediaPlayer.cmd('next', event)">skip_next</span>
-                    </div>
+                <div class="flex-1 overflow-hidden">
+                    <p class="text-[10px] font-black uppercase tracking-widest ${tk.label}">Now Playing</p>
+                    <p id="media-title" class="text-xl font-bold truncate ${tk.title}">${title}</p>
+                    <p id="media-artist" class="text-sm truncate ${tk.artist}">${artist}</p>
                 </div>
             </div>
-        </div>`;
-    }
-
-    function renderAutodelta(data) {
-        const title = data.bt_media_title || "No Media";
-        const artist = data.bt_media_artist || "---";
-        // Enlarged now-playing card (bigger play target + title) so audio is
-        // the prominent card on the wide 1280 panel, consistent with the
-        // other themes.
-        return `<div class="bg-[#111111] rounded-xl p-5 flex items-center gap-5 border border-[#222222]">
-            <div class="w-16 h-16 bg-[#222222] rounded-lg overflow-hidden shrink-0 relative flex items-center justify-center active:scale-90 transition-transform" style="cursor:pointer;" onclick="MediaPlayer.cmd('playpause', event)">
-                <span class="material-symbols-outlined text-white text-opacity-80" style="font-size:34px;">${data.bt_media_playing ? 'pause' : 'play_arrow'}</span>
+            <div class="flex items-center justify-center gap-8">
+                <span class="material-symbols-outlined active:scale-90 transition-transform ${tk.btn}" style="font-size:42px;cursor:pointer;" onclick="MediaPlayer.cmd('previous', event)">skip_previous</span>
+                <span class="w-16 h-16 rounded-full flex items-center justify-center active:scale-90 transition-transform ${tk.play}" style="cursor:pointer;" onclick="MediaPlayer.cmd('playpause', event)">
+                    <span id="media-playpause" class="material-symbols-outlined text-white" style="font-size:40px;font-variation-settings:'FILL' 1;">${playIcon}</span>
+                </span>
+                <span class="material-symbols-outlined active:scale-90 transition-transform ${tk.btn}" style="font-size:42px;cursor:pointer;" onclick="MediaPlayer.cmd('next', event)">skip_next</span>
             </div>
-            <div class="flex flex-col flex-1 overflow-hidden">
-                <span class="text-[9px] font-bold uppercase tracking-widest text-gray-500">Now Playing</span>
-                <span class="text-lg text-white font-bold truncate" data-bind="bt_media_title">${title}</span>
-                <span class="text-[#FF5F00] text-sm font-medium truncate" data-bind="bt_media_artist">${artist}</span>
-            </div>
-            <div class="flex items-center gap-3 text-gray-400">
-                <span class="material-symbols-outlined active:scale-90 transition-transform" style="font-size:30px;cursor:pointer;" onclick="MediaPlayer.cmd('previous', event)">skip_previous</span>
-                <span class="material-symbols-outlined active:scale-90 transition-transform" style="font-size:30px;cursor:pointer;" onclick="MediaPlayer.cmd('next', event)">skip_next</span>
+            <div class="flex items-center gap-3">
+                <span id="media-mute-icon" class="material-symbols-outlined active:scale-90 transition-transform ${tk.btn}" style="font-size:26px;cursor:pointer;" onclick="MediaPlayer.toggleMute(event)">${muteIcon}</span>
+                <input id="media-volume" type="range" min="0" max="100" value="${vol}" class="bcm-vol flex-1" oninput="MediaPlayer.setVolume(this.value, event)">
             </div>
         </div>`;
     }
 
-    return { renderHeritage, renderModern, renderAutodelta, cmd };
+    function renderHeritage(data) { return _card(data, THEMES.heritage); }
+    function renderModern(data) { return _card(data, THEMES.modern); }
+    function renderAutodelta(data) { return _card(data, THEMES.autodelta); }
+
+    return { renderHeritage, renderModern, renderAutodelta, cmd, setVolume, toggleMute };
 })();

--- a/src/dashboard/web/js/components/navbar.js
+++ b/src/dashboard/web/js/components/navbar.js
@@ -4,15 +4,14 @@
  */
 
 const NavBar = (() => {
+    // Quick-start build: only the four screens in scope. Service (A5), DVR
+    // (A6), Performance (A7) and Phone (A8) are hidden — their modules are off
+    // and they only rendered zeros. Calls still work from the SWC buttons.
     const NAV_ITEMS = [
         { icon: "home", screen: "a1", tip: "Dashboard" },
         { icon: "android", screen: "a2", tip: "Android Auto", requiresAA: true },
-        { icon: "call", screen: "a8", tip: "Phone", requiresBT: true },
         { icon: "route", screen: "a3", tip: "Trip" },
         { icon: "cloud", screen: "a4", tip: "Weather" },
-        { icon: "build", screen: "a5", tip: "Service" },
-        { icon: "videocam", screen: "a6", tip: "DVR" },
-        { icon: "speed", screen: "a7", tip: "Performance" },
     ];
 
     function render(theme, activeScreen) {

--- a/src/dashboard/web/js/screens/main.js
+++ b/src/dashboard/web/js/screens/main.js
@@ -1,32 +1,33 @@
 /**
- * A1 Main Screen — Hub with engine temp, fuel, notifications, media.
+ * A1 Main Screen — music-centric hub (now-playing card + volume + spectrum).
+ *
+ * Trimmed for the quick-start build: the engine-temp / fuel / oil-pressure /
+ * avg-speed / voltage tiles are gone (those modules are off and only rendered
+ * zeros). A1 is now the large media card + a tappable equalizer strip, in all
+ * three themes.
  */
 
 App.registerScreen("a1", (() => {
     function render(container, theme, data) {
-        if (theme === "heritage") container.innerHTML = _renderHeritage(data);
-        else if (theme === "modern") container.innerHTML = _renderModern(data);
+        if (theme === "modern") container.innerHTML = _renderModern(data);
         else if (theme === "autodelta") container.innerHTML = _renderAutodelta(data);
         else container.innerHTML = _renderHeritage(data);
     }
 
     function update(data, theme) {
-        // Update dynamic values
-        _updateEl("coolant-val", `${Math.round(data.coolant_temp || 0)}°`);
-        _updateEl("fuel-val", `${Math.round(data.fuel_level || 0)}`);
-        _updateEl("fuel-pct", `${Math.round(data.fuel_level || 0)}%`);
-        _updateEl("range-val", `${Math.round(data.estimated_range || 0)} KM`);
-        _updateEl("avg-speed-val", `${Math.round(data.avg_speed || 0)}`);
-        _updateEl("drive-time-val", data.trip_time || "0h 0m");
-        _updateEl("media-info", `${data.bt_media_title || "No Media"} - ${data.bt_media_artist || "---"}`);
+        // Media now-playing — live refresh every tick (no full re-render).
+        // This fixes the old bug where track info only updated after switching
+        // screens (main.js looked for id="media-info" which never existed).
+        _updateEl("media-title", data.bt_media_title || "No Media");
+        _updateEl("media-artist", data.bt_media_artist || "---");
+        _updateEl("media-playpause", data.bt_media_playing ? "pause" : "play_arrow");
+        _updateEl("media-mute-icon", data.audio_muted ? "volume_off" : "volume_up");
 
-        // Update progress bars
-        const fuelBar = document.getElementById("fuel-bar");
-        if (fuelBar) fuelBar.style.width = `${Math.round(data.fuel_level || 0)}%`;
-        const tempBar = document.getElementById("temp-bar");
-        if (tempBar) {
-            const pct = Math.min(100, Math.max(0, ((data.coolant_temp || 0) - 40) / 90 * 100));
-            tempBar.style.width = `${pct}%`;
+        // Volume slider — reflect backend level, but don't fight the user
+        // while they're dragging it.
+        const volEl = document.getElementById("media-volume");
+        if (volEl && document.activeElement !== volEl && data.audio_volume != null) {
+            volEl.value = data.audio_volume;
         }
 
         // Spectrum visualizer
@@ -34,6 +35,61 @@ App.registerScreen("a1", (() => {
         if (canvas && data.audio_spectrum) {
             _drawSpectrum(canvas, data.audio_spectrum, theme);
         }
+    }
+
+    function _updateEl(id, text) {
+        const el = document.getElementById(id);
+        if (el && el.textContent !== text) el.textContent = text;
+    }
+
+    // Equalizer strip shown under the media card. `tk` supplies theme classes.
+    function _eqStrip(tk) {
+        return `<div class="rounded-xl border p-3 cursor-pointer ${tk.card}" onclick="App.navigateTo('audio')">
+            <div class="flex items-center justify-between mb-1">
+                <span class="text-[9px] font-bold uppercase tracking-wider ${tk.label}">Equalizer</span>
+                <span class="material-symbols-outlined ${tk.eqIcon}" style="font-size:16px">equalizer</span>
+            </div>
+            <canvas id="spectrum-canvas" class="w-full" style="height:44px"></canvas>
+        </div>`;
+    }
+
+    function _renderHeritage(data) {
+        return `<div class="screen-container bg-black text-zinc-100">
+            ${AppBar.render("heritage", data)}
+            <main class="content-area flex items-center justify-center overflow-hidden px-6 py-4">
+                <div class="w-full max-w-2xl flex flex-col gap-4">
+                    ${MediaPlayer.renderHeritage(data)}
+                    ${_eqStrip({ card: "border-zinc-800 bg-zinc-900/30", label: "text-zinc-500", eqIcon: "text-zinc-600" })}
+                </div>
+            </main>
+            ${NavBar.render("heritage", "a1")}
+        </div>`;
+    }
+
+    function _renderModern(data) {
+        return `<div class="screen-container text-slate-900">
+            ${AppBar.render("modern", data)}
+            <main class="content-area flex items-center justify-center overflow-hidden px-6 py-4 bg-gradient-to-br from-slate-50 to-blue-50/30">
+                <div class="w-full max-w-2xl flex flex-col gap-4">
+                    ${MediaPlayer.renderModern(data)}
+                    ${_eqStrip({ card: "border-slate-100 bg-white shadow-sm", label: "text-slate-400", eqIcon: "text-blue-400" })}
+                </div>
+            </main>
+            ${NavBar.render("modern", "a1")}
+        </div>`;
+    }
+
+    function _renderAutodelta(data) {
+        return `<div class="screen-container bg-black text-white">
+            ${AppBar.render("autodelta", data)}
+            <main class="content-area flex items-center justify-center overflow-hidden px-6 py-4">
+                <div class="w-full max-w-2xl flex flex-col gap-4">
+                    ${MediaPlayer.renderAutodelta(data)}
+                    ${_eqStrip({ card: "border-[#222222]", label: "text-gray-500", eqIcon: "text-[#FF5F00]" })}
+                </div>
+            </main>
+            ${NavBar.render("autodelta", "a1")}
+        </div>`;
     }
 
     function _drawSpectrum(canvas, bands, theme) {
@@ -72,239 +128,6 @@ App.registerScreen("a1", (() => {
             ctx.roundRect(x, y, barW, barH, 1.5);
             ctx.fill();
         }
-    }
-
-    function _updateEl(id, text) {
-        const el = document.getElementById(id);
-        if (el) el.textContent = text;
-    }
-
-    function _renderHeritage(data) {
-        const t = App.t.bind(App);
-        const temp = Math.round(data.coolant_temp || 0);
-        const fuel = Math.round(data.fuel_level || 0);
-        const range = Math.round(data.estimated_range || 0);
-        const avgSpd = Math.round(data.avg_speed || 0);
-        const notifs = Notifications.getNotifications(data);
-        const notifHtml = Notifications.renderHeritage(notifs);
-
-        return `<div class="screen-container bg-black text-zinc-100">
-            ${AppBar.render("heritage", data)}
-            <main class="content-area flex items-center justify-center overflow-hidden">
-                <div class="grid grid-cols-12 gap-4 w-full max-w-6xl px-6 h-full py-4">
-                    <!-- Engine Temp -->
-                    <div class="col-span-3 burl-texture rounded-xl border border-zinc-800 p-4 flex flex-col justify-between overflow-hidden">
-                        <div class="flex items-center gap-2 text-zinc-500">
-                            <span class="material-symbols-outlined text-sm">device_thermostat</span>
-                            <span class="text-[10px] font-bold uppercase tracking-wider">${t("engine_temp")}</span>
-                        </div>
-                        <div class="relative py-4 flex flex-col items-center">
-                            <div class="w-24 h-24 rounded-full border-4 border-zinc-900 flex items-center justify-center relative">
-                                <div class="absolute inset-0 rounded-full border-t-4 border-amber-500 rotate-45 opacity-60"></div>
-                                <span id="coolant-val" class="text-2xl font-black text-amber-500 amber-glow">${temp}°</span>
-                            </div>
-                            <span class="text-[10px] text-zinc-500 mt-2 font-bold">${temp > 95 ? 'HOT' : t("optimal")}</span>
-                        </div>
-                    </div>
-                    <!-- Notifications -->
-                    <div class="col-span-6 bg-zinc-950 rounded-xl border border-zinc-800 p-6 flex flex-col gap-4 relative overflow-hidden">
-                        <div class="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-transparent via-red-600 to-transparent opacity-50"></div>
-                        <div class="flex items-center justify-between border-b border-zinc-900 pb-2">
-                            <h2 class="text-xs font-black uppercase tracking-[0.2em] text-zinc-400">${t("system_notifications")}</h2>
-                            <span class="text-[10px] text-red-500 font-bold">${notifs.length} ACTIVE</span>
-                        </div>
-                        <div class="space-y-3 flex-1 overflow-y-auto pr-2">${notifHtml}</div>
-                    </div>
-                    <!-- Fuel -->
-                    <div class="col-span-3 burl-texture rounded-xl border border-zinc-800 p-4 flex flex-col justify-between overflow-hidden">
-                        <div class="flex items-center gap-2 text-zinc-500">
-                            <span class="material-symbols-outlined text-sm">local_gas_station</span>
-                            <span class="text-[10px] font-bold uppercase tracking-wider">${t("fuel_level")}</span>
-                        </div>
-                        <div class="flex flex-col gap-1 py-4">
-                            <span class="text-3xl font-black text-amber-500 amber-glow"><span id="fuel-val">${fuel}</span><span class="text-sm font-normal ml-1">%</span></span>
-                            <div class="w-full h-1.5 bg-zinc-900 rounded-full mt-2 overflow-hidden flex">
-                                <div id="fuel-bar" class="h-full bg-amber-600 shadow-[0_0_8px_#d97706] transition-all duration-500" style="width:${fuel}%"></div>
-                            </div>
-                            <p class="text-[10px] text-zinc-500 mt-1 font-bold">${t("est_range")}: <span id="range-val">${range} KM</span></p>
-                        </div>
-                    </div>
-                    <!-- Bottom Row: now-playing card is intentionally wider
-                         (col-6) than the travel-stats card (col-3) per the
-                         10.1" brief — audio is the primary glanceable card. -->
-                    <div class="col-span-6">
-                        ${MediaPlayer.renderHeritage(data)}
-                    </div>
-                    <div class="col-span-3 bg-zinc-950 rounded-xl border border-zinc-800 p-3 flex flex-col cursor-pointer" onclick="App.navigateTo('audio')">
-                        <div class="flex items-center justify-between mb-1">
-                            <span class="text-[9px] font-bold uppercase tracking-wider text-zinc-500">Spectrum</span>
-                            <span class="material-symbols-outlined text-zinc-600" style="font-size:14px">equalizer</span>
-                        </div>
-                        <canvas id="spectrum-canvas" class="flex-1 w-full" style="min-height:50px"></canvas>
-                    </div>
-                    <div class="col-span-3 bg-zinc-900/30 rounded-xl border border-zinc-800 p-4 flex flex-col items-center justify-center gap-3">
-                        <div class="flex flex-col items-center">
-                            <span class="text-[10px] text-zinc-500 font-bold uppercase">${t("avg_speed")}</span>
-                            <span class="text-xl font-black text-zinc-200"><span id="avg-speed-val">${avgSpd}</span> <span class="text-[10px] text-zinc-500">km/h</span></span>
-                        </div>
-                        <div class="h-px w-12 bg-zinc-800"></div>
-                        <div class="flex flex-col items-center">
-                            <span class="text-[10px] text-zinc-500 font-bold uppercase">${t("drive_time")}</span>
-                            <span id="drive-time-val" class="text-xl font-black text-zinc-200">${data.trip_time || "0h 0m"}</span>
-                        </div>
-                        <div class="h-px w-12 bg-zinc-800"></div>
-                        <div class="flex flex-col items-center">
-                            <span class="text-[10px] text-zinc-500 font-bold uppercase">${t("voltage")}</span>
-                            <span class="text-xl font-black text-zinc-200">${(data.battery_voltage || 12.6).toFixed(1)} <span class="text-[10px] text-zinc-500">V</span></span>
-                        </div>
-                    </div>
-                </div>
-            </main>
-            ${NavBar.render("heritage", "a1")}
-        </div>`;
-    }
-
-    function _renderModern(data) {
-        const t = App.t.bind(App);
-        const temp = Math.round(data.coolant_temp || 0);
-        const fuel = Math.round(data.fuel_level || 0);
-        const range = Math.round(data.estimated_range || 0);
-        const tempPct = Math.min(100, Math.max(0, (temp - 40) / 90 * 100));
-        const notifs = Notifications.getNotifications(data);
-        const notifHtml = Notifications.renderModern(notifs);
-
-        return `<div class="screen-container text-slate-900">
-            ${AppBar.render("modern", data)}
-            <main class="content-area px-6 grid grid-cols-12 gap-4 items-center bg-gradient-to-br from-slate-50 to-blue-50/30 py-4">
-                <!-- Left: Engine + Fuel -->
-                <div class="col-span-3 flex flex-col gap-4">
-                    <div class="bg-white p-4 rounded-xl shadow-sm border border-slate-100">
-                        <div class="flex items-center justify-between mb-2">
-                            <span class="text-[10px] font-bold text-slate-400 uppercase tracking-wider">${t("engine_temp")}</span>
-                            <span class="material-symbols-outlined text-blue-500" style="font-size:16px;">device_thermostat</span>
-                        </div>
-                        <div class="flex items-end gap-2">
-                            <span id="coolant-val" class="text-2xl font-bold text-slate-800 tracking-tighter">${temp}°</span>
-                            <div class="flex-1 h-1.5 bg-slate-100 rounded-full mb-2 overflow-hidden">
-                                <div id="temp-bar" class="bg-blue-500 h-full rounded-full transition-all duration-500" style="width:${tempPct}%"></div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="bg-white p-4 rounded-xl shadow-sm border border-slate-100">
-                        <div class="flex items-center justify-between mb-2">
-                            <span class="text-[10px] font-bold text-slate-400 uppercase tracking-wider">${t("fuel_level")}</span>
-                            <span class="material-symbols-outlined text-blue-500" style="font-size:16px;">local_gas_station</span>
-                        </div>
-                        <div class="flex items-end gap-2">
-                            <span class="text-2xl font-bold text-slate-800 tracking-tighter"><span id="fuel-pct">${fuel}%</span></span>
-                            <div class="flex-1 h-1.5 bg-slate-100 rounded-full mb-2 overflow-hidden">
-                                <div id="fuel-bar" class="bg-blue-500 h-full rounded-full transition-all duration-500" style="width:${fuel}%"></div>
-                            </div>
-                        </div>
-                        <div class="mt-1 text-[10px] text-slate-400 font-medium">${t("est_range")}: <span id="range-val">${range} KM</span></div>
-                    </div>
-                </div>
-                <!-- Center: Notifications (narrowed to give the media/right
-                     column more room on the wide 1280 panel) -->
-                <div class="col-span-5 h-full flex items-center justify-center">
-                    <div class="relative w-full h-[280px] bg-white rounded-2xl shadow-xl shadow-blue-900/5 border border-slate-100 overflow-hidden flex flex-col">
-                        <div class="p-4 border-b border-slate-50 flex items-center justify-between">
-                            <span class="text-xs font-bold text-slate-800 uppercase tracking-widest">Notification Hub</span>
-                            <span class="bg-blue-100 text-blue-600 text-[10px] px-2 py-0.5 rounded-full font-bold">${notifs.length} NEW</span>
-                        </div>
-                        <div class="flex-1 p-4 space-y-3 overflow-y-auto">${notifHtml}</div>
-                    </div>
-                </div>
-                <!-- Right: Media (enlarged) + Status -->
-                <div class="col-span-4 flex flex-col gap-4">
-                    ${MediaPlayer.renderModern(data)}
-                    <div class="bg-white p-3 rounded-xl shadow-sm border border-slate-100 cursor-pointer" onclick="App.navigateTo('audio')">
-                        <div class="flex items-center justify-between mb-1">
-                            <span class="text-[9px] font-bold uppercase tracking-wider text-slate-400">Spectrum</span>
-                            <span class="material-symbols-outlined text-blue-400" style="font-size:14px">equalizer</span>
-                        </div>
-                        <canvas id="spectrum-canvas" class="w-full" style="height:40px"></canvas>
-                    </div>
-                    <div class="bg-white p-4 rounded-xl shadow-sm border border-slate-100 flex items-center justify-between">
-                        <div>
-                            <span class="text-[10px] font-bold text-slate-400 uppercase tracking-wider block mb-1">Status</span>
-                            <span class="text-xs font-bold text-green-600 flex items-center gap-1">
-                                <span class="w-1.5 h-1.5 bg-green-500 rounded-full"></span>SYSTEM READY
-                            </span>
-                        </div>
-                        <span class="material-symbols-outlined text-slate-300" style="font-size:20px;">verified_user</span>
-                    </div>
-                </div>
-            </main>
-            ${NavBar.render("modern", "a1")}
-        </div>`;
-    }
-
-    function _renderAutodelta(data) {
-        const t = App.t.bind(App);
-        const temp = Math.round(data.coolant_temp || 0);
-        const fuel = Math.round(data.fuel_level || 0);
-        const oil = Math.round(data.oil_pressure || 45);
-        const tempPct = Math.min(100, Math.max(0, (temp - 100) / 160 * 100));
-        const notifs = Notifications.getNotifications(data);
-        const notifHtml = Notifications.renderAutodelta(notifs);
-
-        return `<div class="screen-container bg-black text-white">
-            ${AppBar.render("autodelta", data)}
-            <main class="content-area flex flex-row overflow-hidden relative">
-                <!-- Left: Vitals -->
-                <div class="w-1/3 flex flex-col p-6 gap-6 justify-center border-r border-[#222222] bg-gradient-to-r from-[#0a0a0a] to-transparent z-10">
-                    <div class="flex flex-col gap-2">
-                        <div class="flex justify-between items-end mb-1">
-                            <span class="text-sm font-medium text-gray-400 uppercase tracking-widest">${t("coolant")}</span>
-                            <span class="text-2xl font-bold text-white"><span id="coolant-val">${temp}</span><span class="text-sm text-gray-500">°C</span></span>
-                        </div>
-                        <div class="h-2 w-full bg-[#222222] rounded-full overflow-hidden">
-                            <div id="temp-bar" class="h-full bg-gradient-to-r from-blue-500 via-green-500 to-red-500 rounded-full shadow-[0_0_10px_rgba(34,197,94,0.5)] transition-all duration-500" style="width:${tempPct}%"></div>
-                        </div>
-                    </div>
-                    <div class="flex flex-col gap-2 mt-4">
-                        <div class="flex justify-between items-end mb-1">
-                            <span class="text-sm font-medium text-gray-400 uppercase tracking-widest">${t("fuel")}</span>
-                            <span class="text-2xl font-bold text-white"><span id="fuel-val">${fuel}</span><span class="text-sm text-gray-500">%</span></span>
-                        </div>
-                        <div class="h-2 w-full bg-[#222222] rounded-full overflow-hidden">
-                            <div id="fuel-bar" class="h-full bg-[#FF5F00] rounded-full shadow-[0_0_10px_rgba(236,91,19,0.5)] transition-all duration-500" style="width:${fuel}%"></div>
-                        </div>
-                    </div>
-                    <div class="flex flex-col gap-2 mt-4">
-                        <div class="flex justify-between items-end mb-1">
-                            <span class="text-sm font-medium text-gray-400 uppercase tracking-widest">${t("oil_press")}</span>
-                            <span class="text-2xl font-bold text-white">${oil}<span class="text-sm text-gray-500">psi</span></span>
-                        </div>
-                        <div class="h-2 w-full bg-[#222222] rounded-full overflow-hidden">
-                            <div class="h-full bg-white rounded-full" style="width:60%"></div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Right: Status + Media -->
-                <div class="flex-1 flex flex-col p-6 relative">
-                    <div class="absolute inset-0 opacity-5 pointer-events-none flex items-center justify-center">
-                        <div class="w-[300px] h-[300px] rounded-full border-[20px] border-white blur-sm"></div>
-                    </div>
-                    <div class="flex-1 flex flex-col relative z-10">
-                        <h3 class="text-sm font-bold text-[#FF5F00] uppercase tracking-widest mb-4">${t("system_status")}</h3>
-                        ${notifHtml}
-                        <div class="mt-auto">
-                            ${MediaPlayer.renderAutodelta(data)}
-                            <div class="mt-3 p-2 rounded-lg border border-[#222222] cursor-pointer" onclick="App.navigateTo('audio')">
-                                <div class="flex items-center justify-between mb-1">
-                                    <span class="text-[8px] font-bold uppercase tracking-wider text-gray-500">Spectrum</span>
-                                    <span class="material-symbols-outlined text-[#FF5F00]" style="font-size:12px">equalizer</span>
-                                </div>
-                                <canvas id="spectrum-canvas" class="w-full" style="height:32px"></canvas>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </main>
-            ${NavBar.render("autodelta", "a1")}
-        </div>`;
     }
 
     return { render, update };

--- a/src/dashboard/web_viewer.py
+++ b/src/dashboard/web_viewer.py
@@ -130,7 +130,7 @@ class WebViewer:
         if not isinstance(_wc, dict):
             _wc = {}
 
-        return {
+        data = {
             # Engine
             "rpm": _val("obd.rpm", 0),
             "speed": _val("obd.speed", 0),
@@ -227,9 +227,18 @@ class WebViewer:
             # Parking
             "parking_distances": _val("parking.distances", []),
             "parking_active": _val("parking.active", False),
-            # SWC navigation
+            # SWC navigation (edge-triggered — see reset below)
             "navigate_aa": _val("input.navigate_aa", False),
+            "home": _val("input.home", False),
         }
+        # The browser's DataStore only fires subscribers on value *change*, so
+        # a latched True would navigate once and never again (and would nav
+        # spuriously on reload). Emit True for exactly one broadcast frame then
+        # reset to False, so every HOME/NAV press re-fires.
+        for _nav in ("input.navigate_aa", "input.home"):
+            if _val(_nav, False):
+                bus.publish(_nav, False)
+        return data
 
     def _handle_browser_key(self, key: str) -> None:
         """Map browser key to event bus input."""

--- a/src/input/bt_remote.py
+++ b/src/input/bt_remote.py
@@ -118,6 +118,11 @@ def start_input(config: Any, event_bus: EventBus, hal: Any = None,
     # Action dispatcher (keycode → event bus actions)
     dispatcher = ActionDispatcher(event_bus)
 
+    # Bridge orphaned SWC actions (media skip, phone answer/hangup) to their
+    # real handlers. Without this the wheel next/prev/pickup/hangup do nothing.
+    from src.input.input_bridge import InputBridge
+    input_bridge = InputBridge(event_bus)
+
     # Arduino HID (resistor-ladder buttons → USB HID keycodes)
     arduino_hid = ArduinoHidListener(event_bus)
     arduino_hid.start()
@@ -140,6 +145,7 @@ def start_input(config: Any, event_bus: EventBus, hal: Any = None,
 
     event_bus.publish("input._internals", {
         "dispatcher": dispatcher,
+        "input_bridge": input_bridge,
         "arduino_hid": arduino_hid,
         "arduino_serial": arduino_serial,
         "bt_remote": bt_remote,

--- a/src/input/input_bridge.py
+++ b/src/input/input_bridge.py
@@ -1,0 +1,49 @@
+"""Bridge SWC action topics to the subsystems that actually act on them.
+
+`action_dispatch.py` turns Arduino keycodes into `input.*` topics, but a few
+of those topics historically had **no subscriber**, so the steering-wheel
+buttons did nothing:
+
+    input.next_track / input.prev_track  → AVRCP media skip (bt.cmd.media)
+    input.phone_pickup / input.phone_hangup → HFP answer/hangup (bt.cmd.*)
+
+(`input.volume_up/down` and `input.mute` are handled by VolumeController;
+`input.voice_aa_trigger` by VoiceAAHandler; `input.navigate_aa`/`input.home`
+by the web UI via the dashboard payload.)
+
+This bridge just republishes the orphaned topics onto the topics their
+owners already listen on. Instantiated from `bt_remote.start_input()`.
+"""
+
+from typing import Any
+
+from src.core.event_bus import EventBus
+from src.core.logger import get_logger
+
+log = get_logger("input.bridge")
+
+
+class InputBridge:
+    """Route SWC action topics without a native consumer to real handlers."""
+
+    def __init__(self, event_bus: EventBus):
+        self._event_bus = event_bus
+        event_bus.subscribe("input.next_track", self._on_next)
+        event_bus.subscribe("input.prev_track", self._on_prev)
+        event_bus.subscribe("input.phone_pickup", self._on_pickup)
+        event_bus.subscribe("input.phone_hangup", self._on_hangup)
+        log.info("InputBridge initialized (media skip + HFP answer/hangup)")
+
+    # AVRCP media skip — BluetoothManager._on_cmd_media accepts these strings.
+    def _on_next(self, topic: str, value: Any, timestamp: float) -> None:
+        self._event_bus.publish("bt.cmd.media", "next")
+
+    def _on_prev(self, topic: str, value: Any, timestamp: float) -> None:
+        self._event_bus.publish("bt.cmd.media", "previous")
+
+    # HFP call control — BluetoothManager subscribes to bt.cmd.answer/hangup.
+    def _on_pickup(self, topic: str, value: Any, timestamp: float) -> None:
+        self._event_bus.publish("bt.cmd.answer", True)
+
+    def _on_hangup(self, topic: str, value: Any, timestamp: float) -> None:
+        self._event_bus.publish("bt.cmd.hangup", True)

--- a/src/multimedia/openauto.py
+++ b/src/multimedia/openauto.py
@@ -352,8 +352,19 @@ class OpenAutoController:
                     env["PIPEWIRE_RUNTIME_DIR"] = f"/run/user/{uid}"
                     log.info("Audio: PULSE_SERVER=%s", sock)
                     break
+
             else:
                 log.warning("No PulseAudio socket found — audio may not work")
+
+        # Optional: pin autoapp's audio to a specific PipeWire sink (node.name)
+        # instead of the default. Set audio.aa_sink in config to override; empty
+        # = use the PipeWire default (bcm_eq_sink → combine → both outputs).
+        aa_sink = ""
+        if self._config is not None:
+            aa_sink = str(self._config.get("audio.aa_sink", "") or "").strip()
+        if aa_sink:
+            env["PULSE_SINK"] = aa_sink
+            log.info("Audio: PULSE_SINK=%s (autoapp pinned sink)", aa_sink)
 
         # Ensure XDG_RUNTIME_DIR is set for the running process's own UID
         if "XDG_RUNTIME_DIR" not in env:

--- a/src/multimedia/wifi_ap.py
+++ b/src/multimedia/wifi_ap.py
@@ -986,6 +986,15 @@ class WiFiAPManager:
                         "primary %s for IP", self._interface)
             p2p_iface = self._interface
 
+        # WiFi power-save on the GO radio is the classic "AA connects then
+        # drops after a few seconds" cause: the phone associates, the link
+        # goes idle and mac80211 parks the radio. Force it off on the parent
+        # phy (the P2P child inherits it; setting it on the child returns
+        # -95 on MT7921). Best-effort — never fatal.
+        for ps_if in (self._interface, p2p_iface):
+            subprocess.run(["iw", "dev", ps_if, "set", "power_save", "off"],
+                           capture_output=True)
+
         # Wi-Fi Direct GOs broadcast a spec-mandated `DIRECT-XX` SSID
         # with a random WPA2 passphrase. Read what wpa_supplicant
         # generated and overwrite self._ssid / self._password so the
@@ -993,17 +1002,32 @@ class WiFiAPManager:
         # to the phone over BT. Without this, the phone is told to
         # join "ALFA" while the actual GO is "DIRECT-Qi" → AA-Wireless
         # connect fails silently.
+        #
+        # The group needs a beat before wpa_cli reports ssid/bssid, and a
+        # single failed scrape used to silently leave the YAML fallback
+        # (ALFA/87654321) in place — the phone then joins a network that
+        # does not exist and AA flaps. Retry until we actually have both.
         if p2p_iface != self._interface:
-            real_ssid = self._wpa_query(ctrl_dir, p2p_iface, "status",
-                                        prop="ssid")
-            real_psk = self._wpa_query(ctrl_dir, p2p_iface,
-                                       "p2p_get_passphrase")
-            real_bssid = self._wpa_query(ctrl_dir, p2p_iface, "status",
-                                         prop="bssid")
+            real_ssid = real_psk = real_bssid = ""
+            for _attempt in range(10):
+                real_ssid = self._wpa_query(ctrl_dir, p2p_iface, "status",
+                                            prop="ssid") or real_ssid
+                real_psk = self._wpa_query(ctrl_dir, p2p_iface,
+                                           "p2p_get_passphrase") or real_psk
+                real_bssid = self._wpa_query(ctrl_dir, p2p_iface, "status",
+                                             prop="bssid") or real_bssid
+                if real_ssid and real_psk:
+                    break
+                time.sleep(0.5)
             if real_ssid:
                 self._ssid = real_ssid
             if real_psk:
                 self._password = real_psk
+            if not (real_ssid and real_psk):
+                log.warning("P2P-GO credential scrape incomplete after retries "
+                            "(ssid=%r psk=%s bssid=%r) — openauto.ini may carry "
+                            "stale/fallback creds", real_ssid,
+                            "set" if real_psk else "MISSING", real_bssid)
             # The GO has its own MAC (parent±2 typically) — publish so
             # openauto.ini gets the right BSSID for WifiInfoResponse.
             log.info("P2P-GO advertising SSID=%s psk=%s… on BSSID=%s",


### PR DESCRIPTION
Minimal in-car quick-start on the M910q + 7" 1024×600 panel: only wireless **Android Auto**, **steering-wheel pods**, **weather**, **route planning**, **audio**. Driven by a new `config/bcm_config_temp.yaml` (the systemd unit is switched to it).

## Android Auto — root cause found (phone-side)
The "connects + authenticates but won't project, drops every ~2–3 s" loop (`aasdk error 33` = `TCP_TRANSFER` / asio EOF) was **the phone's Android Auto → Developer settings → "Unknown sources" being OFF**. openDsh is not a Google-certified head unit, so modern AA refuses to *project* without it (it still connects+auths — the exact trap). Enabling it → full projection, 0 drops, 0 errors, stable. Verified with an Xvfb `:99` grab of the live car UI.

The head unit was exhaustively ruled out (identical to a solid 94-min, 0-error session on 07-11). **Kept** the head-unit fixes that genuinely stabilise the link:
- mask the system `wpa_supplicant` so it can't reclaim `wlp2s0`
- WiFi power-save **off** on the P2P-GO radio (classic "drops after a few seconds")
- retry the P2P credential scrape so `openauto.ini` never falls back to stale `ALFA/87654321`
- removed the ifupdown + dnsmasq AP leftovers (`interfaces.d/bcm-ap`, `dnsmasq.d/bcm-ap.conf`) that brought `wlp2s0` up as a static AP and fought P2P-GO
- `openauto.py`: optional `audio.aa_sink` to pin autoapp's sink

## SWC pods (`arduino/rotary_encoder`)
Single pod on **A0**, 10 buttons in calibration order (VOL+/−, MUTE, NEXT, PREV, **HOME**, PICKUP, HANGUP, VOICE, **NAV→AA screen**). Removed the `MODE→F10→power-toggle` that ADC noise could trip. `swcValues` defaults **computed from the measured pad resistances for a 1 kΩ pull-up** (not 10 kΩ — the 1 Ω…14.66 kΩ ladder collapses at 10k). New `src/input/input_bridge.py` routes the orphaned actions (mute→VolumeController, next/prev→`bt.cmd.media`, pickup/hangup→`bt.cmd.answer/hangup`); `input.home` → A1.

## UI — all three themes
A1 is a large now-playing card with transport + **master volume slider** + spectrum; dead engine/fuel/oil/voltage tiles removed; navbar trimmed to A1/AA/Trip/Weather/Settings; fixed the media live-update (`id=media-info` vs `data-bind`); rem base bumped for the 7"; icing alert disabled. OSK gains a **Polish diacritics row**.

## Audio
PipeWire combine-sink (`config/pipewire/pipewire.conf.d/50-bcm-combine.conf`) plays to the **USB card and the front minijack simultaneously**; the A1 slider drives it.

## Not in this repo (applied on the M910q as /etc changes)
GRUB `fsck.repair=yes`, ext4 `noatime,commit=30`, bounded journald, the `wpa_supplicant` mask and AP-leftover removal.

## Follow-ups for the owner
- Paste an OpenRouteService key into `travel.openrouteservice_key` (currently `PASTE_ORS_KEY_HERE`).
- SWC hardware: fit the **1 kΩ** pull-up A0→5 V, flash `rotary_encoder`, optionally run `CAL`.
- Run `config/scripts/build-frontend.sh` when node is available (two utility classes are stopgapped in `themes.css`).
- **LTE deferred**: ModemManager hard-conflicts with `ofono` (would break HFP calls) and this E3372 in stick mode activates the PDP context but its `wwx` NDIS bridge doesn't route — needs HiLink firmware, not a config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)